### PR TITLE
feat(esp32): Lilygo T-CAN485 board, NAG killer fixes, CAN dump

### DIFF
--- a/esp32/.firmware/can_dump.cpp
+++ b/esp32/.firmware/can_dump.cpp
@@ -1,0 +1,259 @@
+#include "can_dump.h"
+#include "config.h"
+#include <stdarg.h>
+
+// ─────────────────────────────────────────────────────────────────────────────
+#if defined(BOARD_LILYGO)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#include <SPI.h>
+#include <SD.h>
+
+#define DUMP_MAX_ENTRIES  1000000UL
+#define DUMP_TIMEOUT_MS   (15UL * 60UL * 1000UL)
+
+static SPIClass  g_spi(HSPI);
+static bool      g_sd_ok    = false;
+static bool      g_active   = false;
+static uint32_t  g_start_ms = 0;
+static uint32_t  g_entries  = 0;
+static File      g_file;
+static File      g_log_file;
+static char      g_dir_path[32];
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// Delete a path (file or directory tree) by repeatedly picking the first
+// remaining child — safe against iterator invalidation during deletion.
+static void rm_recursive(const char *path) {
+    {
+        File f = SD.open(path);
+        if (!f) return;
+        bool is_dir = f.isDirectory();
+        f.close();
+        if (!is_dir) { SD.remove(path); return; }
+    }
+    for (;;) {
+        File dir = SD.open(path);
+        if (!dir) break;
+        File child = dir.openNextFile();
+        if (!child) { dir.close(); break; }
+        String cp = child.name();  // full absolute path from SD root
+        child.close();
+        dir.close();
+        rm_recursive(cp.c_str());
+    }
+    SD.rmdir(path);
+}
+
+static uint32_t find_next_seq() {
+    if (!SD.exists("/dumps")) {
+        SD.mkdir("/dumps");
+        return 1;
+    }
+    File dir = SD.open("/dumps");
+    if (!dir) return 1;
+    uint32_t max_seq = 0;
+    File entry = dir.openNextFile();
+    while (entry) {
+        if (entry.isDirectory()) {
+            const char *full = entry.name();
+            const char *slash = strrchr(full, '/');
+            uint32_t n = (uint32_t)atoi(slash ? slash + 1 : full);
+            if (n > max_seq) max_seq = n;
+        }
+        entry.close();
+        entry = dir.openNextFile();
+    }
+    dir.close();
+    return max_seq + 1;
+}
+
+static bool open_new_file() {
+    if (g_file) {
+        g_file.flush();
+        g_file.close();
+    }
+    uint32_t elapsed_s = (millis() - g_start_ms) / 1000;
+    char path[72];
+    snprintf(path, sizeof(path), "%s/candump_%lu.dump",
+             g_dir_path, (unsigned long)elapsed_s);
+    g_file   = SD.open(path, FILE_WRITE);
+    g_entries = 0;
+    if (!g_file) {
+        Serial.printf("[SD] open failed: %s\n", path);
+        return false;
+    }
+    Serial.printf("[SD] → %s\n", path);
+    return true;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+void can_dump_init() {
+    g_spi.begin(SD_SCLK, SD_MISO, SD_MOSI, SD_CS);
+    if (!SD.begin(SD_CS, g_spi, 4000000)) {
+        Serial.println("[SD] No card — CAN dump disabled");
+        g_sd_ok = false;
+        return;
+    }
+    g_sd_ok = true;
+    uint64_t total_mb = SD.totalBytes() / (1024ULL * 1024ULL);
+    uint64_t used_mb  = SD.usedBytes()  / (1024ULL * 1024ULL);
+    Serial.printf("[SD] Card OK  %lluMB total  %lluMB used\n", total_mb, used_mb);
+}
+
+bool can_dump_start() {
+    if (!g_sd_ok || g_active) return false;
+
+    uint32_t seq = find_next_seq();
+    snprintf(g_dir_path, sizeof(g_dir_path), "/dumps/%05lu", (unsigned long)seq);
+    if (!SD.mkdir(g_dir_path)) {
+        Serial.printf("[SD] mkdir failed: %s\n", g_dir_path);
+        return false;
+    }
+    g_start_ms = millis();
+    g_active   = true;
+
+    if (!open_new_file()) {
+        g_active = false;
+        return false;
+    }
+
+    char log_path[72];
+    snprintf(log_path, sizeof(log_path), "%s/debug.log", g_dir_path);
+    g_log_file = SD.open(log_path, FILE_WRITE);
+    if (!g_log_file)
+        Serial.printf("[SD] debug.log open failed: %s\n", log_path);
+
+    Serial.printf("[SD] Dump started  dir=%s\n", g_dir_path);
+    return true;
+}
+
+void can_dump_stop() {
+    if (!g_active) return;
+    g_active = false;
+    if (g_file) {
+        g_file.flush();
+        g_file.close();
+    }
+    if (g_log_file) {
+        g_log_file.flush();
+        g_log_file.close();
+    }
+    uint32_t elapsed_s = (millis() - g_start_ms) / 1000;
+    Serial.printf("[SD] Dump stopped  elapsed=%lus  entries=%lu\n",
+                  (unsigned long)elapsed_s, (unsigned long)g_entries);
+}
+
+void can_dump_record(const CanFrame &frame) {
+    if (!g_active || !g_file) return;
+
+    uint32_t elapsed_ms = millis() - g_start_ms;
+    uint32_t sec  = elapsed_ms / 1000;
+    uint32_t usec = (elapsed_ms % 1000) * 1000;
+
+    // candump ASCII log: (sec.usec) can0 ID#DATA\n
+    char line[48];
+    int pos = snprintf(line, sizeof(line), "(%lu.%06lu) can0 %03X#",
+                       (unsigned long)sec, (unsigned long)usec, frame.id);
+    for (int i = 0; i < frame.dlc && i < 8; i++) {
+        pos += snprintf(line + pos, sizeof(line) - pos, "%02X", frame.data[i]);
+    }
+    line[pos++] = '\n';
+    g_file.write((const uint8_t *)line, pos);
+
+    g_entries++;
+    if (g_entries >= DUMP_MAX_ENTRIES) {
+        open_new_file();
+    }
+}
+
+void can_dump_tick(uint32_t now_ms) {
+    if (!g_active) return;
+    if ((now_ms - g_start_ms) >= DUMP_TIMEOUT_MS) {
+        Serial.println("[SD] 15-min auto-stop");
+        can_dump_stop();
+    }
+}
+
+bool can_dump_active() {
+    return g_active;
+}
+
+void can_dump_log(const char *fmt, ...) {
+    if (!g_active || !g_log_file) return;
+
+    uint32_t elapsed_ms = millis() - g_start_ms;
+    uint32_t sec  = elapsed_ms / 1000;
+    uint32_t usec = (elapsed_ms % 1000) * 1000;
+
+    char buf[160];
+    int pos = snprintf(buf, sizeof(buf), "(%lu.%06lu) ", (unsigned long)sec, (unsigned long)usec);
+
+    va_list ap;
+    va_start(ap, fmt);
+    pos += vsnprintf(buf + pos, sizeof(buf) - pos, fmt, ap);
+    va_end(ap);
+
+    if (pos < (int)sizeof(buf) - 1) buf[pos++] = '\n';
+    g_log_file.write((const uint8_t *)buf, pos);
+}
+
+String sd_format_card() {
+    if (g_active) can_dump_stop();
+
+    // Unmount so we can remount with format_if_failed=true.
+    // This handles both already-mounted cards (wipe) and raw/unformatted cards.
+    if (g_sd_ok) {
+        SD.end();
+        g_sd_ok = false;
+    }
+
+    Serial.println("[SD] Mounting with format_if_failed=true");
+    // format_if_failed=true: ESP32 FAT-formats the card if it can't mount it
+    if (!SD.begin(SD_CS, g_spi, 4000000, "/sd", 5, true)) {
+        return "{\"ok\":false,\"msg\":\"SD card not found or unreadable\"}";
+    }
+    g_sd_ok = true;
+
+    // Wipe any existing content so the card is clean
+    Serial.println("[SD] Clearing existing content");
+    for (;;) {
+        File root = SD.open("/");
+        if (!root) break;
+        File f = root.openNextFile();
+        if (!f) { root.close(); break; }
+        String path = f.name();
+        f.close();
+        root.close();
+        Serial.printf("[SD] rm %s\n", path.c_str());
+        rm_recursive(path.c_str());
+    }
+
+    uint64_t total_mb = SD.totalBytes() / (1024ULL * 1024ULL);
+    uint64_t free_mb  = (SD.totalBytes() - SD.usedBytes()) / (1024ULL * 1024ULL);
+    Serial.printf("[SD] Format done  %lluMB free\n", free_mb);
+
+    String r = "{\"ok\":true,\"msg\":\"SD card formatted\",\"total_mb\":";
+    r += (uint32_t)total_mb;
+    r += ",\"free_mb\":";
+    r += (uint32_t)free_mb;
+    r += '}';
+    return r;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+#else  // Non-Lilygo stubs
+// ─────────────────────────────────────────────────────────────────────────────
+
+void   can_dump_init()                    {}
+bool   can_dump_start()                   { return false; }
+void   can_dump_stop()                    {}
+void   can_dump_record(const CanFrame &)  {}
+void   can_dump_tick(uint32_t)            {}
+bool   can_dump_active()                  { return false; }
+void   can_dump_log(const char *, ...)    {}
+String sd_format_card()                   { return "{\"ok\":false,\"msg\":\"SD not available on this board\"}"; }
+
+#endif

--- a/esp32/.firmware/can_dump.h
+++ b/esp32/.firmware/can_dump.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <Arduino.h>
+#include "fsd_handler.h"
+
+/**
+ * can_dump.h — SD-card CAN bus logger (Lilygo T-CAN485)
+ *
+ * Logs all received CAN frames to SD card in candump ASCII format:
+ *   (elapsed_s.elapsed_us) can0 ID#DATA
+ *
+ * Directory layout:
+ *   /dumps/00001/candump_0.dump
+ *   /dumps/00001/candump_900.dump   (file rotation at 1 M entries)
+ *   /dumps/00002/candump_0.dump     (next dump session)
+ *
+ * Auto-stops after 15 minutes. File is flushed and closed on stop.
+ *
+ * All functions are safe no-ops on non-Lilygo builds.
+ */
+
+void   can_dump_init();
+bool   can_dump_start();
+void   can_dump_stop();
+void   can_dump_record(const CanFrame &frame);
+void   can_dump_tick(uint32_t now_ms);
+bool   can_dump_active();
+String sd_format_card();
+
+// Write a timestamped human-readable entry to debug.log in the active session
+// directory. No-op if no dump is active. Printf-style format.
+void   can_dump_log(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -15,14 +15,25 @@
 #define CAN_ID_DAS_AP_CONFIG  0x331u  // 817  - DAS autopilot config (tier restore target, ~1 Hz)
 #define CAN_ID_AP_CONTROL     0x3FDu  // 1021 - DAS_autopilotControl: HW3 / HW4 core
 
-// ── GPIO — M5Stack ATOM Lite + ATOMIC CAN Base (CA-IS3050G) ──────────────────
-#ifndef PIN_CAN_TX
-#define PIN_CAN_TX   22   // TWAI TX → ATOMIC CAN Base TX
+// ── GPIO ──────────────────────────────────────────────────────────────────────
+#if defined(BOARD_LILYGO)
+  #define PIN_CAN_TX         27
+  #define PIN_CAN_RX         26
+  #define PIN_CAN_SPEED_MODE 23   // SN65HVD230 Rs — must be LOW for TX+RX
+  #define PIN_LED            4    // SK6812 NeoPixel
+  #define SD_MISO            2
+  #define SD_MOSI            15
+  #define SD_SCLK            14
+  #define SD_CS              13
+#else
+  #ifndef PIN_CAN_TX
+  #define PIN_CAN_TX   22   // TWAI TX → ATOMIC CAN Base TX
+  #endif
+  #ifndef PIN_CAN_RX
+  #define PIN_CAN_RX   19   // TWAI RX ← ATOMIC CAN Base RX
+  #endif
+  #define PIN_LED      27   // SK6812 NeoPixel (single LED)
 #endif
-#ifndef PIN_CAN_RX
-#define PIN_CAN_RX   19   // TWAI RX ← ATOMIC CAN Base RX
-#endif
-#define PIN_LED      27   // SK6812 NeoPixel (single LED)
 #define PIN_BUTTON   39   // Built-in button, active-LOW (no external pull-up needed)
 
 // MCP2515 SPI — only used in CAN_DRIVER_MCP2515 build (generic ESP32)
@@ -51,3 +62,7 @@
 #define OTA_IN_PROGRESS_RAW_VALUE  1u
 #define OTA_ASSERT_FRAMES          3u
 #define OTA_CLEAR_FRAMES           6u
+
+#if defined(BOARD_LILYGO)
+  #define ME2107_EN 16
+#endif

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -77,9 +77,11 @@ TeslaHWVersion fsd_detect_hw_version(const CanFrame *frame) {
     // DAS_HWversion field: bits 7:6 of byte 0  (das_hw)
     uint8_t das_hw = (frame->data[0] >> 6) & 0x03;
     switch (das_hw) {
+        case 0:
+        case 1:  return TeslaHW_Legacy;   // HW1/HW2/EAP retrofit — uses 0x3EE/0x045
         case 2:  return TeslaHW_HW3;
         case 3:  return TeslaHW_HW4;
-        default: return TeslaHW_Unknown;  // 0=HW1/HW2 → Legacy, 1=unknown
+        default: return TeslaHW_Unknown;
     }
 }
 
@@ -281,9 +283,10 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
     if (frame->dlc < 8)    return false;
     if (!state->nag_killer) return false;
 
-    // Only act when handsOnLevel == 0 (bits 7:6 of byte 4)
+    // Act when handsOnLevel == 0 (nag imminent) or == 3 (escalated alarm).
+    // Level 1 = hands confirmed OK — no action needed.
     uint8_t hands_on = (frame->data[4] >> 6) & 0x03;
-    if (hands_on != 0) return false;
+    if (hands_on == 1) return false;
 
     out->id  = CAN_ID_EPAS_STATUS;
     out->dlc = 8;
@@ -292,7 +295,7 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
     out->data[1] = frame->data[1];
     out->data[2] = (frame->data[2] & 0xF0u) | 0x08u; // lower nibble = torque quality
     out->data[3] = 0xB6u;                              // torsionBarTorque = 1.80 Nm (fixed)
-    out->data[4] = frame->data[4] | 0x40u;             // handsOnLevel = 1
+    out->data[4] = (frame->data[4] & ~0xC0u) | 0x40u;  // handsOnLevel = 1 (clear bits 7:6 first)
     out->data[5] = frame->data[5];
 
     // counter+1: lower nibble of byte 6

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -21,6 +21,7 @@
 #include "led.h"
 #include "wifi_manager.h"
 #include "web_dashboard.h"
+#include "can_dump.h"
 
 // ── Globals ───────────────────────────────────────────────────────────────────
 static CanDriver *g_can   = nullptr;
@@ -46,6 +47,7 @@ static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
         (hw == TeslaHW_HW4) ? "HW4" :
         (hw == TeslaHW_HW3) ? "HW3" : "Legacy";
     Serial.printf("[HW] Auto-detected: %s (%s)\n", hw_str, reason);
+    can_dump_log("HW  auto-detected: %s (%s)", hw_str, reason);
 }
 
 // ── Button state machine ──────────────────────────────────────────────────────
@@ -62,10 +64,12 @@ static void dispatch_clicks(int n) {
             g_state.op_mode = OpMode_Active;
             g_can->setListenOnly(false);
             Serial.println("[BTN] → Active mode");
+            can_dump_log("MODE switched to Active — TX enabled");
         } else {
             g_state.op_mode = OpMode_ListenOnly;
             g_can->setListenOnly(true);
             Serial.println("[BTN] → Listen-Only mode");
+            can_dump_log("MODE switched to Listen-Only — TX disabled");
         }
     } else if (n >= 2) {
         // Toggle BMS serial output
@@ -129,6 +133,7 @@ static void update_led() {
 // ── CAN frame dispatcher ──────────────────────────────────────────────────────
 static void process_frame(const CanFrame &frame) {
     g_state.rx_count++;
+    can_dump_record(frame);
 
     if (frame.id == CAN_ID_GTW_CAR_STATE)  g_state.seen_gtw_car_state++;
     if (frame.id == CAN_ID_GTW_CAR_CONFIG) g_state.seen_gtw_car_config++;
@@ -141,8 +146,6 @@ static void process_frame(const CanFrame &frame) {
     if (frame.dlc == 0) return;
 
     // ── HW auto-detect (passive, runs in both modes) ─────────────────────────
-    // Only needed until we lock in a version; keep running after that too so
-    // we can print it if a new frame arrives.
     if (frame.id == CAN_ID_GTW_CAR_CONFIG) {
         TeslaHWVersion hw = fsd_detect_hw_version(&frame);
         if (hw != TeslaHW_Unknown && g_state.hw_version == TeslaHW_Unknown)
@@ -154,10 +157,13 @@ static void process_frame(const CanFrame &frame) {
     if (frame.id == CAN_ID_GTW_CAR_STATE) {
         bool was_ota = g_state.tesla_ota_in_progress;
         fsd_handle_gtw_car_state(&g_state, &frame);
-        if (!was_ota && g_state.tesla_ota_in_progress)
+        if (!was_ota && g_state.tesla_ota_in_progress) {
             Serial.printf("[OTA] Update in progress (raw=%u) - TX suspended\n", g_state.ota_raw_state);
-        else if (was_ota && !g_state.tesla_ota_in_progress)
+            can_dump_log("OTA  started — TX suspended");
+        } else if (was_ota && !g_state.tesla_ota_in_progress) {
             Serial.printf("[OTA] Update finished (raw=%u) - TX resumed\n", g_state.ota_raw_state);
+            can_dump_log("OTA  finished — TX resumed");
+        }
         return;
     }
 
@@ -172,8 +178,15 @@ static void process_frame(const CanFrame &frame) {
     // NAG killer — build echo and send before the real frame propagates (0x370)
     if (frame.id == CAN_ID_EPAS_STATUS) {
         CanFrame echo;
-        if (fsd_handle_nag_killer(&g_state, &frame, &echo) && tx)
-            g_can->send(echo);
+        bool fired = fsd_handle_nag_killer(&g_state, &frame, &echo);
+        if (fired) {
+            uint8_t lvl     = (frame.data[4] >> 6) & 0x03;
+            uint8_t cnt_in  = frame.data[6] & 0x0F;
+            uint8_t cnt_out = echo.data[6] & 0x0F;
+            can_dump_log("NAG 0x370 hands_off lvl=%u cnt=%u->%u %s",
+                         lvl, cnt_in, cnt_out, tx ? "TX echo" : "listen-only no-TX");
+            if (tx) g_can->send(echo);
+        }
         return;
     }
 
@@ -251,6 +264,16 @@ void setup() {
     Serial.println("[CAN] Driver: MCP2515 via SPI");
 #endif
 
+#if defined(BOARD_LILYGO)
+    pinMode(ME2107_EN, OUTPUT);
+    digitalWrite(ME2107_EN, HIGH);
+    // CAN transceiver slope/mode pin — must be LOW for normal TX+RX operation.
+    // Floating or HIGH puts the SN65HVD230/TJA1051 into standby (RX-only),
+    // which causes the TWAI controller to go bus-off the first time it tries to TX.
+    pinMode(PIN_CAN_SPEED_MODE, OUTPUT);
+    digitalWrite(PIN_CAN_SPEED_MODE, LOW);
+#endif
+
     pinMode(PIN_BUTTON, INPUT_PULLUP);
     led_init();
 
@@ -264,6 +287,8 @@ void setup() {
     g_state.bms_output            = false;
 
     led_set(LED_BLUE);
+
+    can_dump_init();
 
     g_can = can_driver_create();
     if (!g_can->begin(true)) {
@@ -362,6 +387,8 @@ void loop() {
         Serial.println("[WARN] Verify CAN-H on OBD pin 6, CAN-L on pin 14");
         last_warn_ms = now;
     }
+
+    can_dump_tick(now);
 
     // ── Web dashboard (after CAN to preserve CAN frame latency) ──────────────
     web_dashboard_update();

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "web_dashboard.h"
+#include "can_dump.h"
 #include <WebServer.h>
 #include <WebSocketsServer.h>
 #include <WiFi.h>
@@ -253,6 +254,21 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">TLSSC Restore</span>
     <label class="sw"><input type="checkbox" id="swTlssc" onchange="cmd('tlssc_restore',this.checked)"><span class="sl2"></span></label>
   </div>
+  <div class="row">
+    <span class="lbl">CAN Dump</span>
+    <label class="sw"><input type="checkbox" id="swDump" onchange="cmd('dump',this.checked)"><span class="sl2"></span></label>
+  </div>
+</div>
+
+<!-- SD Card -->
+<div class="card">
+  <div class="card-head"><div class="icon ic-d">S</div><h2>SD Card</h2></div>
+  <div class="row">
+    <span class="lbl">Dump Status</span>
+    <span class="pill off" id="dumpSt"><span class="pd"></span>Idle</span>
+  </div>
+  <button id="btnFmt" class="btn-main btn-stop" onclick="sdFormat()" style="margin-top:8px">FORMAT SD CARD</button>
+  <div id="fmtOut" style="font-size:.75em;color:var(--text2);margin-top:8px;display:none"></div>
 </div>
 
 <!-- Device Info -->
@@ -324,6 +340,8 @@ function upd(d){
   document.getElementById('swBms').checked=d.bms_output;
   document.getElementById('swFsd').checked=d.force_fsd;
   document.getElementById('swTlssc').checked=d.tlssc_restore;
+  document.getElementById('swDump').checked=!!d.can_dump;
+  pill('dumpSt',d.can_dump,d.can_dump?'Recording':'Idle');
 
   // CAN stats
   document.getElementById('rxCnt').textContent=d.rx_count.toLocaleString();
@@ -350,6 +368,21 @@ function upd(d){
   document.getElementById('wifiCl').textContent=d.wifi_clients;
 }
 
+function sdFormat(){
+  if(!confirm('Format SD card? All data will be lost.'))return;
+  var btn=document.getElementById('btnFmt');
+  var out=document.getElementById('fmtOut');
+  btn.disabled=true;btn.textContent='FORMATTING\u2026';
+  fetch('/sdformat').then(function(r){return r.json();}).then(function(d){
+    out.style.display='block';
+    out.style.color=d.ok?'var(--accent)':'var(--red)';
+    out.textContent=d.msg+(d.ok?' \u2014 '+d.free_mb+' MB free':'');
+  }).catch(function(){
+    out.style.display='block';out.style.color='var(--red)';out.textContent='Request failed';
+  }).then(function(){
+    btn.disabled=false;btn.textContent='FORMAT SD CARD';
+  });
+}
 function cmd(c,v){
   if(ws&&ws.readyState===1) ws.send(JSON.stringify({cmd:c,value:v}));
 }
@@ -379,10 +412,10 @@ conn();
 // ── JSON builder ──────────────────────────────────────────────────────────────
 static String build_json() {
     uint32_t uptime_s = (millis() - g_start_ms) / 1000;
-  bool can_vehicle_detected = false;
-  if (g_state != nullptr && g_state->rx_count > 0) {
-    can_vehicle_detected = (millis() - g_last_can_seen_ms) <= CAN_VEHICLE_ALIVE_MS;
-  }
+    bool can_vehicle_detected = false;
+    if (g_state != nullptr && g_state->rx_count > 0) {
+        can_vehicle_detected = (millis() - g_last_can_seen_ms) <= CAN_VEHICLE_ALIVE_MS;
+    }
 
     // BMS sub-object
     char bms[128];
@@ -425,6 +458,7 @@ static String build_json() {
     j += "\"bms\":";           j += bms;                               j += ',';
     j += "\"uptime_s\":";      j += uptime_s;                          j += ',';
     j += "\"fw_build\":\"";    j += __DATE__;  j += ' '; j += __TIME__; j += "\",";
+    j += "\"can_dump\":";      j += can_dump_active()                 ? "true" : "false"; j += ',';
     j += "\"wifi_clients\":";  j += (int)WiFi.softAPgetStationNum();
     j += '}';
     return j;
@@ -471,6 +505,11 @@ static void ws_event(uint8_t num, WStype_t type,
     } else if (strstr(buf, "\"force_fsd\"")) {
         g_state->force_fsd = (strstr(buf, "true") != nullptr);
         Serial.printf("[Web] Force FSD: %s\n", g_state->force_fsd ? "ON" : "OFF");
+    } else if (strstr(buf, "\"dump\"")) {
+        bool want = (strstr(buf, "true") != nullptr);
+        if (want) can_dump_start();
+        else      can_dump_stop();
+        Serial.printf("[Web] CAN Dump: %s\n", want ? "START" : "STOP");
     }
 }
 
@@ -484,6 +523,11 @@ static void handle_status() {
     g_http.send(200, "application/json", build_json());
 }
 
+static void handle_sdformat() {
+    String result = sd_format_card();
+    g_http.send(200, "application/json", result);
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 void web_dashboard_init(FSDState *state, CanDriver *can) {
     g_state       = state;
@@ -495,6 +539,7 @@ void web_dashboard_init(FSDState *state, CanDriver *can) {
 
     g_http.on("/",           HTTP_GET, handle_root);
     g_http.on("/api/status", HTTP_GET, handle_status);
+    g_http.on("/sdformat",   HTTP_GET, handle_sdformat);
     g_http.begin();
 
     g_ws.begin();
@@ -514,7 +559,7 @@ void web_dashboard_update() {
     if ((now - g_last_fps_ms) >= 1000u) {
         uint32_t rx = g_state->rx_count;
         float    dt = (now - g_last_fps_ms) / 1000.0f;
-      if (rx != g_last_rx) g_last_can_seen_ms = now;
+        if (rx != g_last_rx) g_last_can_seen_ms = now;
         g_fps        = (float)(rx - g_last_rx) / dt;
         g_last_rx    = rx;
         g_last_fps_ms = now;

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -39,3 +39,15 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     autowp/autowp-mcp2515@^1.3.0
     Links2004/WebSockets@^2.4.0
+
+[env:esp32-lilygo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+build_flags =
+    -D BOARD_LILYGO
+    -D CAN_DRIVER_TWAI
+lib_deps =
+    adafruit/Adafruit NeoPixel@^1.12.0
+    Links2004/WebSockets@^2.4.0


### PR DESCRIPTION
## Summary

Tested on a **2017 Model X** and **Model S**, both with MCU2/HW3 and EAP (Enhanced Autopilot), tapped into the **Chassis CAN bus** (X179 connector). Hardware is a cheap [Lilygo T-CAN485](https://github.com/Xinyuan-LilyGO/T-CAN485) ESP32 board with an onboard SN65HVD230 transceiver and SD card reader.

### Bug fixes

- **Legacy HW detection**: `fsd_detect_hw_version()` fell through to `TeslaHW_Unknown` for `das_hw=0` and `das_hw=1`. The MCU2/HW3 retrofit reports `das_hw=0` in `GTW_carConfig` (0x398), so FSD injection was silently disabled. Fixed by mapping cases 0 and 1 to `TeslaHW_Legacy`.
- **NAG killer - level 3**: The hands-off alarm has two levels: level 0 (nag imminent) and level 3 (escalated alarm). The previous guard `if (hands_on != 0)` skipped level 3 entirely, leaving the escalated alarm unsuppressed. Changed to `if (hands_on == 1)` so both 0 and 3 are suppressed.
- **NAG killer - echo byte corruption**: `out->data[4] = frame->data[4] | 0x40u` does not clear the existing `handsOnLevel` bits first. If the incoming frame has level=3 (bits[7:6]=`11`), OR-ing `0x40` leaves bit 7 set, so the spoofed frame still reads level=3. Fixed to `(frame->data[4] & ~0xC0u) | 0x40u`.

### New board: Lilygo T-CAN485

- `config.h`: `BOARD_LILYGO` GPIO block - CAN TX/RX, `PIN_CAN_SPEED_MODE` (SN65HVD230 Rs pin), NeoPixel, SD card SPI, `ME2107_EN` (3.3 V regulator).
- `main.cpp`: board init drives `ME2107_EN` HIGH and `PIN_CAN_SPEED_MODE` LOW. **The Rs pin is critical**: if left floating it puts the transceiver into standby (RX-only), which causes the TWAI peripheral to go bus-off on the very first TX attempt.
- `platformio.ini`: new `[env:esp32-lilygo]` alongside the existing three environments.

### CAN dump (Lilygo only)

- `can_dump.h` / `can_dump.cpp`: SD-card logger writing all frames in candump ASCII format with per-session `debug.log` for annotated events (mode changes, OTA, NAG echoes, HW detection). Auto-rotation at 1 M entries, 15-minute auto-stop. Non-Lilygo builds compile to safe no-ops with zero impact on M5Stack/generic targets.
- Web dashboard: CAN Dump toggle added to Controls card; new SD Card card with dump status pill and FORMAT button (`/sdformat` endpoint).
- All existing upstream features preserved: TLSSC Restore, OTA debounce hardening, fallback HW detection, CAN vehicle detection, BMS frame counters.

## Test plan

- [ ] Build all four environments (`m5stack-atom`, `m5stack-atom-swap-pins`, `esp32-mcp2515`, `esp32-lilygo`) - no compile errors
- [ ] On Lilygo T-CAN485 connected to Chassis CAN: verify green LED on activation, NAG suppression active at level 0 and level 3
- [ ] Confirm HW auto-detect prints `Legacy` (not `Unknown`) on MCU2/HW3 cars reporting `das_hw=0`
- [ ] Start CAN dump via web UI, verify `.dump` file appears on SD card in candump format
- [ ] Non-Lilygo build: verify `can_dump_*` calls compile cleanly as no-ops
