### PR TITLE
feat(esp32): add Waveshare ESP32-S3-RS485-CAN support

### DIFF
--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -32,9 +32,13 @@
   #ifndef PIN_CAN_RX
   #define PIN_CAN_RX   19   // TWAI RX ← ATOMIC CAN Base RX
   #endif
+  #ifndef PIN_LED
   #define PIN_LED      27   // SK6812 NeoPixel (single LED)
+  #endif
 #endif
+#ifndef PIN_BUTTON
 #define PIN_BUTTON   39   // Built-in button, active-LOW (no external pull-up needed)
+#endif
 
 // MCP2515 SPI — only used in CAN_DRIVER_MCP2515 build (generic ESP32)
 // Standard VSPI pins: SCK=18, MISO=19, MOSI=23, CS=5

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -259,7 +259,13 @@ void setup() {
     Serial.println("============================");
     Serial.printf("[FSD] Build: %s %s\n", __DATE__, __TIME__);
 #if defined(CAN_DRIVER_TWAI)
+  #if defined(BOARD_WAVESHARE_S3)
+    Serial.println("[CAN] Driver: ESP32-S3 TWAI (Waveshare ESP32-S3-RS485-CAN)");
+  #elif defined(BOARD_LILYGO)
+    Serial.println("[CAN] Driver: ESP32 TWAI (LilyGO T-CAN485)");
+  #else
     Serial.println("[CAN] Driver: ESP32 TWAI (M5Stack ATOM Lite + ATOMIC CAN Base)");
+  #endif
 #elif defined(CAN_DRIVER_MCP2515)
     Serial.println("[CAN] Driver: MCP2515 via SPI");
 #endif
@@ -273,6 +279,9 @@ void setup() {
     pinMode(PIN_CAN_SPEED_MODE, OUTPUT);
     digitalWrite(PIN_CAN_SPEED_MODE, LOW);
 #endif
+
+    Serial.printf("[CFG] pins: LED=%d BUTTON=%d CAN_TX=%d CAN_RX=%d\n",
+                  PIN_LED, PIN_BUTTON, PIN_CAN_TX, PIN_CAN_RX);
 
     pinMode(PIN_BUTTON, INPUT_PULLUP);
     led_init();

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -101,10 +101,24 @@ Dual CAN driver support (compile-time switch):
 
 ### Alternative Hardware
 
-Any ESP32 board + CAN transceiver works. Change the build environment in `platformio.ini`:
-- ESP32 + SN65HVD230 (TWAI driver, cheapest option)
-- ESP32 + MCP2515 module (SPI driver, use `esp32-mcp2515` env)
-- ESP32-C3/S3 Super Mini + SN65HVD230
+Any ESP32 board + CAN transceiver works. Pick the matching build env in `platformio.ini`:
+
+| PlatformIO env | Board | CAN driver | CAN pins (TX/RX) | Notes |
+|---|---|---|---|---|
+| `m5stack-atom` | M5Stack ATOM Lite + ATOMIC CAN Base | TWAI | 22 / 19 | Default, cheapest |
+| `m5stack-atom-swap-pins` | M5Stack ATOM Lite + ATOMIC CAN Base | TWAI | 19 / 22 | For boards with swapped silkscreen |
+| `esp32-mcp2515` | Generic ESP32 + MCP2515 module | MCP2515 SPI | SPI CS=5 | 8 MHz crystal |
+| `esp32-lilygo` | LilyGO T-CAN485 | TWAI | 27 / 26 | Built-in SN65HVD230 + SD slot |
+| `waveshare-s3-can` | Waveshare ESP32-S3-RS485-CAN | TWAI | 15 / 16 | ESP32-S3, 8MB flash/PSRAM, USB-CDC |
+| generic | ESP32-C3/S3 Super Mini + SN65HVD230 | TWAI | any two pins | Override `PIN_CAN_TX` / `PIN_CAN_RX` |
+
+Build + upload:
+
+```bash
+pio run -e <env-name> -t upload -t monitor
+```
+
+On first boot every target prints its pin map as `[CFG] pins: LED=.. BUTTON=.. CAN_TX=.. CAN_RX=..` — if the numbers don't match your board, the build flags are being shadowed by an unguarded `#define` somewhere.
 
 ---
 

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -51,3 +51,30 @@ build_flags =
 lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     Links2004/WebSockets@^2.4.0
+
+[env:waveshare-s3-can]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+
+board_build.flash_size = 8MB
+board_build.flash_mode = qio
+board_build.partitions = default_8MB.csv
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+
+build_flags =
+    -D BOARD_WAVESHARE_S3
+    -D CAN_DRIVER_TWAI
+    -D PIN_CAN_TX=15
+    -D PIN_CAN_RX=16
+    -D PIN_LED=46
+    -D PIN_BUTTON=0
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MODE=1
+
+lib_deps =
+    adafruit/Adafruit NeoPixel@^1.12.0
+    Links2004/WebSockets@^2.4.0


### PR DESCRIPTION
Adds a `waveshare-s3-can` PlatformIO env for Waveshare's all-in-one ESP32-S3 board with integrated CAN transceiver (8MB flash/PSRAM, CAN TX=GPIO15, CAN RX=GPIO16, NeoPixel=GPIO46, BOOT button=GPIO0, native USB-CDC serial). Uses the built-in TWAI peripheral at 500 kbps.

Fixes a latent bug that previously made the -D PIN_LED / -D PIN_BUTTON build flags silently no-op: the unconditional `#define PIN_LED 27` and `#define PIN_BUTTON 39` in config.h would override the command-line values (GCC emits a redefinition warning but the later define wins), so any board overriding these pins ended up driving the wrong GPIO. On S3 this was fatal because GPIO 39 does not exist — pinMode() would hit the invalid-GPIO path and the board never reached TWAI init. Config.h now guards PIN_LED and PIN_BUTTON with `#ifndef`, matching the existing pattern used for PIN_CAN_TX / PIN_CAN_RX.

Also adds a `[CFG] pins:` diagnostic line at boot so future pin-shadowing bugs are visible at a glance, and makes the startup banner board-aware (M5Stack / LilyGO / Waveshare S3).

Tested on Waveshare ESP32-S3-RS485-CAN (MAC 44:1b:f6:84:13:a4, 120Ω terminator jumpered): TWAI init succeeds, WiFi AP + web dashboard come up, device enters Listen-Only as expected.