### PR TITLE
feat(esp32): update firmware logic and documentation

### DIFF
--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -15,8 +15,12 @@
 #define CAN_ID_AP_CONTROL     0x3FDu  // 1021 - DAS_autopilotControl: HW3 / HW4 core
 
 // ── GPIO — M5Stack ATOM Lite + ATOMIC CAN Base (CA-IS3050G) ──────────────────
+#ifndef PIN_CAN_TX
 #define PIN_CAN_TX   22   // TWAI TX → ATOMIC CAN Base TX
+#endif
+#ifndef PIN_CAN_RX
 #define PIN_CAN_RX   19   // TWAI RX ← ATOMIC CAN Base RX
+#endif
 #define PIN_LED      27   // SK6812 NeoPixel (single LED)
 #define PIN_BUTTON   39   // Built-in button, active-LOW (no external pull-up needed)
 
@@ -38,3 +42,11 @@
 #define LONG_PRESS_MS         3000u   // Long press → toggle NAG killer
 #define DOUBLE_CLICK_MS        400u   // Max gap between two clicks for double-click
 #define STATUS_PRINT_MS       5000u   // Periodic status line when Active
+
+// OTA detection hardening on GTW_carState (0x318)
+// Some firmware versions keep non-zero states when no update is actively running.
+// We only treat one specific raw value as "update in progress" and require
+// consecutive-frame confirmation to avoid false positives.
+#define OTA_IN_PROGRESS_RAW_VALUE  1u
+#define OTA_ASSERT_FRAMES          3u
+#define OTA_CLEAR_FRAMES           6u

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -87,9 +87,23 @@ TeslaHWVersion fsd_detect_hw_version(const CanFrame *frame) {
 
 void fsd_handle_gtw_car_state(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 7) return;
-    // GTW_updateInProgress: bits 1:0 of byte 6.  Any non-zero → OTA running.
-    uint8_t in_progress = (frame->data[6] >> 0) & 0x03;
-    state->tesla_ota_in_progress = (in_progress != 0);
+    // GTW_updateInProgress: bits 1:0 of byte 6.
+    // Filter transient / incompatible values to avoid false positives.
+    uint8_t raw = frame->data[6] & 0x03u;
+    state->ota_raw_state = raw;
+
+    bool in_progress = (raw == OTA_IN_PROGRESS_RAW_VALUE);
+    if (in_progress) {
+        if (state->ota_assert_count < 255u) state->ota_assert_count++;
+        state->ota_clear_count = 0;
+        if (state->ota_assert_count >= OTA_ASSERT_FRAMES)
+            state->tesla_ota_in_progress = true;
+    } else {
+        if (state->ota_clear_count < 255u) state->ota_clear_count++;
+        state->ota_assert_count = 0;
+        if (state->ota_clear_count >= OTA_CLEAR_FRAMES)
+            state->tesla_ota_in_progress = false;
+    }
 }
 
 // ── Follow distance → speed profile (DAS_followDistance 0x3F8) ───────────────

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -46,8 +46,17 @@ struct FSDState {
     // ── Mode + diagnostics ────────────────────────────────────────────────────
     OpMode         op_mode;
     bool           tesla_ota_in_progress;   // pause TX during OTA
+    uint8_t        ota_raw_state;           // raw GTW_updateInProgress bits [1:0]
+    uint8_t        ota_assert_count;        // consecutive "in-progress" samples
+    uint8_t        ota_clear_count;         // consecutive "not in-progress" samples
     uint32_t       crc_err_count;           // CAN bus error counter
     uint32_t       rx_count;                // total frames seen (wiring check)
+    uint32_t       seen_gtw_car_state;      // 0x318 seen count
+    uint32_t       seen_gtw_car_config;     // 0x398 seen count
+    uint32_t       seen_ap_control;         // 0x3FD seen count
+    uint32_t       seen_bms_hv;             // 0x132 seen count
+    uint32_t       seen_bms_soc;            // 0x292 seen count
+    uint32_t       seen_bms_thermal;        // 0x312 seen count
 
     // ── BMS read-only sniff ───────────────────────────────────────────────────
     bool           bms_output;       // print BMS data to serial

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -26,6 +26,28 @@
 static CanDriver *g_can   = nullptr;
 static FSDState   g_state = {};
 
+static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
+    if (hw == TeslaHW_Unknown || g_state.hw_version == hw) return;
+
+    bool old_nag    = g_state.nag_killer;
+    bool old_chime  = g_state.suppress_speed_chime;
+    bool old_bms    = g_state.bms_output;
+    bool old_force  = g_state.force_fsd;
+    OpMode old_mode = g_state.op_mode;
+
+    fsd_state_init(&g_state, hw);
+    g_state.nag_killer           = old_nag;
+    g_state.suppress_speed_chime = old_chime;
+    g_state.bms_output           = old_bms;
+    g_state.force_fsd            = old_force;
+    g_state.op_mode              = old_mode;
+
+    const char *hw_str =
+        (hw == TeslaHW_HW4) ? "HW4" :
+        (hw == TeslaHW_HW3) ? "HW3" : "Legacy";
+    Serial.printf("[HW] Auto-detected: %s (%s)\n", hw_str, reason);
+}
+
 // ── Button state machine ──────────────────────────────────────────────────────
 static uint32_t g_btn_down_ms     = 0;
 static uint32_t g_last_release_ms = 0;
@@ -108,6 +130,13 @@ static void update_led() {
 static void process_frame(const CanFrame &frame) {
     g_state.rx_count++;
 
+    if (frame.id == CAN_ID_GTW_CAR_STATE)  g_state.seen_gtw_car_state++;
+    if (frame.id == CAN_ID_GTW_CAR_CONFIG) g_state.seen_gtw_car_config++;
+    if (frame.id == CAN_ID_AP_CONTROL)     g_state.seen_ap_control++;
+    if (frame.id == CAN_ID_BMS_HV_BUS)     g_state.seen_bms_hv++;
+    if (frame.id == CAN_ID_BMS_SOC)        g_state.seen_bms_soc++;
+    if (frame.id == CAN_ID_BMS_THERMAL)    g_state.seen_bms_thermal++;
+
     // DLC sanity: skip zero-length frames
     if (frame.dlc == 0) return;
 
@@ -116,23 +145,8 @@ static void process_frame(const CanFrame &frame) {
     // we can print it if a new frame arrives.
     if (frame.id == CAN_ID_GTW_CAR_CONFIG) {
         TeslaHWVersion hw = fsd_detect_hw_version(&frame);
-        if (hw != TeslaHW_Unknown && g_state.hw_version == TeslaHW_Unknown) {
-            g_state.hw_version = hw;
-            // Re-initialise defaults for detected HW
-            bool old_nag   = g_state.nag_killer;
-            bool old_chime = g_state.suppress_speed_chime;
-            bool old_bms   = g_state.bms_output;
-            OpMode old_mode = g_state.op_mode;
-            fsd_state_init(&g_state, hw);
-            g_state.nag_killer           = old_nag;
-            g_state.suppress_speed_chime = old_chime;
-            g_state.bms_output           = old_bms;
-            g_state.op_mode              = old_mode;
-            const char *hw_str =
-                (hw == TeslaHW_HW4) ? "HW4" :
-                (hw == TeslaHW_HW3) ? "HW3" : "Legacy";
-            Serial.printf("[HW] Auto-detected: %s\n", hw_str);
-        }
+        if (hw != TeslaHW_Unknown && g_state.hw_version == TeslaHW_Unknown)
+            apply_detected_hw(hw, "0x398");
         return;
     }
 
@@ -141,9 +155,9 @@ static void process_frame(const CanFrame &frame) {
         bool was_ota = g_state.tesla_ota_in_progress;
         fsd_handle_gtw_car_state(&g_state, &frame);
         if (!was_ota && g_state.tesla_ota_in_progress)
-            Serial.println("[OTA] Update in progress — TX suspended");
+            Serial.printf("[OTA] Update in progress (raw=%u) - TX suspended\n", g_state.ota_raw_state);
         else if (was_ota && !g_state.tesla_ota_in_progress)
-            Serial.println("[OTA] Update finished — TX resumed");
+            Serial.printf("[OTA] Update finished (raw=%u) - TX resumed\n", g_state.ota_raw_state);
         return;
     }
 
@@ -175,6 +189,18 @@ static void process_frame(const CanFrame &frame) {
         if (fsd_handle_legacy_autopilot(&g_state, &f) && tx)
             g_can->send(f);
         return;
+    }
+
+    // Fallback HW detection when 0x398 is unavailable on the tapped bus.
+    if (g_state.hw_version == TeslaHW_Unknown) {
+        if (frame.id == CAN_ID_AP_LEGACY) {
+            apply_detected_hw(TeslaHW_Legacy, "fallback:0x3EE");
+        } else if (frame.id == CAN_ID_ISA_SPEED) {
+            apply_detected_hw(TeslaHW_HW4, "fallback:0x399");
+        } else if (frame.id == CAN_ID_AP_CONTROL) {
+            // 0x3FD exists on HW3/HW4. Prefer HW3 as safe default until 0x399 appears.
+            apply_detected_hw(TeslaHW_HW3, "fallback:0x3FD");
+        }
     }
 
     // ISA speed chime (0x399, HW4 only)

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -27,7 +27,10 @@ static WebSocketsServer g_ws(81);
 static uint32_t g_start_ms    = 0;
 static uint32_t g_last_rx     = 0;
 static uint32_t g_last_fps_ms = 0;
+static uint32_t g_last_can_seen_ms = 0;
 static float    g_fps         = 0.0f;
+
+#define CAN_VEHICLE_ALIVE_MS 3000u
 
 // ── Embedded HTML/CSS/JS ──────────────────────────────────────────────────────
 // Tesla dark theme; mobile-first (max 480 px); WebSocket on :81
@@ -182,11 +185,23 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">NAG Killer</span>
     <span class="pill off" id="nagSt"><span class="pd"></span>--</span>
   </div>
+  <div class="row">
+    <span class="lbl">CAN Vehicle</span>
+    <span class="pill off" id="canVeh"><span class="pd"></span>--</span>
+  </div>
 </div>
 
 <!-- Battery -->
 <div class="card">
   <div class="card-head"><div class="icon ic-b">B</div><h2>Battery</h2></div>
+  <div class="row">
+    <span class="lbl">BMS Status</span>
+    <span class="pill off" id="bmsSt"><span class="pd"></span>Waiting Frames</span>
+  </div>
+  <div class="row">
+    <span class="lbl">BMS Frames</span>
+    <span id="bmsFrames" style="font-size:.8em;color:var(--text2)">HV:0 SOC:0 TH:0</span>
+  </div>
   <div class="hero">
     <div class="soc-ring">
       <svg viewBox="0 0 120 120" width="120" height="120">
@@ -287,6 +302,9 @@ function upd(d){
   hwEl.innerHTML='<span class="pd"></span>'+(HW[d.hw_version]||'?');
 
   pill('nagSt', d.nag_killer, d.nag_killer?'ON':'OFF');
+  pill('canVeh', d.can_vehicle_detected, d.can_vehicle_detected?'Detected':'No CAN Traffic');
+  pill('bmsSt', d.bms && d.bms.seen, (d.bms && d.bms.seen)?'Live':'Waiting Frames');
+  document.getElementById('bmsFrames').textContent='HV:'+d.bms_hv_seen+' SOC:'+d.bms_soc_seen+' TH:'+d.bms_thermal_seen;
 
   // OTA banner
   document.getElementById('otaBanner').style.display=d.ota?'block':'none';
@@ -356,6 +374,10 @@ conn();
 // ── JSON builder ──────────────────────────────────────────────────────────────
 static String build_json() {
     uint32_t uptime_s = (millis() - g_start_ms) / 1000;
+  bool can_vehicle_detected = false;
+  if (g_state != nullptr && g_state->rx_count > 0) {
+    can_vehicle_detected = (millis() - g_last_can_seen_ms) <= CAN_VEHICLE_ALIVE_MS;
+  }
 
     // BMS sub-object
     char bms[128];
@@ -386,6 +408,10 @@ static String build_json() {
     j += "\"nag_killer\":";    j += g_state->nag_killer               ? "true" : "false"; j += ',';
     j += "\"bms_output\":";    j += g_state->bms_output               ? "true" : "false"; j += ',';
     j += "\"force_fsd\":";     j += g_state->force_fsd                ? "true" : "false"; j += ',';
+    j += "\"can_vehicle_detected\":"; j += can_vehicle_detected       ? "true" : "false"; j += ',';
+    j += "\"bms_hv_seen\":";   j += g_state->seen_bms_hv;              j += ',';
+    j += "\"bms_soc_seen\":";  j += g_state->seen_bms_soc;             j += ',';
+    j += "\"bms_thermal_seen\":"; j += g_state->seen_bms_thermal;       j += ',';
     j += "\"rx_count\":";      j += g_state->rx_count;                 j += ',';
     j += "\"tx_count\":";      j += g_state->frames_modified;          j += ',';
     j += "\"crc_errors\":";    j += g_state->crc_err_count;            j += ',';
@@ -456,6 +482,7 @@ void web_dashboard_init(FSDState *state, CanDriver *can) {
     g_start_ms    = millis();
     g_last_fps_ms = millis();
     g_last_rx     = state ? state->rx_count : 0;
+    g_last_can_seen_ms = (state && state->rx_count > 0) ? millis() : 0;
 
     g_http.on("/",           HTTP_GET, handle_root);
     g_http.on("/api/status", HTTP_GET, handle_status);
@@ -478,6 +505,7 @@ void web_dashboard_update() {
     if ((now - g_last_fps_ms) >= 1000u) {
         uint32_t rx = g_state->rx_count;
         float    dt = (now - g_last_fps_ms) / 1000.0f;
+      if (rx != g_last_rx) g_last_can_seen_ms = now;
         g_fps        = (float)(rx - g_last_rx) / dt;
         g_last_rx    = rx;
         g_last_fps_ms = now;

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -5,11 +5,16 @@
 Unlock Tesla FSD with an ESP32 + CAN transceiver via OBD-II. No Flipper Zero needed — ~¥100 total cost.
 
 > [!CAUTION]
-> **🚧 ESP32 Port — UNTESTED ON VEHICLE as of 2026-04-09**
+> **✅ ESP32 Port — TESTED ON VEHICLE (Model 3 2022 HW3)**
 >
-> This firmware compiles, flashes, and boots correctly on bench. It has **not yet been tested on a real Tesla**. CAN logic is faithfully ported from hypery11/flipper-tesla-fsd but real-car validation is pending.
+> This firmware has been tested on a **Tesla Model 3 (2022, HW3)** and works well in real-world use. CAN logic is faithfully ported from hypery11/flipper-tesla-fsd.
 >
-> **If you test this on your vehicle, please report your results in this PR thread.**
+> **If you test this on another vehicle model, please report your results in this PR thread.**
+
+> [!WARNING]
+> **BMS section is currently not working in real vehicle usage.**
+>
+> The BMS parser and dashboard fields are implemented in code, but on current tested setup they do not provide reliable/usable live data yet.
 
 > [!IMPORTANT]
 > The device boots in **Listen-Only mode** by default and will **not transmit any CAN frames** until the user explicitly switches to Active mode via the physical button or Web Dashboard UI. This ensures safe first-boot behavior.
@@ -30,7 +35,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - Speed profile mapping from follow-distance stalk
 - OTA update detection and automatic TX suspension
 - ISA speed warning chime suppression (HW4)
-- BMS data parsing (voltage, current, SOC, temperature)
+- BMS data parsing logic (voltage, current, SOC, temperature) — currently not reliable in real use
 - Battery precondition trigger
 - CRC/checksum recalculation after frame modification
 - DLC length validation on all handlers
@@ -46,7 +51,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - **Real-time WebSocket push** — 1 Hz state updates via WebSocket on port 81
 - **FSD Status Panel** — FSD active/waiting, Listen-Only/Active mode, HW version, NAG Killer state
 - **Battery SOC Ring** — animated circular progress bar with color coding (green >60%, yellow >30%, red ≤30%)
-- **BMS Live Data** — pack voltage, current (color-coded charge/discharge), temperature range
+- **BMS Live Data UI hooks** — fields exist in UI/API, but BMS section is currently not working reliably on tested vehicle setup
 - **CAN Bus Stats** — RX frame count, TX modified count, CRC errors, frames/second
 - **Web Controls** — toggle buttons for:
   - Activate/Stop FSD (Listen-Only ↔ Active mode switch)
@@ -74,8 +79,8 @@ Dual CAN driver support (compile-time switch):
 | **NAG Killer** | `0x370` | Suppresses hands-on-wheel reminder |
 | **Speed Profile** | `0x3FD` mux2 | Follow-distance stalk maps to speed offset |
 | **ISA Chime Suppress** | `0x399` | Kills speed warning chime (HW4 only) |
-| **Battery Precondition** | `0x082` | Triggers active battery heating |
-| **BMS Dashboard** | `0x132`/`0x292`/`0x312` | Live battery data (read-only) |
+| **Battery Precondition** | `0x082` | Frame builder implemented; no user control exposed yet |
+| **BMS Dashboard** | `0x132`/`0x292`/`0x312` | Parsing/UI path implemented, but currently not working reliably |
 | **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected |
 | **HW Auto-Detect** | `0x398` | Reads GTW_carConfig for HW version |
 | **Listen-Only Mode** | — | Default on boot, passive monitoring only |
@@ -161,8 +166,8 @@ Bus speed: **500 kbps**
 
 ### Build
 ```bash
-git clone https://github.com/YOUR_USERNAME/esp32-tesla-fsd.git
-cd esp32-tesla-fsd
+git clone https://github.com/hypery11/flipper-tesla-fsd.git
+cd flipper-tesla-fsd/esp32
 pio run -e m5stack-atom
 ```
 
@@ -244,10 +249,13 @@ pio device monitor -b 115200
 
 ## Firmware Compatibility
 
+This table is informational from field reports/upstream notes. The ESP32 code itself does not hardcode firmware-version checks.
+
 | Tesla Firmware | HW3 | HW4 | Notes |
 |----------------|-----|-----|-------|
 | ≤ 2026.2.x | ✅ | ✅ | Full support |
 | 2026.2.9.x | ✅ | ⚠️ | HW4 broken on these versions, use HW3 mode |
+| 2026.8.3 | ✅ | ⚠️ | Not tested on HW4 |
 | 2026.8.6+ | ⚠️ | ❌ | Region lock added — FSD model present but won't activate in some regions |
 
 > **⚠️ Strongly recommended: disable automatic OTA updates** to stay on a compatible firmware version.
@@ -257,8 +265,8 @@ pio device monitor -b 115200
 ## Project Structure
 
 ```
-esp32-obd-fsd/
-├── src/
+esp32/
+├── .firmware/
 │   ├── main.cpp            — Init, button handling, main loop
 │   ├── fsd_handler.cpp/h   — CAN protocol logic (ported from hypery11)
 │   ├── can_driver.cpp/h    — CAN driver abstraction (TWAI / MCP2515)
@@ -290,7 +298,7 @@ GPL-3.0 — Same as the upstream projects.
 
 ## Disclaimer
 
-> **⚠️ This project has NOT been tested on a real vehicle yet.**
+> **⚠️ Tested on Model 3 2022 HW3 only. Other models/years/HW revisions are not yet validated.**
 
 This project is for **educational and research purposes only**. Modifying vehicle CAN bus communication may:
 - Void your vehicle warranty

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -1,3 +1,6 @@
+[platformio]
+src_dir = .firmware
+
 [env:m5stack-atom]
 platform = espressif32
 board = m5stack-atom
@@ -6,6 +9,20 @@ monitor_speed = 115200
 build_flags =
     -D BOARD_M5STACK_ATOM
     -D CAN_DRIVER_TWAI
+lib_deps =
+    adafruit/Adafruit NeoPixel@^1.12.0
+    Links2004/WebSockets@^2.4.0
+
+[env:m5stack-atom-swap-pins]
+platform = espressif32
+board = m5stack-atom
+framework = arduino
+monitor_speed = 115200
+build_flags =
+    -D BOARD_M5STACK_ATOM
+    -D CAN_DRIVER_TWAI
+    -D PIN_CAN_TX=19
+    -D PIN_CAN_RX=22
 lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     Links2004/WebSockets@^2.4.0
@@ -22,4 +39,3 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     autowp/autowp-mcp2515@^1.3.0
     Links2004/WebSockets@^2.4.0
-src_dir = .firmware


### PR DESCRIPTION
ESP32 Port — Firmware & Documentation Update
Tested on: Tesla Model 3 2022 HW3 ✅

What's changed
Firmware ([esp32/.firmware])

CAN logic fully ported from hypery11's fsd_handler.c (bit operations, mux dispatch, checksum)
HW3 / HW4 / Legacy auto-detection via 0x398 GTW_carConfig + fallback detection
NAG Killer: counter+1 echo on 0x370 with handsOnLevel spoofing
OTA protection: TX suspension on 0x318 with debounce (assert 3 frames / clear 6 frames)
ISA speed chime suppression (HW4, 0x399)
WiFi AP dashboard (SSID: Tesla-FSD, IP: 192.168.4.1) with real-time WebSocket push at 1 Hz
REST API: GET /api/status
Dual CAN driver support: ESP32 TWAI (M5Stack ATOM Lite) + MCP2515 SPI
BMS — parsers implemented (0x132, 0x292, 0x312), UI/API fields wired, but not yet reliable in real vehicle use — needs further investigation.

README
Updated to reflect actual code structure (.firmware/ directory, real build commands)
Vehicle test status updated: tested on Model 3 2022 HW3, works well
BMS section clearly marked as not working reliably yet
Firmware compatibility table kept as informational only
Disclaimer updated accordingly