### PR TITLE
Implement NVS persistence for user settings and WiFi credentials

### DIFF
--- a/esp32/.firmware/can_driver.cpp
+++ b/esp32/.firmware/can_driver.cpp
@@ -88,6 +88,12 @@ public:
         stop_and_uninstall();
         install_and_start(enable);
     }
+
+    void reset() override {
+        bool lo = listen_only_;
+        stop_and_uninstall();
+        install_and_start(lo);
+    }
 };
 
 CanDriver *can_driver_create() {
@@ -153,6 +159,15 @@ public:
         if (listen_only_ == enable) return;
         listen_only_ = enable;
         if (enable)
+            mcp_.setListenOnlyMode();
+        else
+            mcp_.setNormalMode();
+    }
+
+    void reset() override {
+        mcp_.reset();
+        mcp_.setBitrate(CAN_500KBPS, MCP_CRYSTAL_MHZ);
+        if (listen_only_)
             mcp_.setListenOnlyMode();
         else
             mcp_.setNormalMode();

--- a/esp32/.firmware/can_driver.h
+++ b/esp32/.firmware/can_driver.h
@@ -25,6 +25,10 @@ public:
      *  Implementations must reinitialise the hardware as needed. */
     virtual void setListenOnly(bool enable) = 0;
 
+    /** Force a full hardware reinitialisation (stop + start) in the current mode.
+     *  Use after prolonged CAN silence to clear error states. */
+    virtual void reset() = 0;
+
     virtual ~CanDriver() = default;
 };
 

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -2,10 +2,6 @@
 
 // ── CAN IDs ───────────────────────────────────────────────────────────────────
 #define CAN_ID_STW_ACTN_RQ    0x045u  // 69   - STW_ACTN_RQ:  steering stalk (Legacy follow distance)
-#define CAN_ID_TRIP_PLANNING  0x082u  // 130  - UI_tripPlanning: precondition trigger
-#define CAN_ID_BMS_HV_BUS     0x132u  // 306  - BMS_hvBusStatus: pack voltage / current
-#define CAN_ID_BMS_SOC        0x292u  // 658  - BMS_socStatus:   state of charge
-#define CAN_ID_BMS_THERMAL    0x312u  // 786  - BMS_thermalStatus: battery temp
 #define CAN_ID_GTW_CAR_STATE  0x318u  // 792  - GTW_carState:    OTA detection
 #define CAN_ID_EPAS_STATUS    0x370u  // 880  - EPAS3P_sysStatus: nag killer target
 #define CAN_ID_GTW_CAR_CONFIG 0x398u  // 920  - GTW_carConfig:   HW version detection
@@ -52,21 +48,30 @@
 
 // ── Timing ────────────────────────────────────────────────────────────────────
 #define WIRING_WARN_MS        5000u   // Red LED / serial warning if no CAN after this
-#define PRECOND_INTERVAL_MS    500u   // Re-inject 0x082 precondition every N ms
-#define BMS_PRINT_MS          1000u   // BMS serial print interval
 #define BUTTON_DEBOUNCE_MS      50u
 #define LONG_PRESS_MS         3000u   // Long press → toggle NAG killer
 #define DOUBLE_CLICK_MS        400u   // Max gap between two clicks for double-click
 #define STATUS_PRINT_MS       5000u   // Periodic status line when Active
 
 // OTA detection hardening on GTW_carState (0x318)
-// Some firmware versions keep non-zero states when no update is actively running.
-// We only treat one specific raw value as "update in progress" and require
-// consecutive-frame confirmation to avoid false positives.
-#define OTA_IN_PROGRESS_RAW_VALUE  1u
-#define OTA_ASSERT_FRAMES          3u
+// GTW_updateInProgress bits [1:0] of byte 6:
+//   0 = No update, 1 = Update available, 2 = Installing, 3 = Scheduled
+// Only value 2 (installing) should suspend TX.  Value 1 just means an update
+// is available but NOT actively being installed — ignore it.
+#define OTA_IN_PROGRESS_RAW_VALUE  2u
+#define OTA_ASSERT_FRAMES         10u
 #define OTA_CLEAR_FRAMES           6u
 
 #if defined(BOARD_LILYGO)
   #define ME2107_EN 16
 #endif
+
+// Car sleep / wake detection
+// When no CAN frames are received for this long, consider the car asleep.
+#define CAR_SLEEP_TIMEOUT_MS    3000u
+
+// HW version fallback detection hardening
+// Delay before accepting fallback-based HW detection (gives 0x398 time to arrive).
+#define HW_FALLBACK_DELAY_MS    3000u
+// Number of 0x399 frames required before committing to HW4 via fallback.
+#define HW_FALLBACK_CONFIRM        5u

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -10,6 +10,10 @@
 #define CAN_ID_FOLLOW_DIST    0x3F8u  // 1016 - DAS_followDistance: speed profile source
 #define CAN_ID_DAS_AP_CONFIG  0x331u  // 817  - DAS autopilot config (tier restore target, ~1 Hz)
 #define CAN_ID_AP_CONTROL     0x3FDu  // 1021 - DAS_autopilotControl: HW3 / HW4 core
+#define CAN_ID_GTW_CONFIG_ETH 0x7FFu  // 2047 - GTW_carConfig_ETH (BAN Shield target)
+#define CAN_ID_BMS_HV_BUS     0x132u  // 306  - BMS_hvBusStatus: pack voltage & current (read-only)
+#define CAN_ID_BMS_SOC        0x292u  // 658  - BMS_socStatus: state of charge (read-only)
+#define CAN_ID_BMS_THERMAL    0x312u  // 786  - BMS_thermalStatus: battery temps (read-only)
 
 // ── GPIO ──────────────────────────────────────────────────────────────────────
 #if defined(BOARD_LILYGO)

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -60,9 +60,9 @@
 // OTA detection hardening on GTW_carState (0x318)
 // GTW_updateInProgress bits [1:0] of byte 6:
 //   0 = No update, 1 = Update available, 2 = Installing, 3 = Scheduled
-// Only value 2 (installing) should suspend TX.  Value 1 just means an update
-// is available but NOT actively being installed — ignore it.
-#define OTA_IN_PROGRESS_RAW_VALUE  2u
+// Only value 1 (update available) should suspend TX to be conservative.
+// Value 2 is more permissive but requires vehicle validation.
+#define OTA_IN_PROGRESS_RAW_VALUE  1u
 #define OTA_ASSERT_FRAMES         10u
 #define OTA_CLEAR_FRAMES           6u
 

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -51,7 +51,6 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->suppress_speed_chime = true;
     state->emergency_vehicle_detect = false;
     state->force_fsd            = false;
-    state->bms_output           = false;
 
     // Default speed profile per HW version
     if (hw == TeslaHW_HW4)
@@ -67,6 +66,7 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
 bool fsd_can_transmit(const FSDState *state) {
     if (state->op_mode == OpMode_ListenOnly) return false;
     if (state->tesla_ota_in_progress)        return false;
+    if (state->car_asleep)                   return false;
     return true;
 }
 
@@ -313,45 +313,6 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
     state->nag_echo_count++;
     state->nag_suppressed = true;
     return true;
-}
-
-// ── BMS read-only parsers ─────────────────────────────────────────────────────
-
-void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame) {
-    if (frame->dlc < 4) return;
-    // Voltage: uint16 little-endian bytes 1:0, LSB = 0.01 V
-    uint16_t raw_v = ((uint16_t)frame->data[1] << 8) | frame->data[0];
-    // Current: int16 little-endian bytes 3:2, LSB = 0.1 A (signed)
-    int16_t  raw_i = (int16_t)(((uint16_t)frame->data[3] << 8) | frame->data[2]);
-    state->pack_voltage_v = raw_v * 0.01f;
-    state->pack_current_a = raw_i * 0.1f;
-    state->bms_seen = true;
-}
-
-void fsd_handle_bms_soc(FSDState *state, const CanFrame *frame) {
-    if (frame->dlc < 2) return;
-    // SoC: 10-bit little-endian (bits 9:0 across bytes 1:0), LSB = 0.1 %
-    uint16_t raw = ((uint16_t)(frame->data[1] & 0x03u) << 8) | frame->data[0];
-    state->soc_percent = raw * 0.1f;
-    state->bms_seen = true;
-}
-
-void fsd_handle_bms_thermal(FSDState *state, const CanFrame *frame) {
-    if (frame->dlc < 6) return;
-    // Temperatures: raw byte − 40 = °C
-    state->batt_temp_min_c = (int8_t)((int)frame->data[4] - 40);
-    state->batt_temp_max_c = (int8_t)((int)frame->data[5] - 40);
-    state->bms_seen = true;
-}
-
-// ── Precondition trigger ──────────────────────────────────────────────────────
-
-void fsd_build_precondition_frame(CanFrame *frame) {
-    memset(frame, 0, sizeof(CanFrame));
-    frame->id  = CAN_ID_TRIP_PLANNING;
-    frame->dlc = 8;
-    // byte0: bit0 = tripPlanningActive, bit2 = requestActiveBatteryHeating
-    frame->data[0] = 0x05u;
 }
 
 // ── TLSSC Restore (0x331) ─────────────────────────────────────────────────────

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -51,6 +51,9 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->suppress_speed_chime = true;
     state->emergency_vehicle_detect = false;
     state->force_fsd            = false;
+    state->fsd_inject_enabled   = true;
+    state->ban_shield           = true;
+    state->ban_shield_armed     = false;
 
     // Default speed profile per HW version
     if (hw == TeslaHW_HW4)
@@ -151,6 +154,9 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
     // mux 0 is the authoritative "is FSD requested" mux
     if (mux == 0) state->fsd_enabled = fsd_ui;
 
+    // If FSD injection is disabled, don't modify the frame
+    if (!state->fsd_inject_enabled) return false;
+
     if (state->hw_version == TeslaHW_HW3) {
         // ── HW3 ──────────────────────────────────────────────────────────────
         if (mux == 0 && state->fsd_enabled) {
@@ -206,7 +212,6 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
         }
     }
 
-    if (modified) state->frames_modified++;
     return modified;
 }
 
@@ -234,6 +239,9 @@ bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame) {
 
     if (mux == 0) state->fsd_enabled = fsd_ui;
 
+    // If FSD injection is disabled, don't modify the frame
+    if (!state->fsd_inject_enabled) return false;
+
     if (mux == 0 && state->fsd_enabled) {
         set_bit(frame, 46, true);
         // Speed profile in bits 2:1 of byte 6 (same encoding as HW3)
@@ -247,7 +255,6 @@ bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame) {
         modified = true;
     }
 
-    if (modified) state->frames_modified++;
     return modified;
 }
 
@@ -329,4 +336,82 @@ bool fsd_handle_tlssc_restore(FSDState *state, CanFrame *frame) {
     frame->data[0] = modified;
     state->tlssc_restore_count++;
     return true;
+}
+
+// ── 0x7FF BAN Shield (GTW_carConfig_ETH) ───────────────────────────────────
+
+bool fsd_handle_ban_shield(FSDState *state, CanFrame *frame) {
+    if (!state->ban_shield) return false;
+    if (frame->dlc < 8) return false;
+
+    uint8_t mux = frame->data[0] & 0x07u;
+
+    // Learning phase: capture healthy snapshot for each mux.
+    if (!state->ban_shield_armed) {
+        if (!state->ban_shield_snapshot_valid[mux]) {
+            for (int i = 0; i < 8; i++)
+                state->ban_shield_snapshot[mux][i] = frame->data[i];
+            state->ban_shield_snapshot_valid[mux] = true;
+        }
+
+        bool all_mux_seen = true;
+        for (int i = 0; i < 8; i++) {
+            if (!state->ban_shield_snapshot_valid[i]) {
+                all_mux_seen = false;
+                break;
+            }
+        }
+        if (all_mux_seen) state->ban_shield_armed = true;
+        return false;
+    }
+
+    // Armed phase: overwrite any changed frame with the learned snapshot.
+    if (!state->ban_shield_snapshot_valid[mux]) return false;
+
+    bool changed = false;
+    for (int i = 0; i < 8; i++) {
+        if (frame->data[i] != state->ban_shield_snapshot[mux][i]) {
+            changed = true;
+            break;
+        }
+    }
+    if (!changed) return false;
+
+    for (int i = 0; i < 8; i++)
+        frame->data[i] = state->ban_shield_snapshot[mux][i];
+
+    state->ban_shield_blocks++;
+    return true;
+}
+
+// ── BMS read-only parsers (only active when bms_enabled=true) ──────────────────
+
+void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame) {
+    if (!state->bms_enabled) return;
+    if (frame->dlc < 4) return;
+    // Voltage: uint16 little-endian bytes 1:0, LSB = 0.01 V
+    uint16_t raw_v = ((uint16_t)frame->data[1] << 8) | frame->data[0];
+    // Current: int16 little-endian bytes 3:2, LSB = 0.1 A (signed)
+    int16_t  raw_i = (int16_t)(((uint16_t)frame->data[3] << 8) | frame->data[2]);
+    state->pack_voltage_v = raw_v * 0.01f;
+    state->pack_current_a = raw_i * 0.1f;
+    state->bms_seen = true;
+}
+
+void fsd_handle_bms_soc(FSDState *state, const CanFrame *frame) {
+    if (!state->bms_enabled) return;
+    if (frame->dlc < 2) return;
+    // SoC: 10-bit little-endian (bits 9:0 across bytes 1:0), LSB = 0.1 %
+    uint16_t raw = ((uint16_t)(frame->data[1] & 0x03u) << 8) | frame->data[0];
+    state->soc_percent = raw * 0.1f;
+    state->bms_seen = true;
+}
+
+void fsd_handle_bms_thermal(FSDState *state, const CanFrame *frame) {
+    if (!state->bms_enabled) return;
+    if (frame->dlc < 6) return;
+    // Temperatures: raw byte − 40 = °C
+    state->batt_temp_min_c = (int8_t)((int)frame->data[4] - 40);
+    state->batt_temp_max_c = (int8_t)((int)frame->data[5] - 40);
+    state->bms_seen = true;
 }

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -54,25 +54,20 @@ struct FSDState {
     uint32_t       seen_gtw_car_state;      // 0x318 seen count
     uint32_t       seen_gtw_car_config;     // 0x398 seen count
     uint32_t       seen_ap_control;         // 0x3FD seen count
-    uint32_t       seen_bms_hv;             // 0x132 seen count
-    uint32_t       seen_bms_soc;            // 0x292 seen count
-    uint32_t       seen_bms_thermal;        // 0x312 seen count
-
-    // ── BMS read-only sniff ───────────────────────────────────────────────────
-    bool           bms_output;       // print BMS data to serial
-    bool           bms_seen;
-    float          pack_voltage_v;
-    float          pack_current_a;
-    float          soc_percent;
-    int8_t         batt_temp_min_c;
-    int8_t         batt_temp_max_c;
-
-    // ── Precondition trigger ──────────────────────────────────────────────────
-    bool           precondition;     // periodically inject 0x082
 
     // ── TLSSC Restore (0x331 DAS config spoof) ──────────────────────────────
     bool           tlssc_restore;
     uint32_t       tlssc_restore_count;
+
+    // ── Car sleep / wake detection ────────────────────────────────────────────
+    bool           car_asleep;              // true when no CAN traffic detected
+    bool           auto_activate_on_wake;   // switch to Active mode on car wake
+    uint32_t       last_rx_ms;              // timestamp of last received CAN frame
+    uint32_t       first_rx_ms;             // timestamp of first frame after boot/wake
+
+    // ── HW detection hardening ────────────────────────────────────────────────
+    bool           hw_from_authoritative;   // true if HW was detected via 0x398
+    uint8_t        hw_fallback_count_399;   // confirmation counter for ISA speed fallback
 };
 
 // ── API ───────────────────────────────────────────────────────────────────────
@@ -111,18 +106,6 @@ bool fsd_handle_isa_speed_chime(CanFrame *frame);
 /** Build an echo of EPAS3P_sysStatus (0x370) with counter+1 and handsOnLevel=1.
  *  Writes result into *out.  Returns true if echo should be sent. */
 bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out);
-
-/** Parse BMS_hvBusStatus (0x132) — updates pack_voltage_v / pack_current_a. */
-void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame);
-
-/** Parse BMS_socStatus (0x292) — updates soc_percent. */
-void fsd_handle_bms_soc(FSDState *state, const CanFrame *frame);
-
-/** Parse BMS_thermalStatus (0x312) — updates batt_temp_min/max_c. */
-void fsd_handle_bms_thermal(FSDState *state, const CanFrame *frame);
-
-/** Build a UI_tripPlanning (0x082) frame to trigger active battery heating. */
-void fsd_build_precondition_frame(CanFrame *frame);
 
 /** Handle CAN ID 0x331 — TLSSC Restore via DAS config spoof.
  *  Overwrites byte[0] lower 6 bits to 0x1B (SELF_DRIVING).

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -69,7 +69,6 @@ struct FSDState {
 
     // ── BMS read-only sniff (enabled when bms_enabled=true) ────────────────
     bool           bms_enabled;       // read/display BMS data when true
-    bool           bms_output;        // print BMS data to serial (debug)
     bool           bms_seen;
     float          pack_voltage_v;
     float          pack_current_a;
@@ -146,3 +145,9 @@ void fsd_handle_bms_soc(FSDState *state, const CanFrame *frame);
 
 /** Parse BMS_thermalStatus (0x312) — updates batt_temp_min/max_c. */
 void fsd_handle_bms_thermal(FSDState *state, const CanFrame *frame);
+
+// NOTE: fsd_build_precondition_frame() (0x082 UI_tripPlanning) is intentionally
+// absent from this ESP32 port.  0x082 is a Party CAN frame and is not present
+// on the Autopilot CAN bus that this device taps.  Sending it would have no
+// effect and would add unnecessary TX traffic.  The Flipper Zero implementation
+// retains it because the Flipper connects to a different bus topology.

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -31,7 +31,8 @@ struct FSDState {
     int            speed_profile;   // 0-4 depending on HW
     int            speed_offset;    // HW3 only, 0-100
 
-    bool           fsd_enabled;     // true when car's UI has FSD selected (mux0)
+    bool           fsd_enabled;         // true when car's UI has FSD selected (mux0)
+    bool           fsd_inject_enabled;  // master FSD injection switch (independent of force_fsd)
     bool           nag_suppressed;  // true after first nag-killer echo sent
 
     uint32_t       frames_modified; // TX counter
@@ -54,6 +55,27 @@ struct FSDState {
     uint32_t       seen_gtw_car_state;      // 0x318 seen count
     uint32_t       seen_gtw_car_config;     // 0x398 seen count
     uint32_t       seen_ap_control;         // 0x3FD seen count
+    uint32_t       seen_bms_hv;             // 0x132 seen count
+    uint32_t       seen_bms_soc;            // 0x292 seen count
+    uint32_t       seen_bms_thermal;        // 0x312 seen count
+    uint32_t       seen_gtw_config_eth;     // 0x7FF seen count
+
+    // ── BAN Shield (0x7FF GTW_carConfig_ETH) ───────────────────────────────
+    bool           ban_shield;              // master enable
+    bool           ban_shield_armed;        // true once all mux snapshots captured
+    uint8_t        ban_shield_snapshot[8][8];
+    bool           ban_shield_snapshot_valid[8];
+    uint32_t       ban_shield_blocks;       // number of frames overwritten
+
+    // ── BMS read-only sniff (enabled when bms_enabled=true) ────────────────
+    bool           bms_enabled;       // read/display BMS data when true
+    bool           bms_output;        // print BMS data to serial (debug)
+    bool           bms_seen;
+    float          pack_voltage_v;
+    float          pack_current_a;
+    float          soc_percent;
+    int8_t         batt_temp_min_c;
+    int8_t         batt_temp_max_c;
 
     // ── TLSSC Restore (0x331 DAS config spoof) ──────────────────────────────
     bool           tlssc_restore;
@@ -111,3 +133,16 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
  *  Overwrites byte[0] lower 6 bits to 0x1B (SELF_DRIVING).
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_tlssc_restore(FSDState *state, CanFrame *frame);
+
+/** 0x7FF BAN Shield: learn healthy mux snapshots, then block/overwrite changes.
+ *  Returns true if frame data was overwritten and should be re-sent immediately. */
+bool fsd_handle_ban_shield(FSDState *state, CanFrame *frame);
+
+/** Parse BMS_hvBusStatus (0x132) — updates pack_voltage_v / pack_current_a. */
+void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame);
+
+/** Parse BMS_socStatus (0x292) — updates soc_percent. */
+void fsd_handle_bms_soc(FSDState *state, const CanFrame *frame);
+
+/** Parse BMS_thermalStatus (0x312) — updates batt_temp_min/max_c. */
+void fsd_handle_bms_thermal(FSDState *state, const CanFrame *frame);

--- a/esp32/.firmware/led.cpp
+++ b/esp32/.firmware/led.cpp
@@ -19,6 +19,7 @@ void led_set(LedColor color) {
         case LED_GREEN:  c = g_strip.Color(  0, 255,   0); break;
         case LED_YELLOW: c = g_strip.Color(255, 200,   0); break;
         case LED_RED:    c = g_strip.Color(255,   0,   0); break;
+        case LED_PURPLE: c = g_strip.Color(128,   0, 255); break;
         default:         c = 0;                             break;
     }
     g_strip.setPixelColor(0, c);

--- a/esp32/.firmware/led.h
+++ b/esp32/.firmware/led.h
@@ -7,6 +7,7 @@ typedef enum {
     LED_GREEN,    // Active mode (FSD transmitting)
     LED_YELLOW,   // OTA detected (TX suspended)
     LED_RED,      // Error (no CAN traffic / wiring fault)
+    LED_PURPLE,   // Car asleep (no CAN traffic, TX suspended)
 } LedColor;
 
 void led_init();

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -8,10 +8,8 @@
  * Button:
  *   Single click  → toggle Listen-Only / Active
  *   Long press 3s → toggle NAG Killer on/off
- *   Double click  → toggle BMS serial output
  *
  * Serial 115200 baud.  Status prints every 5 s when Active.
- * BMS output (when enabled): voltage, current, power, SoC, temp every 1 s.
  */
 
 #include <Arduino.h>
@@ -22,6 +20,7 @@
 #include "wifi_manager.h"
 #include "web_dashboard.h"
 #include "can_dump.h"
+#include "nvs_settings.h"
 
 // ── Globals ───────────────────────────────────────────────────────────────────
 static CanDriver *g_can   = nullptr;
@@ -30,18 +29,22 @@ static FSDState   g_state = {};
 static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
     if (hw == TeslaHW_Unknown || g_state.hw_version == hw) return;
 
-    bool old_nag    = g_state.nag_killer;
-    bool old_chime  = g_state.suppress_speed_chime;
-    bool old_bms    = g_state.bms_output;
-    bool old_force  = g_state.force_fsd;
-    OpMode old_mode = g_state.op_mode;
+    bool old_nag       = g_state.nag_killer;
+    bool old_chime     = g_state.suppress_speed_chime;
+    bool old_force     = g_state.force_fsd;
+    bool old_emerg     = g_state.emergency_vehicle_detect;
+    bool old_tlssc     = g_state.tlssc_restore;
+    bool old_auto_wake = g_state.auto_activate_on_wake;
+    OpMode old_mode    = g_state.op_mode;
 
     fsd_state_init(&g_state, hw);
-    g_state.nag_killer           = old_nag;
-    g_state.suppress_speed_chime = old_chime;
-    g_state.bms_output           = old_bms;
-    g_state.force_fsd            = old_force;
-    g_state.op_mode              = old_mode;
+    g_state.nag_killer              = old_nag;
+    g_state.suppress_speed_chime    = old_chime;
+    g_state.force_fsd               = old_force;
+    g_state.emergency_vehicle_detect = old_emerg;
+    g_state.tlssc_restore           = old_tlssc;
+    g_state.auto_activate_on_wake   = old_auto_wake;
+    g_state.op_mode                 = old_mode;
 
     const char *hw_str =
         (hw == TeslaHW_HW4) ? "HW4" :
@@ -58,7 +61,7 @@ static int      g_pending_clicks  = 0;
 static bool     g_long_fired      = false;  // prevent double-fire on long press
 
 static void dispatch_clicks(int n) {
-    if (n == 1) {
+    if (n >= 1) {
         // Toggle Listen-Only ↔ Active
         if (g_state.op_mode == OpMode_ListenOnly) {
             g_state.op_mode = OpMode_Active;
@@ -71,10 +74,6 @@ static void dispatch_clicks(int n) {
             Serial.println("[BTN] → Listen-Only mode");
             can_dump_log("MODE switched to Listen-Only — TX disabled");
         }
-    } else if (n >= 2) {
-        // Toggle BMS serial output
-        g_state.bms_output = !g_state.bms_output;
-        Serial.printf("[BTN] BMS output: %s\n", g_state.bms_output ? "ON" : "OFF");
     }
 }
 
@@ -97,6 +96,7 @@ static void button_tick() {
             g_pending_clicks  = 0;  // cancel any pending click
             g_state.nag_killer = !g_state.nag_killer;
             Serial.printf("[BTN] NAG Killer: %s\n", g_state.nag_killer ? "ON" : "OFF");
+            nvs_settings_save(&g_state);
         }
     }
 
@@ -121,6 +121,8 @@ static void button_tick() {
 static void update_led() {
     if (g_state.rx_count == 0 && millis() > WIRING_WARN_MS) {
         led_set(LED_RED);
+    } else if (g_state.car_asleep) {
+        led_set(LED_PURPLE);
     } else if (g_state.tesla_ota_in_progress) {
         led_set(LED_YELLOW);
     } else if (g_state.op_mode == OpMode_Active) {
@@ -135,21 +137,35 @@ static void process_frame(const CanFrame &frame) {
     g_state.rx_count++;
     can_dump_record(frame);
 
+    // Track first frame timestamp for fallback HW detection delay
+    if (g_state.rx_count == 1)
+        g_state.first_rx_ms = millis();
+
     if (frame.id == CAN_ID_GTW_CAR_STATE)  g_state.seen_gtw_car_state++;
     if (frame.id == CAN_ID_GTW_CAR_CONFIG) g_state.seen_gtw_car_config++;
     if (frame.id == CAN_ID_AP_CONTROL)     g_state.seen_ap_control++;
-    if (frame.id == CAN_ID_BMS_HV_BUS)     g_state.seen_bms_hv++;
-    if (frame.id == CAN_ID_BMS_SOC)        g_state.seen_bms_soc++;
-    if (frame.id == CAN_ID_BMS_THERMAL)    g_state.seen_bms_thermal++;
 
     // DLC sanity: skip zero-length frames
     if (frame.dlc == 0) return;
 
     // ── HW auto-detect (passive, runs in both modes) ─────────────────────────
+    // 0x398 is the AUTHORITATIVE source — always overrides fallback detections.
     if (frame.id == CAN_ID_GTW_CAR_CONFIG) {
         TeslaHWVersion hw = fsd_detect_hw_version(&frame);
-        if (hw != TeslaHW_Unknown && g_state.hw_version == TeslaHW_Unknown)
-            apply_detected_hw(hw, "0x398");
+        if (hw != TeslaHW_Unknown) {
+            if (!g_state.hw_from_authoritative || g_state.hw_version != hw) {
+                if (!g_state.hw_from_authoritative && g_state.hw_version != TeslaHW_Unknown &&
+                    g_state.hw_version != hw) {
+                    const char *old_str =
+                        (g_state.hw_version == TeslaHW_HW4) ? "HW4" :
+                        (g_state.hw_version == TeslaHW_HW3) ? "HW3" : "Legacy";
+                    Serial.printf("[HW] Correcting fallback %s → 0x398 authoritative\n", old_str);
+                }
+                apply_detected_hw(hw, "0x398");
+                g_state.hw_from_authoritative = true;
+                g_state.hw_fallback_count_399 = 0;
+            }
+        }
         return;
     }
 
@@ -166,11 +182,6 @@ static void process_frame(const CanFrame &frame) {
         }
         return;
     }
-
-    // ── BMS sniff (read-only, always) ─────────────────────────────────────────
-    if (frame.id == CAN_ID_BMS_HV_BUS)  { fsd_handle_bms_hv(&g_state, &frame);      return; }
-    if (frame.id == CAN_ID_BMS_SOC)     { fsd_handle_bms_soc(&g_state, &frame);     return; }
-    if (frame.id == CAN_ID_BMS_THERMAL) { fsd_handle_bms_thermal(&g_state, &frame); return; }
 
     // ── Beyond here only run when TX is allowed ───────────────────────────────
     bool tx = fsd_can_transmit(&g_state);
@@ -205,14 +216,22 @@ static void process_frame(const CanFrame &frame) {
     }
 
     // Fallback HW detection when 0x398 is unavailable on the tapped bus.
-    if (g_state.hw_version == TeslaHW_Unknown) {
-        if (frame.id == CAN_ID_AP_LEGACY) {
-            apply_detected_hw(TeslaHW_Legacy, "fallback:0x3EE");
-        } else if (frame.id == CAN_ID_ISA_SPEED) {
-            apply_detected_hw(TeslaHW_HW4, "fallback:0x399");
-        } else if (frame.id == CAN_ID_AP_CONTROL) {
-            // 0x3FD exists on HW3/HW4. Prefer HW3 as safe default until 0x399 appears.
-            apply_detected_hw(TeslaHW_HW3, "fallback:0x3FD");
+    // Only runs when 0x398 hasn't provided an authoritative answer yet,
+    // and after a grace period to let 0x398 arrive first.
+    if (!g_state.hw_from_authoritative && g_state.hw_version == TeslaHW_Unknown) {
+        uint32_t age = millis() - g_state.first_rx_ms;
+        if (age >= HW_FALLBACK_DELAY_MS) {
+            if (frame.id == CAN_ID_AP_LEGACY) {
+                apply_detected_hw(TeslaHW_Legacy, "fallback:0x3EE");
+            } else if (frame.id == CAN_ID_ISA_SPEED) {
+                // Require multiple 0x399 frames to avoid false HW4 on HW3 vehicles
+                g_state.hw_fallback_count_399++;
+                if (g_state.hw_fallback_count_399 >= HW_FALLBACK_CONFIRM)
+                    apply_detected_hw(TeslaHW_HW4, "fallback:0x399");
+            } else if (frame.id == CAN_ID_AP_CONTROL) {
+                // 0x3FD exists on HW3/HW4. Prefer HW3 as safe default until 0x399 appears.
+                apply_detected_hw(TeslaHW_HW3, "fallback:0x3FD");
+            }
         }
     }
 
@@ -291,9 +310,14 @@ void setup() {
     g_state.op_mode               = OpMode_ListenOnly;
     g_state.nag_killer            = true;
     g_state.suppress_speed_chime  = true;
+    g_state.auto_activate_on_wake = false;
     g_state.emergency_vehicle_detect = false;
     g_state.force_fsd             = false;
-    g_state.bms_output            = false;
+    g_state.last_rx_ms            = millis();  // prevent false sleep on boot
+    g_state.first_rx_ms           = millis();
+
+    // Load persisted settings from NVS (overrides defaults above)
+    nvs_settings_load(&g_state);
 
     led_set(LED_BLUE);
 
@@ -313,9 +337,13 @@ void setup() {
     Serial.println("[CAN] 500 kbps — Listen-Only");
     Serial.println("[BTN] Single click : toggle Listen-Only / Active");
     Serial.println("[BTN] Long press 3s: toggle NAG Killer");
-    Serial.println("[BTN] Double click : toggle BMS serial output");
-    Serial.println("[LED] Blue=Listen  Green=Active  Yellow=OTA  Red=Error");
-
+    Serial.println("[LED] Blue=Listen  Green=Active  Yellow=OTA  Purple=Sleep  Red=Error");
+    // If auto-activate on wake is enabled, start directly in Active mode
+    if (g_state.auto_activate_on_wake) {
+        g_state.op_mode = OpMode_Active;
+        g_can->setListenOnly(false);
+        Serial.println("[BOOT] Auto-activate enabled \u2192 Active mode");
+    }
     // ── WiFi AP + Web dashboard (non-fatal if WiFi fails) ─────────────────────
     if (wifi_ap_init()) {
         web_dashboard_init(&g_state, g_can);
@@ -331,7 +359,35 @@ void loop() {
     // Drain all available CAN frames in one shot
     CanFrame frame;
     while (g_can->receive(frame)) {
+        // ── Wake-up detection: first frame after sleep ────────────────────────
+        if (g_state.car_asleep) {
+            g_state.car_asleep = false;
+            Serial.println("[WAKE] CAN traffic resumed — car is awake");
+            // Reinitialise CAN driver to clear any bus-off / error state
+            g_can->reset();
+            // Reset HW detection so 0x398 can re-identify correctly
+            g_state.hw_version            = TeslaHW_Unknown;
+            g_state.hw_from_authoritative = false;
+            g_state.hw_fallback_count_399 = 0;
+            g_state.fsd_enabled           = false;
+            g_state.nag_suppressed        = false;
+            g_state.first_rx_ms           = now;
+            // Auto-activate if enabled
+            if (g_state.auto_activate_on_wake && g_state.op_mode == OpMode_ListenOnly) {
+                g_state.op_mode = OpMode_Active;
+                g_can->setListenOnly(false);
+                Serial.println("[WAKE] Auto-activate → Active mode");
+            }
+        }
+        g_state.last_rx_ms = now;
         process_frame(frame);
+    }
+
+    // ── Car sleep detection ───────────────────────────────────────────────────
+    if (g_state.rx_count > 0 && !g_state.car_asleep &&
+        (now - g_state.last_rx_ms) >= CAR_SLEEP_TIMEOUT_MS) {
+        g_state.car_asleep = true;
+        Serial.println("[SLEEP] No CAN traffic — car is asleep, TX suspended");
     }
 
     // ── Periodic error counter refresh (~every 250 ms) ────────────────────────
@@ -339,31 +395,6 @@ void loop() {
     if ((now - last_err_ms) >= 250u) {
         g_state.crc_err_count = g_can->errorCount();
         last_err_ms = now;
-    }
-
-    // ── Precondition frame injection ──────────────────────────────────────────
-    static uint32_t last_precond_ms = 0;
-    if (g_state.precondition && fsd_can_transmit(&g_state) &&
-        (now - last_precond_ms) >= PRECOND_INTERVAL_MS) {
-        CanFrame pf;
-        fsd_build_precondition_frame(&pf);
-        g_can->send(pf);
-        last_precond_ms = now;
-    }
-
-    // ── BMS serial output ─────────────────────────────────────────────────────
-    static uint32_t last_bms_ms = 0;
-    if (g_state.bms_output && g_state.bms_seen &&
-        (now - last_bms_ms) >= BMS_PRINT_MS) {
-        float kw = g_state.pack_voltage_v * g_state.pack_current_a / 1000.0f;
-        Serial.printf("[BMS] %.1fV  %.1fA  %.2fkW  SoC:%.1f%%  Temp:%d~%d°C\n",
-            g_state.pack_voltage_v,
-            g_state.pack_current_a,
-            kw,
-            g_state.soc_percent,
-            (int)g_state.batt_temp_min_c,
-            (int)g_state.batt_temp_max_c);
-        last_bms_ms = now;
     }
 
     // ── Active-mode status line ───────────────────────────────────────────────
@@ -375,12 +406,13 @@ void loop() {
             (g_state.hw_version == TeslaHW_HW3)    ? "HW3"    :
             (g_state.hw_version == TeslaHW_Legacy)  ? "Legacy" : "?";
         Serial.printf(
-            "[STA] HW:%-6s FSD:%-4s NAG:%-10s OTA:%-3s "
+            "[STA] HW:%-6s FSD:%-4s NAG:%-10s OTA:%-3s Sleep:%-3s "
             "Profile:%d  RX:%lu TX:%lu Err:%lu\n",
             hw_str,
             g_state.fsd_enabled     ? "ON"         : "wait",
             g_state.nag_suppressed  ? "suppressed"  : "active",
             g_state.tesla_ota_in_progress ? "YES"  : "no",
+            g_state.car_asleep            ? "YES"  : "no",
             g_state.speed_profile,
             (unsigned long)g_state.rx_count,
             (unsigned long)g_state.frames_modified,

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -29,22 +29,26 @@ static FSDState   g_state = {};
 static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
     if (hw == TeslaHW_Unknown || g_state.hw_version == hw) return;
 
-    bool old_nag       = g_state.nag_killer;
-    bool old_chime     = g_state.suppress_speed_chime;
-    bool old_force     = g_state.force_fsd;
-    bool old_emerg     = g_state.emergency_vehicle_detect;
-    bool old_tlssc     = g_state.tlssc_restore;
-    bool old_auto_wake = g_state.auto_activate_on_wake;
-    OpMode old_mode    = g_state.op_mode;
+    bool old_nag        = g_state.nag_killer;
+    bool old_chime      = g_state.suppress_speed_chime;
+    bool old_force      = g_state.force_fsd;
+    bool old_emerg      = g_state.emergency_vehicle_detect;
+    bool old_tlssc      = g_state.tlssc_restore;
+    bool old_auto_wake  = g_state.auto_activate_on_wake;
+    bool old_fsd_inject = g_state.fsd_inject_enabled;
+    bool old_ban_shield = g_state.ban_shield;
+    OpMode old_mode     = g_state.op_mode;
 
     fsd_state_init(&g_state, hw);
-    g_state.nag_killer              = old_nag;
-    g_state.suppress_speed_chime    = old_chime;
-    g_state.force_fsd               = old_force;
+    g_state.nag_killer               = old_nag;
+    g_state.suppress_speed_chime     = old_chime;
+    g_state.force_fsd                = old_force;
     g_state.emergency_vehicle_detect = old_emerg;
-    g_state.tlssc_restore           = old_tlssc;
-    g_state.auto_activate_on_wake   = old_auto_wake;
-    g_state.op_mode                 = old_mode;
+    g_state.tlssc_restore            = old_tlssc;
+    g_state.auto_activate_on_wake    = old_auto_wake;
+    g_state.fsd_inject_enabled       = old_fsd_inject;
+    g_state.ban_shield               = old_ban_shield;
+    g_state.op_mode                  = old_mode;
 
     const char *hw_str =
         (hw == TeslaHW_HW4) ? "HW4" :
@@ -144,6 +148,10 @@ static void process_frame(const CanFrame &frame) {
     if (frame.id == CAN_ID_GTW_CAR_STATE)  g_state.seen_gtw_car_state++;
     if (frame.id == CAN_ID_GTW_CAR_CONFIG) g_state.seen_gtw_car_config++;
     if (frame.id == CAN_ID_AP_CONTROL)     g_state.seen_ap_control++;
+    if (frame.id == CAN_ID_BMS_HV_BUS)     g_state.seen_bms_hv++;
+    if (frame.id == CAN_ID_BMS_SOC)        g_state.seen_bms_soc++;
+    if (frame.id == CAN_ID_BMS_THERMAL)    g_state.seen_bms_thermal++;
+    if (frame.id == CAN_ID_GTW_CONFIG_ETH) g_state.seen_gtw_config_eth++;
 
     // DLC sanity: skip zero-length frames
     if (frame.dlc == 0) return;
@@ -183,6 +191,22 @@ static void process_frame(const CanFrame &frame) {
         return;
     }
 
+    // ── BMS sniff (read-only, active when bms_enabled=true) ────────────────────
+    if (frame.id == CAN_ID_BMS_HV_BUS)  { fsd_handle_bms_hv(&g_state, &frame);      return; }
+    if (frame.id == CAN_ID_BMS_SOC)     { fsd_handle_bms_soc(&g_state, &frame);     return; }
+    if (frame.id == CAN_ID_BMS_THERMAL) { fsd_handle_bms_thermal(&g_state, &frame); return; }
+
+    // ── BAN Shield (0x7FF): always learn snapshots; retransmit corrected frames in TX mode ──
+    if (frame.id == CAN_ID_GTW_CONFIG_ETH) {
+        CanFrame f = frame;
+        bool modified = fsd_handle_ban_shield(&g_state, &f);
+        if (modified && fsd_can_transmit(&g_state)) {
+            g_can->send(f);
+            can_dump_log("BAN 0x7FF mux=%u corrected and retransmitted", (unsigned)(f.data[0] & 0x07u));
+        }
+        return;
+    }
+
     // ── Beyond here only run when TX is allowed ───────────────────────────────
     bool tx = fsd_can_transmit(&g_state);
 
@@ -210,8 +234,10 @@ static void process_frame(const CanFrame &frame) {
     // Legacy autopilot control (0x3EE)
     if (frame.id == CAN_ID_AP_LEGACY && g_state.hw_version == TeslaHW_Legacy) {
         CanFrame f = frame;
-        if (fsd_handle_legacy_autopilot(&g_state, &f) && tx)
+        if (fsd_handle_legacy_autopilot(&g_state, &f) && tx) {
             g_can->send(f);
+            g_state.frames_modified++;
+        }
         return;
     }
 
@@ -262,8 +288,10 @@ static void process_frame(const CanFrame &frame) {
     // HW3/HW4 autopilot control (0x3FD) — main FSD activation frame
     if (frame.id == CAN_ID_AP_CONTROL) {
         CanFrame f = frame;
-        if (fsd_handle_autopilot_frame(&g_state, &f) && tx)
+        if (fsd_handle_autopilot_frame(&g_state, &f) && tx) {
             g_can->send(f);
+            g_state.frames_modified++;
+        }
         return;
     }
 }

--- a/esp32/.firmware/nvs_settings.cpp
+++ b/esp32/.firmware/nvs_settings.cpp
@@ -1,0 +1,56 @@
+/*
+ * nvs_settings.cpp — Persist user toggle settings in ESP32 NVS (flash).
+ *
+ * Uses the Arduino Preferences library (wrapper around ESP-IDF NVS).
+ * Namespace: "fsd" — keys are short (max 15 chars for NVS).
+ *
+ * Only boolean toggles that the user sets via the web dashboard are stored.
+ * Operational state (op_mode, counters, HW version…) is NOT persisted.
+ */
+
+#include "nvs_settings.h"
+#include <Preferences.h>
+#include <Arduino.h>
+
+static const char *NVS_NS = "fsd";
+
+void nvs_settings_load(FSDState *state) {
+    Preferences prefs;
+    // Always open in readWrite mode — readOnly fails if namespace doesn't exist yet
+    // and can keep failing on some ESP32 Arduino core versions.
+    if (!prefs.begin(NVS_NS, false /* readWrite */)) {
+        Serial.println("[NVS] FATAL: cannot open NVS namespace");
+        return;
+    }
+
+    state->nag_killer               = prefs.getBool("nag",       state->nag_killer);
+    state->suppress_speed_chime     = prefs.getBool("chime",     state->suppress_speed_chime);
+    state->force_fsd                = prefs.getBool("force_fsd", state->force_fsd);
+    state->tlssc_restore            = prefs.getBool("tlssc",     state->tlssc_restore);
+    state->auto_activate_on_wake    = prefs.getBool("auto_wake", state->auto_activate_on_wake);
+    state->emergency_vehicle_detect = prefs.getBool("emerg_veh", state->emergency_vehicle_detect);
+
+    prefs.end();
+
+    Serial.printf("[NVS] Loaded: nag=%d chime=%d force=%d tlssc=%d auto_wake=%d emerg=%d\n",
+        state->nag_killer, state->suppress_speed_chime, state->force_fsd,
+        state->tlssc_restore, state->auto_activate_on_wake,
+        state->emergency_vehicle_detect);
+}
+
+void nvs_settings_save(const FSDState *state) {
+    Preferences prefs;
+    if (!prefs.begin(NVS_NS, false /* readWrite */)) {
+        Serial.println("[NVS] Save failed — cannot open namespace");
+        return;
+    }
+
+    prefs.putBool("nag",       state->nag_killer);
+    prefs.putBool("chime",     state->suppress_speed_chime);
+    prefs.putBool("force_fsd", state->force_fsd);
+    prefs.putBool("tlssc",     state->tlssc_restore);
+    prefs.putBool("auto_wake", state->auto_activate_on_wake);
+    prefs.putBool("emerg_veh", state->emergency_vehicle_detect);
+
+    prefs.end();
+}

--- a/esp32/.firmware/nvs_settings.cpp
+++ b/esp32/.firmware/nvs_settings.cpp
@@ -23,12 +23,14 @@ void nvs_settings_load(FSDState *state) {
         return;
     }
 
-    state->nag_killer               = prefs.getBool("nag",       state->nag_killer);
-    state->suppress_speed_chime     = prefs.getBool("chime",     state->suppress_speed_chime);
-    state->force_fsd                = prefs.getBool("force_fsd", state->force_fsd);
-    state->tlssc_restore            = prefs.getBool("tlssc",     state->tlssc_restore);
-    state->auto_activate_on_wake    = prefs.getBool("auto_wake", state->auto_activate_on_wake);
-    state->emergency_vehicle_detect = prefs.getBool("emerg_veh", state->emergency_vehicle_detect);
+    state->nag_killer               = prefs.getBool("nag",        state->nag_killer);
+    state->suppress_speed_chime     = prefs.getBool("chime",      state->suppress_speed_chime);
+    state->force_fsd                = prefs.getBool("force_fsd",  state->force_fsd);
+    state->fsd_inject_enabled       = prefs.getBool("fsd_inject", state->fsd_inject_enabled);
+    state->tlssc_restore            = prefs.getBool("tlssc",      state->tlssc_restore);
+    state->auto_activate_on_wake    = prefs.getBool("auto_wake",  state->auto_activate_on_wake);
+    state->emergency_vehicle_detect = prefs.getBool("emerg_veh",  state->emergency_vehicle_detect);
+    state->ban_shield               = prefs.getBool("ban_shield", state->ban_shield);
 
     prefs.end();
 
@@ -45,12 +47,36 @@ void nvs_settings_save(const FSDState *state) {
         return;
     }
 
-    prefs.putBool("nag",       state->nag_killer);
-    prefs.putBool("chime",     state->suppress_speed_chime);
-    prefs.putBool("force_fsd", state->force_fsd);
-    prefs.putBool("tlssc",     state->tlssc_restore);
-    prefs.putBool("auto_wake", state->auto_activate_on_wake);
-    prefs.putBool("emerg_veh", state->emergency_vehicle_detect);
+    prefs.putBool("nag",        state->nag_killer);
+    prefs.putBool("chime",      state->suppress_speed_chime);
+    prefs.putBool("force_fsd",  state->force_fsd);
+    prefs.putBool("fsd_inject", state->fsd_inject_enabled);
+    prefs.putBool("tlssc",      state->tlssc_restore);
+    prefs.putBool("auto_wake",  state->auto_activate_on_wake);
+    prefs.putBool("emerg_veh",  state->emergency_vehicle_detect);
+    prefs.putBool("ban_shield", state->ban_shield);
 
     prefs.end();
+}
+
+void nvs_wifi_load(char *ssid, size_t ssid_len, char *pass, size_t pass_len) {
+    Preferences prefs;
+    if (!prefs.begin(NVS_NS, false)) return;
+    // getString returns 0 and leaves buffer unchanged when key is absent
+    prefs.getString("wifi_ssid", ssid, (unsigned)ssid_len);
+    prefs.getString("wifi_pass", pass, (unsigned)pass_len);
+    prefs.end();
+    Serial.printf("[NVS] WiFi: SSID=%s\n", ssid);
+}
+
+void nvs_wifi_save(const char *ssid, const char *pass) {
+    Preferences prefs;
+    if (!prefs.begin(NVS_NS, false)) {
+        Serial.println("[NVS] WiFi save failed — cannot open namespace");
+        return;
+    }
+    prefs.putString("wifi_ssid", ssid);
+    prefs.putString("wifi_pass", pass);
+    prefs.end();
+    Serial.printf("[NVS] WiFi saved: SSID=%s\n", ssid);
 }

--- a/esp32/.firmware/nvs_settings.cpp
+++ b/esp32/.firmware/nvs_settings.cpp
@@ -31,6 +31,7 @@ void nvs_settings_load(FSDState *state) {
     state->auto_activate_on_wake    = prefs.getBool("auto_wake",  state->auto_activate_on_wake);
     state->emergency_vehicle_detect = prefs.getBool("emerg_veh",  state->emergency_vehicle_detect);
     state->ban_shield               = prefs.getBool("ban_shield", state->ban_shield);
+    state->bms_enabled              = prefs.getBool("bms_enable", state->bms_enabled);
 
     prefs.end();
 
@@ -55,6 +56,7 @@ void nvs_settings_save(const FSDState *state) {
     prefs.putBool("auto_wake",  state->auto_activate_on_wake);
     prefs.putBool("emerg_veh",  state->emergency_vehicle_detect);
     prefs.putBool("ban_shield", state->ban_shield);
+    prefs.putBool("bms_enable", state->bms_enabled);
 
     prefs.end();
 }

--- a/esp32/.firmware/nvs_settings.h
+++ b/esp32/.firmware/nvs_settings.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "fsd_handler.h"
+
+/** Load persisted toggle settings from NVS into state.
+ *  Missing keys use the current state values as defaults. */
+void nvs_settings_load(FSDState *state);
+
+/** Save all toggle settings from state to NVS. */
+void nvs_settings_save(const FSDState *state);

--- a/esp32/.firmware/nvs_settings.h
+++ b/esp32/.firmware/nvs_settings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fsd_handler.h"
+#include <stddef.h>
 
 /** Load persisted toggle settings from NVS into state.
  *  Missing keys use the current state values as defaults. */
@@ -8,3 +9,13 @@ void nvs_settings_load(FSDState *state);
 
 /** Save all toggle settings from state to NVS. */
 void nvs_settings_save(const FSDState *state);
+
+/**
+ * Load WiFi AP credentials from NVS.
+ * Buffers must be pre-filled with defaults — unchanged if key absent.
+ * ssid: max 33 bytes (32 + NUL), pass: max 64 bytes (63 + NUL).
+ */
+void nvs_wifi_load(char *ssid, size_t ssid_len, char *pass, size_t pass_len);
+
+/** Save WiFi AP credentials to NVS. */
+void nvs_wifi_save(const char *ssid, const char *pass);

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -13,6 +13,7 @@
 
 #include "web_dashboard.h"
 #include "can_dump.h"
+#include "nvs_settings.h"
 #include <WebServer.h>
 #include <WebSocketsServer.h>
 #include <WiFi.h>
@@ -35,6 +36,7 @@ static float    g_fps         = 0.0f;
 
 // ── Embedded HTML/CSS/JS ──────────────────────────────────────────────────────
 // Tesla dark theme; mobile-first (max 480 px); WebSocket on :81
+// Tabbed interface: Dashboard, Controls, CAN Bus, Device
 static const char WEB_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
 <html lang="en">
@@ -55,76 +57,74 @@ static const char WEB_HTML[] PROGMEM = R"rawliteral(
   --border:#1e293b;--text:#e2e8f0;--text2:#94a3b8;--text3:#475569
 }
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  background:var(--bg);color:var(--text);min-height:100vh}
-.wrap{max-width:480px;margin:0 auto;padding:16px 16px 40px}
+  background:var(--bg);color:var(--text);min-height:100vh;
+  -webkit-tap-highlight-color:transparent}
+.wrap{max-width:480px;margin:0 auto;padding:12px 16px 32px}
 
 /* ── Header ── */
-.hdr{text-align:center;padding:20px 0 12px;position:relative}
-.hdr h1{font-size:1.65em;font-weight:700;
+.hdr{text-align:center;padding:16px 0 8px;position:relative}
+.hdr h1{font-size:1.5em;font-weight:700;
   background:linear-gradient(135deg,var(--accent),var(--blue));
   -webkit-background-clip:text;-webkit-text-fill-color:transparent;
   letter-spacing:-.02em}
-.hdr .sub{font-size:.68em;color:var(--text3);margin-top:3px;
+.hdr .sub{font-size:.65em;color:var(--text3);margin-top:2px;
   letter-spacing:.1em;text-transform:uppercase}
-.cdot{position:absolute;right:0;top:26px;width:10px;height:10px;
+.cdot{position:absolute;right:0;top:22px;width:10px;height:10px;
   border-radius:50%;background:var(--accent);
   box-shadow:0 0 10px var(--accent);transition:.4s}
 .cdot.off{background:var(--red);box-shadow:0 0 10px var(--red)}
 
-/* ── OTA Warning ── */
+/* ── Banners ── */
 .ota{display:none;background:rgba(255,107,107,.1);border:1px solid rgba(255,107,107,.4);
-  border-radius:12px;padding:12px 16px;margin-bottom:12px;text-align:center;
-  color:var(--red);font-weight:700;font-size:.9em;letter-spacing:.04em;
+  border-radius:12px;padding:10px 14px;margin-bottom:10px;text-align:center;
+  color:var(--red);font-weight:700;font-size:.85em;letter-spacing:.04em;
   animation:pulse 1s ease-in-out infinite}
+.sleep-ban{display:none;background:rgba(148,93,255,.1);border:1px solid rgba(148,93,255,.4);
+  border-radius:12px;padding:10px 14px;margin-bottom:10px;text-align:center;
+  color:#b87aff;font-weight:700;font-size:.85em;letter-spacing:.04em}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.55}}
-
-/* ── Error banner ── */
 .err{display:none;color:var(--red);text-align:center;font-size:.78em;padding:8px;
-  background:rgba(255,107,107,.07);border-radius:10px;margin-bottom:10px;
+  background:rgba(255,107,107,.07);border-radius:10px;margin-bottom:8px;
   border:1px solid rgba(255,107,107,.18)}
 
+/* ── Tabs ── */
+.tabs{display:flex;gap:4px;margin-bottom:12px;
+  background:var(--card);border-radius:12px;padding:4px;border:1px solid var(--border)}
+.tab{flex:1;text-align:center;padding:10px 4px;border-radius:8px;
+  font-size:.72em;font-weight:600;color:var(--text3);cursor:pointer;
+  transition:all .2s;text-transform:uppercase;letter-spacing:.06em;
+  user-select:none;-webkit-user-select:none}
+.tab.active{background:rgba(0,212,170,.12);color:var(--accent)}
+.tab:active{opacity:.7}
+.pane{display:none}.pane.active{display:block}
+
 /* ── Cards ── */
-.card{background:var(--card);border-radius:16px;padding:16px;
-  margin-bottom:12px;border:1px solid var(--border)}
-.card-head{display:flex;align-items:center;gap:8px;margin-bottom:12px}
-.icon{width:28px;height:28px;border-radius:8px;display:flex;
-  align-items:center;justify-content:center;font-size:.85em;font-weight:700}
+.card{background:var(--card);border-radius:16px;padding:14px;
+  margin-bottom:10px;border:1px solid var(--border)}
+.card-head{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.icon{width:26px;height:26px;border-radius:8px;display:flex;
+  align-items:center;justify-content:center;font-size:.8em;font-weight:700}
 .ic-s{background:rgba(0,212,170,.14);color:var(--accent)}
 .ic-b{background:rgba(77,171,247,.14);color:var(--blue)}
 .ic-c{background:rgba(255,217,61,.14);color:var(--yellow)}
 .ic-d{background:rgba(148,163,184,.14);color:var(--text2)}
-.card-head h2{font-size:.78em;font-weight:600;color:var(--text2);
+.ic-p{background:rgba(184,122,255,.14);color:#b87aff}
+.card-head h2{font-size:.75em;font-weight:600;color:var(--text2);
   text-transform:uppercase;letter-spacing:.07em}
 
 /* ── Rows ── */
-.row{display:flex;justify-content:space-between;align-items:center;padding:9px 0}
+.row{display:flex;justify-content:space-between;align-items:center;padding:8px 0}
 .row+.row{border-top:1px solid rgba(255,255,255,.04)}
-.lbl{color:var(--text2);font-size:.85em}
+.lbl{color:var(--text2);font-size:.82em}
 
 /* ── Pills ── */
 .pill{display:inline-flex;align-items:center;gap:5px;
-  padding:3px 10px;border-radius:20px;font-size:.8em;font-weight:600}
+  padding:3px 10px;border-radius:20px;font-size:.78em;font-weight:600}
 .pill.on{background:rgba(0,212,170,.14);color:var(--accent)}
 .pill.off{background:rgba(71,85,105,.22);color:var(--text3)}
 .pill.warn{background:rgba(255,107,107,.14);color:var(--red)}
 .pd{width:6px;height:6px;border-radius:50%;flex-shrink:0;
   background:currentColor;box-shadow:0 0 5px currentColor}
-
-/* ── Battery Hero ── */
-.hero{text-align:center;padding-bottom:4px}
-.soc-ring{width:120px;height:120px;margin:0 auto 14px;position:relative}
-.soc-ring svg{transform:rotate(-90deg)}
-.trk{fill:none;stroke:#1e293b;stroke-width:8}
-.bar{fill:none;stroke:var(--accent);stroke-width:8;stroke-linecap:round;
-  transition:stroke-dashoffset .8s ease,stroke .5s}
-.soc-val{position:absolute;inset:0;display:flex;flex-direction:column;
-  align-items:center;justify-content:center}
-.soc-num{font-size:2em;font-weight:700;line-height:1;
-  font-variant-numeric:tabular-nums}
-.soc-lbl{font-size:.6em;color:var(--text3);margin-top:3px;text-transform:uppercase}
-.hg{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;text-align:center}
-.hg .hv{font-size:1.1em;font-weight:600;font-variant-numeric:tabular-nums}
-.hg .hl{font-size:.65em;color:var(--text3);margin-top:2px}
 
 /* ── CAN stat grid ── */
 .sg{display:grid;grid-template-columns:repeat(2,1fr);gap:8px}
@@ -148,9 +148,11 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   left:3px;bottom:3px;background:#555;border-radius:50%;transition:.3s}
 input:checked+.sl2{background:var(--accent)}
 input:checked+.sl2:before{transform:translateX(20px);background:#fff}
+.sep{font-size:.68em;color:var(--text3);text-transform:uppercase;letter-spacing:.08em;
+  padding:10px 0 4px;border-bottom:1px solid rgba(255,255,255,.06);margin-bottom:2px}
 
 /* ── Footer ── */
-.foot{text-align:center;padding:16px 0 0;font-size:.64em;color:var(--text3)}
+.foot{text-align:center;padding:12px 0 0;font-size:.6em;color:var(--text3)}
 </style>
 </head>
 <body>
@@ -159,100 +161,110 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 <!-- Header -->
 <div class="hdr">
   <h1>Tesla FSD</h1>
-  <div class="sub">ESP32 CAN Controller &middot; 192.168.4.1</div>
+  <div class="sub">ESP32 CAN Controller</div>
   <div class="cdot" id="dot"></div>
 </div>
 <div id="connErr" class="err">Connection lost &mdash; retrying&hellip;</div>
+<div id="otaBanner" class="ota">&#9888;&#xFE0F; OTA IN PROGRESS &mdash; TX SUSPENDED</div>
+<div id="sleepBanner" class="sleep-ban">&#x1F4A4; CAR ASLEEP &mdash; TX SUSPENDED</div>
 
-<!-- OTA Warning -->
-<div id="otaBanner" class="ota">&#9888;&#xFE0F; OTA UPDATE IN PROGRESS &mdash; CAN TX SUSPENDED</div>
-
-<!-- FSD Status -->
-<div class="card">
-  <div class="card-head"><div class="icon ic-s">S</div><h2>FSD Status</h2></div>
-  <div class="row">
-    <span class="lbl">FSD Active</span>
-    <span class="pill off" id="fsdSt"><span class="pd"></span>--</span>
-  </div>
-  <div class="row">
-    <span class="lbl">Mode</span>
-    <span class="pill off" id="opMode"><span class="pd"></span>--</span>
-  </div>
-  <div class="row">
-    <span class="lbl">Hardware</span>
-    <span class="pill off" id="hwVer"><span class="pd"></span>--</span>
-  </div>
-  <div class="row">
-    <span class="lbl">NAG Killer</span>
-    <span class="pill off" id="nagSt"><span class="pd"></span>--</span>
-  </div>
-  <div class="row">
-    <span class="lbl">CAN Vehicle</span>
-    <span class="pill off" id="canVeh"><span class="pd"></span>--</span>
-  </div>
+<!-- Tabs -->
+<div class="tabs">
+  <div class="tab active" onclick="showTab(0)">Dashboard</div>
+  <div class="tab" onclick="showTab(1)">Controls</div>
+  <div class="tab" onclick="showTab(2)">CAN Bus</div>
+  <div class="tab" onclick="showTab(3)">Device</div>
 </div>
 
-<!-- Battery -->
-<div class="card">
-  <div class="card-head"><div class="icon ic-b">B</div><h2>Battery</h2></div>
-  <div class="row">
-    <span class="lbl">BMS Status</span>
-    <span class="pill off" id="bmsSt"><span class="pd"></span>Waiting Frames</span>
-  </div>
-  <div class="row">
-    <span class="lbl">BMS Frames</span>
-    <span id="bmsFrames" style="font-size:.8em;color:var(--text2)">HV:0 SOC:0 TH:0</span>
-  </div>
-  <div class="hero">
-    <div class="soc-ring">
-      <svg viewBox="0 0 120 120" width="120" height="120">
-        <circle class="trk" cx="60" cy="60" r="52"/>
-        <circle class="bar" id="socBar" cx="60" cy="60" r="52"
-          stroke-dasharray="326.73" stroke-dashoffset="326.73"/>
-      </svg>
-      <div class="soc-val">
-        <span class="soc-num" id="bSoc">--</span>
-        <span class="soc-lbl">SOC</span>
-      </div>
+<!-- ═══ TAB 0: Dashboard ═══ -->
+<div class="pane active" id="p0">
+
+  <!-- Status -->
+  <div class="card">
+    <div class="card-head"><div class="icon ic-s">S</div><h2>Status</h2></div>
+    <div class="row">
+      <span class="lbl">FSD</span>
+      <span class="pill off" id="fsdSt"><span class="pd"></span>--</span>
     </div>
-    <div class="hg">
-      <div><div class="hv" id="bVolt">--</div><div class="hl">Voltage</div></div>
-      <div><div class="hv" id="bCurr">--</div><div class="hl">Current</div></div>
-      <div><div class="hv" id="bTemp">--</div><div class="hl">Temp</div></div>
+    <div class="row">
+      <span class="lbl">Mode</span>
+      <span class="pill off" id="opMode"><span class="pd"></span>--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Hardware</span>
+      <span class="pill off" id="hwVer"><span class="pd"></span>--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Vehicle</span>
+      <span class="pill off" id="canVeh"><span class="pd"></span>--</span>
     </div>
   </div>
+
 </div>
 
-<!-- CAN Stats -->
-<div class="card">
-  <div class="card-head"><div class="icon ic-d">C</div><h2>CAN Bus</h2></div>
-  <div class="sg">
-    <div class="sb"><div class="sv" id="rxCnt">0</div><div class="sl">RX Frames</div></div>
-    <div class="sb"><div class="sv" id="txCnt">0</div><div class="sl">TX Modified</div></div>
-    <div class="sb"><div class="sv" id="crcErr">0</div><div class="sl">CRC Errors</div></div>
-    <div class="sb"><div class="sv" id="fps">0.0</div><div class="sl">Frames/s</div></div>
+<!-- ═══ TAB 1: Controls ═══ -->
+<div class="pane" id="p1">
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-c">C</div><h2>Mode</h2></div>
+    <button id="btnMode" class="btn-main btn-act" onclick="toggleMode()">ACTIVATE FSD</button>
   </div>
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-s">&#9881;</div><h2>Features</h2></div>
+    <div class="row">
+      <span class="lbl">NAG Killer</span>
+      <label class="sw"><input type="checkbox" id="swNag" onchange="cmd('nag',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
+      <span class="lbl">Force FSD</span>
+      <label class="sw"><input type="checkbox" id="swFsd" onchange="cmd('force_fsd',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
+      <span class="lbl">TLSSC Restore</span>
+      <label class="sw"><input type="checkbox" id="swTlssc" onchange="cmd('tlssc_restore',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
+      <span class="lbl">Speed Chime Suppress (HW4 only)</span>
+      <label class="sw"><input type="checkbox" id="swChime" onchange="cmd('chime',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
+      <span class="lbl">Emergency Vehicle Detect (HW4 only)</span>
+      <label class="sw"><input type="checkbox" id="swEmerg" onchange="cmd('emerg_veh',this.checked)"><span class="sl2"></span></label>
+    </div>
+
+    <div class="sep">Settings</div>
+    <div class="row">
+      <span class="lbl">Auto-Activate on Wake</span>
+      <label class="sw"><input type="checkbox" id="swAutoWake" onchange="cmd('auto_wake',this.checked)"><span class="sl2"></span></label>
+    </div>
+  </div>
+
 </div>
 
-<!-- Controls -->
-<div class="card">
-  <div class="card-head"><div class="icon ic-c">C</div><h2>Controls</h2></div>
-  <button id="btnMode" class="btn-main btn-act" onclick="toggleMode()">ACTIVATE FSD</button>
-  <div class="row">
-    <span class="lbl">NAG Killer</span>
-    <label class="sw"><input type="checkbox" id="swNag" onchange="cmd('nag',this.checked)"><span class="sl2"></span></label>
+<!-- ═══ TAB 2: CAN Bus ═══ -->
+<div class="pane" id="p2">
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-d">C</div><h2>CAN Statistics</h2></div>
+    <div class="sg">
+      <div class="sb"><div class="sv" id="rxCnt">0</div><div class="sl">RX Frames</div></div>
+      <div class="sb"><div class="sv" id="txCnt">0</div><div class="sl">TX Modified</div></div>
+      <div class="sb"><div class="sv" id="crcErr">0</div><div class="sl">CRC Errors</div></div>
+      <div class="sb"><div class="sv" id="fps">0.0</div><div class="sl">Frames/s</div></div>
+    </div>
   </div>
-  <div class="row">
-    <span class="lbl">BMS Display</span>
-    <label class="sw"><input type="checkbox" id="swBms" onchange="cmd('bms',this.checked)"><span class="sl2"></span></label>
-  </div>
-  <div class="row">
-    <span class="lbl">Force FSD</span>
-    <label class="sw"><input type="checkbox" id="swFsd" onchange="cmd('force_fsd',this.checked)"><span class="sl2"></span></label>
-  </div>
-  <div class="row">
-    <span class="lbl">TLSSC Restore</span>
-    <label class="sw"><input type="checkbox" id="swTlssc" onchange="cmd('tlssc_restore',this.checked)"><span class="sl2"></span></label>
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-b">F</div><h2>Frame Counters</h2></div>
+    <div class="row">
+      <span class="lbl">NAG Echoes</span>
+      <span id="nagEcho" style="font-variant-numeric:tabular-nums">0</span>
+    </div>
+    <div class="row">
+      <span class="lbl">TLSSC Restores</span>
+      <span id="tlsscCnt" style="font-variant-numeric:tabular-nums">0</span>
+    </div>
   </div>
   <div class="row">
     <span class="lbl">CAN Dump</span>
@@ -271,101 +283,98 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   <div id="fmtOut" style="font-size:.75em;color:var(--text2);margin-top:8px;display:none"></div>
 </div>
 
-<!-- Device Info -->
-<div class="card">
-  <div class="card-head"><div class="icon ic-d">D</div><h2>Device</h2></div>
-  <div class="row">
-    <span class="lbl">Firmware</span>
-    <span id="fwBuild" style="font-size:.8em;color:var(--text2)">--</span>
+<!-- ═══ TAB 3: Device ═══ -->
+<div class="pane" id="p3">
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-d">D</div><h2>Device Info</h2></div>
+    <div class="row">
+      <span class="lbl">Firmware</span>
+      <span id="fwBuild" style="font-size:.78em;color:var(--text2)">--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Uptime</span>
+      <span id="uptime" style="font-variant-numeric:tabular-nums">--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">WiFi Clients</span>
+      <span id="wifiCl">--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Speed Profile</span>
+      <span id="speedProf" style="font-variant-numeric:tabular-nums">--</span>
+    </div>
   </div>
-  <div class="row">
-    <span class="lbl">Uptime</span>
-    <span id="uptime" style="font-variant-numeric:tabular-nums">--</span>
-  </div>
-  <div class="row">
-    <span class="lbl">WiFi Clients</span>
-    <span id="wifiCl">--</span>
-  </div>
+
 </div>
 
-<div class="foot">Tesla FSD ESP32 &middot; M5Stack ATOM Lite + ATOMIC CAN Base</div>
+<div class="foot">Tesla FSD ESP32 &middot; M5Stack ATOM Lite</div>
 </div><!-- /wrap -->
 
 <script>
 var ws,rt;
 var HW=['Unknown','Legacy','HW3','HW4'];
-var CIRC=326.73;
 
+function showTab(i){
+  var tabs=document.querySelectorAll('.tab');
+  var panes=document.querySelectorAll('.pane');
+  for(var t=0;t<tabs.length;t++){
+    tabs[t].className='tab'+(t===i?' active':'');
+    panes[t].className='pane'+(t===i?' active':'');
+  }
+}
 function fmt(s){
   var h=Math.floor(s/3600),m=Math.floor((s%3600)/60),sc=s%60;
   return h+':'+(m<10?'0':'')+m+':'+(sc<10?'0':'')+sc;
 }
-function socCol(p){return p>60?'var(--accent)':p>30?'var(--yellow)':'var(--red)';}
-function pill(id,on,txt,warnClass){
+function pill(id,on,txt){
   var e=document.getElementById(id);
-  e.className='pill '+(warnClass||''+(on?'on':'off'));
+  e.className='pill '+(on?'on':'off');
   e.innerHTML='<span class="pd"></span>'+txt;
-}
-function ring(p){
-  var b=document.getElementById('socBar');
-  b.style.strokeDashoffset=CIRC-(CIRC*Math.min(p,100)/100);
-  b.style.stroke=socCol(p);
 }
 
 function upd(d){
-  // Status
+  // Dashboard — Status pills
   pill('fsdSt', d.fsd_enabled, d.fsd_enabled?'Active':'Waiting');
   pill('opMode', d.op_mode===1, d.op_mode===1?'Active':'Listen-Only');
-
   var hwEl=document.getElementById('hwVer');
   hwEl.className='pill '+(d.hw_version>0?'on':'off');
   hwEl.innerHTML='<span class="pd"></span>'+(HW[d.hw_version]||'?');
+  pill('canVeh', d.can_vehicle_detected, d.can_vehicle_detected?'Detected':'No CAN');
 
-  pill('nagSt', d.nag_killer, d.nag_killer?'ON':'OFF');
-  pill('canVeh', d.can_vehicle_detected, d.can_vehicle_detected?'Detected':'No CAN Traffic');
-  pill('bmsSt', d.bms && d.bms.seen, (d.bms && d.bms.seen)?'Live':'Waiting Frames');
-  document.getElementById('bmsFrames').textContent='HV:'+d.bms_hv_seen+' SOC:'+d.bms_soc_seen+' TH:'+d.bms_thermal_seen;
-
-  // OTA banner
+  // Banners
   document.getElementById('otaBanner').style.display=d.ota?'block':'none';
+  document.getElementById('sleepBanner').style.display=d.car_asleep?'block':'none';
 
-  // Mode button
+  // Controls — mode button
   var act=d.op_mode===1;
   var btn=document.getElementById('btnMode');
-  btn.textContent=act?'STOP FSD  \u2192  Listen-Only':'ACTIVATE FSD  \u2192  Active';
+  btn.textContent=act?'STOP \u2192 Listen-Only':'ACTIVATE FSD \u2192 Active';
   btn.className='btn-main '+(act?'btn-stop':'btn-act');
 
   // Switches sync
   document.getElementById('swNag').checked=d.nag_killer;
-  document.getElementById('swBms').checked=d.bms_output;
   document.getElementById('swFsd').checked=d.force_fsd;
   document.getElementById('swTlssc').checked=d.tlssc_restore;
   document.getElementById('swDump').checked=!!d.can_dump;
   pill('dumpSt',d.can_dump,d.can_dump?'Recording':'Idle');
+  document.getElementById('swAutoWake').checked=d.auto_wake;
+  document.getElementById('swChime').checked=d.chime;
+  document.getElementById('swEmerg').checked=d.emerg_veh;
 
   // CAN stats
   document.getElementById('rxCnt').textContent=d.rx_count.toLocaleString();
   document.getElementById('txCnt').textContent=d.tx_count.toLocaleString();
   document.getElementById('crcErr').textContent=d.crc_errors;
   document.getElementById('fps').textContent=d.fps.toFixed(1);
-
-  // Battery
-  if(d.bms && d.bms.seen){
-    var sn=document.getElementById('bSoc');
-    sn.textContent=d.bms.soc.toFixed(0)+'%';
-    sn.style.color=socCol(d.bms.soc);
-    ring(d.bms.soc);
-    document.getElementById('bVolt').textContent=d.bms.voltage.toFixed(0)+'V';
-    var ce=document.getElementById('bCurr');
-    ce.textContent=(d.bms.current>=0?'+':'')+d.bms.current.toFixed(1)+'A';
-    ce.style.color=d.bms.current>=0?'var(--accent)':'var(--red)';
-    document.getElementById('bTemp').textContent=d.bms.temp_min+'~'+d.bms.temp_max+'\u00b0C';
-  }
+  document.getElementById('nagEcho').textContent=d.nag_echo_count;
+  document.getElementById('tlsscCnt').textContent=d.tlssc_restore_count;
 
   // Device
   document.getElementById('fwBuild').textContent=d.fw_build;
   document.getElementById('uptime').textContent=fmt(d.uptime_s);
   document.getElementById('wifiCl').textContent=d.wifi_clients;
+  document.getElementById('speedProf').textContent=d.speed_profile;
 }
 
 function sdFormat(){
@@ -417,45 +426,32 @@ static String build_json() {
         can_vehicle_detected = (millis() - g_last_can_seen_ms) <= CAN_VEHICLE_ALIVE_MS;
     }
 
-    // BMS sub-object
-    char bms[128];
-    if (g_state->bms_seen) {
-        snprintf(bms, sizeof(bms),
-            "{\"seen\":true,\"voltage\":%.1f,\"current\":%.1f,"
-            "\"soc\":%.1f,\"temp_min\":%d,\"temp_max\":%d}",
-            g_state->pack_voltage_v,
-            g_state->pack_current_a,
-            g_state->soc_percent,
-            (int)g_state->batt_temp_min_c,
-            (int)g_state->batt_temp_max_c);
-    } else {
-        strcpy(bms, "{\"seen\":false}");
-    }
-
     // fps as fixed-point string
     char fps_s[12];
     snprintf(fps_s, sizeof(fps_s), "%.1f", g_fps);
 
     String j;
-    j.reserve(512);
+    j.reserve(640);
     j  = "{";
     j += "\"fsd_enabled\":";   j += g_state->fsd_enabled             ? "true" : "false"; j += ',';
     j += "\"op_mode\":";       j += (int)g_state->op_mode;            j += ',';
     j += "\"hw_version\":";    j += (int)g_state->hw_version;         j += ',';
     j += "\"ota\":";           j += g_state->tesla_ota_in_progress    ? "true" : "false"; j += ',';
+    j += "\"car_asleep\":";    j += g_state->car_asleep               ? "true" : "false"; j += ',';
     j += "\"nag_killer\":";    j += g_state->nag_killer               ? "true" : "false"; j += ',';
-    j += "\"bms_output\":";    j += g_state->bms_output               ? "true" : "false"; j += ',';
     j += "\"force_fsd\":";     j += g_state->force_fsd                ? "true" : "false"; j += ',';
     j += "\"tlssc_restore\":"; j += g_state->tlssc_restore            ? "true" : "false"; j += ',';
+    j += "\"auto_wake\":";     j += g_state->auto_activate_on_wake    ? "true" : "false"; j += ',';
+    j += "\"chime\":";         j += g_state->suppress_speed_chime     ? "true" : "false"; j += ',';
+    j += "\"emerg_veh\":";     j += g_state->emergency_vehicle_detect ? "true" : "false"; j += ',';
     j += "\"can_vehicle_detected\":"; j += can_vehicle_detected       ? "true" : "false"; j += ',';
-    j += "\"bms_hv_seen\":";   j += g_state->seen_bms_hv;              j += ',';
-    j += "\"bms_soc_seen\":";  j += g_state->seen_bms_soc;             j += ',';
-    j += "\"bms_thermal_seen\":"; j += g_state->seen_bms_thermal;       j += ',';
+    j += "\"nag_echo_count\":"; j += g_state->nag_echo_count;           j += ',';
+    j += "\"tlssc_restore_count\":"; j += g_state->tlssc_restore_count; j += ',';
+    j += "\"speed_profile\":"; j += g_state->speed_profile;             j += ',';
     j += "\"rx_count\":";      j += g_state->rx_count;                 j += ',';
     j += "\"tx_count\":";      j += g_state->frames_modified;          j += ',';
     j += "\"crc_errors\":";    j += g_state->crc_err_count;            j += ',';
     j += "\"fps\":";           j += fps_s;                             j += ',';
-    j += "\"bms\":";           j += bms;                               j += ',';
     j += "\"uptime_s\":";      j += uptime_s;                          j += ',';
     j += "\"fw_build\":\"";    j += __DATE__;  j += ' '; j += __TIME__; j += "\",";
     j += "\"can_dump\":";      j += can_dump_active()                 ? "true" : "false"; j += ',';
@@ -496,20 +492,32 @@ static void ws_event(uint8_t num, WStype_t type,
     } else if (strstr(buf, "\"nag\"")) {
         g_state->nag_killer = (strstr(buf, "true") != nullptr);
         Serial.printf("[Web] NAG Killer: %s\n", g_state->nag_killer ? "ON" : "OFF");
-    } else if (strstr(buf, "\"bms\"")) {
-        g_state->bms_output = (strstr(buf, "true") != nullptr);
-        Serial.printf("[Web] BMS output: %s\n", g_state->bms_output ? "ON" : "OFF");
+        nvs_settings_save(g_state);
     } else if (strstr(buf, "\"tlssc_restore\"")) {
         g_state->tlssc_restore = (strstr(buf, "true") != nullptr);
         Serial.printf("[Web] TLSSC Restore: %s\n", g_state->tlssc_restore ? "ON" : "OFF");
+        nvs_settings_save(g_state);
     } else if (strstr(buf, "\"force_fsd\"")) {
         g_state->force_fsd = (strstr(buf, "true") != nullptr);
         Serial.printf("[Web] Force FSD: %s\n", g_state->force_fsd ? "ON" : "OFF");
+        nvs_settings_save(g_state);
+    } else if (strstr(buf, "\"auto_wake\"")) {
+        g_state->auto_activate_on_wake = (strstr(buf, "true") != nullptr);
+        Serial.printf("[Web] Auto-Activate on Wake: %s\n", g_state->auto_activate_on_wake ? "ON" : "OFF");
+        nvs_settings_save(g_state);
+    } else if (strstr(buf, "\"chime\"")) {
+        g_state->suppress_speed_chime = (strstr(buf, "true") != nullptr);
+        Serial.printf("[Web] Speed Chime Suppress: %s\n", g_state->suppress_speed_chime ? "ON" : "OFF");
+        nvs_settings_save(g_state);
+    } else if (strstr(buf, "\"emerg_veh\"")) {
+        g_state->emergency_vehicle_detect = (strstr(buf, "true") != nullptr);
+        Serial.printf("[Web] Emergency Vehicle Detect: %s\n", g_state->emergency_vehicle_detect ? "ON" : "OFF");
+        nvs_settings_save(g_state);
     } else if (strstr(buf, "\"dump\"")) {
-        bool want = (strstr(buf, "true") != nullptr);
-        if (want) can_dump_start();
-        else      can_dump_stop();
-        Serial.printf("[Web] CAN Dump: %s\n", want ? "START" : "STOP");
+      bool want = (strstr(buf, "true") != nullptr);
+      if (want) can_dump_start();
+      else      can_dump_stop();
+      Serial.printf("[Web] CAN Dump: %s\n", want ? "START" : "STOP");
     }
 }
 

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -1,5 +1,5 @@
 /*
- * web_dashboard.cpp — HTTP + WebSocket dashboard for Tesla FSD ESP32
+ * web_dashboard.cpp — HTTP + WebSocket dashboard for Tesla CAN Controller ESP32
  *
  * HTTP  :80  → serves the embedded HTML page
  * WS    :81  → pushes JSON state every 1 s; receives control commands
@@ -14,6 +14,7 @@
 #include "web_dashboard.h"
 #include "can_dump.h"
 #include "nvs_settings.h"
+#include "wifi_manager.h"
 #include <WebServer.h>
 #include <WebSocketsServer.h>
 #include <WiFi.h>
@@ -47,7 +48,7 @@ static const char WEB_HTML[] PROGMEM = R"rawliteral(
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="theme-color" content="#0a0a1a">
 <link rel="icon" href="data:,">
-<title>Tesla FSD</title>
+<title>Tesla CAN Controller</title>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
@@ -153,6 +154,11 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 
 /* ── Footer ── */
 .foot{text-align:center;padding:12px 0 0;font-size:.6em;color:var(--text3)}
+/* ── Inputs ── */
+.inp{width:100%;background:var(--card2);border:1px solid var(--border);border-radius:8px;
+  padding:8px 10px;color:var(--text);font-size:.85em;outline:none}
+.inp:focus{border-color:var(--accent)}
+.inp-lbl{font-size:.75em;color:var(--text2);margin-bottom:4px}
 </style>
 </head>
 <body>
@@ -160,7 +166,7 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 
 <!-- Header -->
 <div class="hdr">
-  <h1>Tesla FSD</h1>
+  <h1>Tesla CAN Controller</h1>
   <div class="sub">ESP32 CAN Controller</div>
   <div class="cdot" id="dot"></div>
 </div>
@@ -172,8 +178,9 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 <div class="tabs">
   <div class="tab active" onclick="showTab(0)">Dashboard</div>
   <div class="tab" onclick="showTab(1)">Controls</div>
-  <div class="tab" onclick="showTab(2)">CAN Bus</div>
-  <div class="tab" onclick="showTab(3)">Device</div>
+  <div class="tab" onclick="showTab(2)">CAN</div>
+  <div class="tab" onclick="showTab(3)">BMS</div>
+  <div class="tab" onclick="showTab(4)">Device</div>
 </div>
 
 <!-- ═══ TAB 0: Dashboard ═══ -->
@@ -182,10 +189,6 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   <!-- Status -->
   <div class="card">
     <div class="card-head"><div class="icon ic-s">S</div><h2>Status</h2></div>
-    <div class="row">
-      <span class="lbl">FSD</span>
-      <span class="pill off" id="fsdSt"><span class="pd"></span>--</span>
-    </div>
     <div class="row">
       <span class="lbl">Mode</span>
       <span class="pill off" id="opMode"><span class="pd"></span>--</span>
@@ -198,6 +201,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
       <span class="lbl">Vehicle</span>
       <span class="pill off" id="canVeh"><span class="pd"></span>--</span>
     </div>
+    <div class="row">
+      <span class="lbl">BAN Shield</span>
+      <span class="pill off" id="banSt"><span class="pd"></span>--</span>
+    </div>
   </div>
 
 </div>
@@ -206,15 +213,26 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 <div class="pane" id="p1">
 
   <div class="card">
-    <div class="card-head"><div class="icon ic-c">C</div><h2>Mode</h2></div>
-    <button id="btnMode" class="btn-main btn-act" onclick="toggleMode()">ACTIVATE FSD</button>
+    <div class="card-head"><div class="icon ic-c">T</div><h2>Transmission Mode</h2></div>
+    <div class="row">
+      <span class="lbl">TX Active (off = Listen-Only)</span>
+      <label class="sw"><input type="checkbox" id="swTxMode" onchange="cmd('mode',this.checked)"><span class="sl2"></span></label>
+    </div>
   </div>
 
   <div class="card">
     <div class="card-head"><div class="icon ic-s">&#9881;</div><h2>Features</h2></div>
     <div class="row">
+      <span class="lbl">FSD Inject</span>
+      <label class="sw"><input type="checkbox" id="swFsdInject" onchange="cmd('fsd_inject',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
       <span class="lbl">NAG Killer</span>
       <label class="sw"><input type="checkbox" id="swNag" onchange="cmd('nag',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
+      <span class="lbl">BAN Shield</span>
+      <label class="sw"><input type="checkbox" id="swBan" onchange="cmd('ban_shield',this.checked)"><span class="sl2"></span></label>
     </div>
     <div class="row">
       <span class="lbl">Force FSD</span>
@@ -272,19 +290,83 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   </div>
 </div>
 
-<!-- SD Card -->
-<div class="card">
-  <div class="card-head"><div class="icon ic-d">S</div><h2>SD Card</h2></div>
-  <div class="row">
-    <span class="lbl">Dump Status</span>
-    <span class="pill off" id="dumpSt"><span class="pd"></span>Idle</span>
+<!-- ═══ TAB 3: BMS ═══ -->
+<div class="pane" id="p3">
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-b">⚡</div><h2>Battery Management</h2></div>
+    <div class="row">
+      <span class="lbl">BMS Enabled</span>
+      <label class="sw"><input type="checkbox" id="swBmsEn" onchange="cmd('bms_enable',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row">
+      <span class="lbl">Status</span>
+      <span class="pill off" id="bmsSt"><span class="pd"></span>--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Frames Seen</span>
+      <span id="bmsFrames" style="font-variant-numeric:tabular-nums">0</span>
+    </div>
   </div>
-  <button id="btnFmt" class="btn-main btn-stop" onclick="sdFormat()" style="margin-top:8px">FORMAT SD CARD</button>
-  <div id="fmtOut" style="font-size:.75em;color:var(--text2);margin-top:8px;display:none"></div>
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-b">V</div><h2>Live Data</h2></div>
+    <div class="row">
+      <span class="lbl">Pack Voltage</span>
+      <span id="bmsVolt">--V</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Pack Current</span>
+      <span id="bmsCurr">--A</span>
+    </div>
+    <div class="row">
+      <span class="lbl">State of Charge</span>
+      <span id="bmsSoc" class="ring">--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Temperature</span>
+      <span id="bmsTemp">--°C</span>
+    </div>
+  </div>
+
 </div>
 
-<!-- ═══ TAB 3: Device ═══ -->
-<div class="pane" id="p3">
+<!-- ═══ TAB 4: Device ═══ -->
+<div class="pane" id="p4">
+
+  <!-- SD Card -->
+  <div class="card">
+    <div class="card-head"><div class="icon ic-d">S</div><h2>SD Card</h2></div>
+    <div class="row">
+      <span class="lbl">Dump Status</span>
+      <span class="pill off" id="dumpSt"><span class="pd"></span>Idle</span>
+    </div>
+    <button id="btnFmt" class="btn-main btn-stop" onclick="sdFormat()" style="margin-top:8px">FORMAT SD CARD</button>
+    <div id="fmtOut" style="font-size:.75em;color:var(--text2);margin-top:8px;display:none"></div>
+  </div>
+
+  <div class="card">
+    <div class="card-head"><div class="icon ic-b">W</div><h2>WiFi AP</h2></div>
+    <div class="row">
+      <span class="lbl">Current SSID</span>
+      <span id="wifiSSID" style="font-size:.82em;color:var(--text2)">--</span>
+    </div>
+    <div class="row">
+      <span class="lbl">Current Password</span>
+      <span id="wifiPass" style="font-size:.82em;color:var(--text2)">--</span>
+    </div>
+    <div class="sep">Change credentials</div>
+    <div style="margin-bottom:8px">
+      <div class="inp-lbl">New SSID (1&ndash;32 chars)</div>
+      <input class="inp" id="inSSID" maxlength="32" placeholder="Tesla-FSD" autocomplete="off">
+    </div>
+    <div style="margin-bottom:10px">
+      <div class="inp-lbl">Password (min 8 chars, leave empty = unchanged)</div>
+      <input class="inp" type="password" id="inPass" maxlength="63" placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" autocomplete="new-password">
+    </div>
+    <button class="btn-main btn-act" onclick="saveWifi()" style="margin-bottom:4px">SAVE</button>
+    <div id="wifiOut" style="font-size:.75em;margin-top:4px;display:none"></div>
+  </div>
 
   <div class="card">
     <div class="card-head"><div class="icon ic-d">D</div><h2>Device Info</h2></div>
@@ -306,9 +388,13 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     </div>
   </div>
 
+  <div class="card">
+    <button class="btn-main btn-stop" onclick="reboot()">REBOOT</button>
+  </div>
+
 </div>
 
-<div class="foot">Tesla FSD ESP32 &middot; M5Stack ATOM Lite</div>
+<div class="foot">Tesla CAN Controller ESP32 &middot; M5Stack ATOM Lite</div>
 </div><!-- /wrap -->
 
 <script>
@@ -335,30 +421,28 @@ function pill(id,on,txt){
 
 function upd(d){
   // Dashboard — Status pills
-  pill('fsdSt', d.fsd_enabled, d.fsd_enabled?'Active':'Waiting');
-  pill('opMode', d.op_mode===1, d.op_mode===1?'Active':'Listen-Only');
+  pill('opMode', d.op_mode===1, d.op_mode===1?'TX Mode':'Listen-Only');
   var hwEl=document.getElementById('hwVer');
   hwEl.className='pill '+(d.hw_version>0?'on':'off');
   hwEl.innerHTML='<span class="pd"></span>'+(HW[d.hw_version]||'?');
   pill('canVeh', d.can_vehicle_detected, d.can_vehicle_detected?'Detected':'No CAN');
+  var banTxt=d.ban_shield_armed?'Armed ('+d.ban_shield_blocks+')':(d.ban_shield?'Learning':'Off');
+  pill('banSt', d.ban_shield_armed, banTxt);
 
   // Banners
   document.getElementById('otaBanner').style.display=d.ota?'block':'none';
   document.getElementById('sleepBanner').style.display=d.car_asleep?'block':'none';
 
-  // Controls — mode button
-  var act=d.op_mode===1;
-  var btn=document.getElementById('btnMode');
-  btn.textContent=act?'STOP \u2192 Listen-Only':'ACTIVATE FSD \u2192 Active';
-  btn.className='btn-main '+(act?'btn-stop':'btn-act');
-
   // Switches sync
+  document.getElementById('swTxMode').checked=d.op_mode===1;
+  document.getElementById('swFsdInject').checked=d.fsd_inject_enabled;
   document.getElementById('swNag').checked=d.nag_killer;
   document.getElementById('swFsd').checked=d.force_fsd;
   document.getElementById('swTlssc').checked=d.tlssc_restore;
   document.getElementById('swDump').checked=!!d.can_dump;
   pill('dumpSt',d.can_dump,d.can_dump?'Recording':'Idle');
   document.getElementById('swAutoWake').checked=d.auto_wake;
+  document.getElementById('swBan').checked=d.ban_shield;
   document.getElementById('swChime').checked=d.chime;
   document.getElementById('swEmerg').checked=d.emerg_veh;
 
@@ -370,6 +454,20 @@ function upd(d){
   document.getElementById('nagEcho').textContent=d.nag_echo_count;
   document.getElementById('tlsscCnt').textContent=d.tlssc_restore_count;
 
+  // BMS Tab
+  document.getElementById('swBmsEn').checked=d.bms_enabled;
+  var bmsOk=d.bms_enabled && d.bms_seen;
+  pill('bmsSt', bmsOk, bmsOk?'Reading':'--');
+  var bmsF=d.bms_hv_seen+d.bms_soc_seen+d.bms_thermal_seen;
+  document.getElementById('bmsFrames').textContent=bmsF;
+  document.getElementById('bmsVolt').textContent=d.bms_voltage.toFixed(1)+'V';
+  document.getElementById('bmsCurr').textContent=(d.bms_current>=0?'+':'')+d.bms_current.toFixed(1)+'A';
+  document.getElementById('bmsSoc').textContent=d.bms_soc.toFixed(1)+'%';
+  document.getElementById('bmsTemp').textContent=d.bms_temp_min+'–'+d.bms_temp_max+'°C';
+
+  document.getElementById('wifiSSID').textContent=d.wifi_ssid||'--';
+  document.getElementById('wifiPass').textContent=d.wifi_pass||'--';
+
   // Device
   document.getElementById('fwBuild').textContent=d.fw_build;
   document.getElementById('uptime').textContent=fmt(d.uptime_s);
@@ -377,6 +475,31 @@ function upd(d){
   document.getElementById('speedProf').textContent=d.speed_profile;
 }
 
+function cmd(c,v){
+  if(ws&&ws.readyState===1) ws.send(JSON.stringify({cmd:c,value:v}));
+}
+function reboot(){
+  if(!confirm('Reboot the device?'))return;
+  fetch('/reboot').catch(function(){});
+}
+function saveWifi(){
+  var ssid=document.getElementById('inSSID').value.trim();
+  var pass=document.getElementById('inPass').value;
+  if(ssid.length<1||ssid.length>32){alert('SSID: 1-32 characters');return;}
+  if(pass.length>0&&pass.length<8){alert('Password: 8 characters minimum');return;}
+  var out=document.getElementById('wifiOut');
+  out.style.display='none';
+  fetch('/wificreds',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({ssid:ssid,pass:pass})})
+    .then(function(r){return r.json();})
+    .then(function(d){
+      out.style.display='block';
+      out.style.color=d.ok?'var(--accent)':'var(--red)';
+      out.textContent=d.msg;
+    }).catch(function(){
+      out.style.display='block';out.style.color='var(--red)';out.textContent='Network error';
+    });
+}
 function sdFormat(){
   if(!confirm('Format SD card? All data will be lost.'))return;
   var btn=document.getElementById('btnFmt');
@@ -392,11 +515,6 @@ function sdFormat(){
     btn.disabled=false;btn.textContent='FORMAT SD CARD';
   });
 }
-function cmd(c,v){
-  if(ws&&ws.readyState===1) ws.send(JSON.stringify({cmd:c,value:v}));
-}
-function toggleMode(){ cmd('mode',null); }
-
 function conn(){
   ws=new WebSocket('ws://'+location.hostname+':81/');
   ws.onopen=function(){
@@ -440,6 +558,7 @@ static String build_json() {
     j += "\"car_asleep\":";    j += g_state->car_asleep               ? "true" : "false"; j += ',';
     j += "\"nag_killer\":";    j += g_state->nag_killer               ? "true" : "false"; j += ',';
     j += "\"force_fsd\":";     j += g_state->force_fsd                ? "true" : "false"; j += ',';
+    j += "\"fsd_inject_enabled\":"; j += g_state->fsd_inject_enabled  ? "true" : "false"; j += ',';
     j += "\"tlssc_restore\":"; j += g_state->tlssc_restore            ? "true" : "false"; j += ',';
     j += "\"auto_wake\":";     j += g_state->auto_activate_on_wake    ? "true" : "false"; j += ',';
     j += "\"chime\":";         j += g_state->suppress_speed_chime     ? "true" : "false"; j += ',';
@@ -455,6 +574,35 @@ static String build_json() {
     j += "\"uptime_s\":";      j += uptime_s;                          j += ',';
     j += "\"fw_build\":\"";    j += __DATE__;  j += ' '; j += __TIME__; j += "\",";
     j += "\"can_dump\":";      j += can_dump_active()                 ? "true" : "false"; j += ',';
+    j += "\"bms_enabled\":";   j += g_state->bms_enabled               ? "true" : "false"; j += ',';
+    j += "\"bms_seen\":";      j += g_state->bms_seen                  ? "true" : "false"; j += ',';
+    j += "\"bms_voltage\":";   snprintf(fps_s, sizeof(fps_s), "%.2f", g_state->pack_voltage_v); j += fps_s; j += ',';
+    j += "\"bms_current\":";   snprintf(fps_s, sizeof(fps_s), "%.2f", g_state->pack_current_a); j += fps_s; j += ',';
+    j += "\"bms_soc\":";       snprintf(fps_s, sizeof(fps_s), "%.1f", g_state->soc_percent); j += fps_s; j += ',';
+    j += "\"bms_temp_min\":";  j += (int)g_state->batt_temp_min_c;      j += ',';
+    j += "\"bms_temp_max\":";  j += (int)g_state->batt_temp_max_c;      j += ',';
+    j += "\"bms_hv_seen\":";   j += g_state->seen_bms_hv;              j += ',';
+    j += "\"bms_soc_seen\":";  j += g_state->seen_bms_soc;             j += ',';
+    j += "\"bms_thermal_seen\":"; j += g_state->seen_bms_thermal;      j += ',';
+    j += "\"ban_shield\":";       j += g_state->ban_shield               ? "true" : "false"; j += ',';
+    j += "\"ban_shield_armed\":"; j += g_state->ban_shield_armed          ? "true" : "false"; j += ',';
+    j += "\"ban_shield_blocks\":"; j += g_state->ban_shield_blocks;                           j += ',';
+    j += "\"wifi_ssid\":\"";
+    String ap_ssid = String(wifi_ap_ssid());
+    for (size_t i = 0; i < ap_ssid.length(); i++) {
+        char c = ap_ssid[i];
+        if (c == '"' || c == '\\') j += '\\';
+        j += c;
+    }
+    j += "\",";
+    j += "\"wifi_pass\":\"";
+    String ap_pass = String(wifi_ap_pass());
+    for (size_t i = 0; i < ap_pass.length(); i++) {
+        char c = ap_pass[i];
+        if (c == '"' || c == '\\') j += '\\';
+        j += c;
+    }
+    j += "\",";
     j += "\"wifi_clients\":";  j += (int)WiFi.softAPgetStationNum();
     j += '}';
     return j;
@@ -480,15 +628,14 @@ static void ws_event(uint8_t num, WStype_t type,
     memcpy(buf, payload, n);
 
     if (strstr(buf, "\"mode\"")) {
-        if (g_state->op_mode == OpMode_ListenOnly) {
-            g_state->op_mode = OpMode_Active;
-            if (g_can) g_can->setListenOnly(false);
-            Serial.println("[Web] \u2192 Active mode");
-        } else {
-            g_state->op_mode = OpMode_ListenOnly;
-            if (g_can) g_can->setListenOnly(true);
-            Serial.println("[Web] \u2192 Listen-Only mode");
-        }
+        bool want = (strstr(buf, "true") != nullptr);
+        g_state->op_mode = want ? OpMode_Active : OpMode_ListenOnly;
+        if (g_can) g_can->setListenOnly(!want);
+        Serial.printf("[Web] \u2192 %s\n", want ? "TX Mode" : "Listen-Only");
+    } else if (strstr(buf, "\"fsd_inject\"")) {
+        g_state->fsd_inject_enabled = (strstr(buf, "true") != nullptr);
+        Serial.printf("[Web] FSD Inject: %s\n", g_state->fsd_inject_enabled ? "ON" : "OFF");
+        nvs_settings_save(g_state);
     } else if (strstr(buf, "\"nag\"")) {
         g_state->nag_killer = (strstr(buf, "true") != nullptr);
         Serial.printf("[Web] NAG Killer: %s\n", g_state->nag_killer ? "ON" : "OFF");
@@ -518,6 +665,32 @@ static void ws_event(uint8_t num, WStype_t type,
       if (want) can_dump_start();
       else      can_dump_stop();
       Serial.printf("[Web] CAN Dump: %s\n", want ? "START" : "STOP");
+    } else if (strstr(buf, "\"bms_enable\"")) {
+        g_state->bms_enabled = (strstr(buf, "true") != nullptr);
+        if (!g_state->bms_enabled) {
+            g_state->bms_seen = false;
+            g_state->pack_voltage_v = 0.0f;
+            g_state->pack_current_a = 0.0f;
+            g_state->soc_percent = 0.0f;
+            g_state->batt_temp_min_c = 0;
+            g_state->batt_temp_max_c = 0;
+        }
+        Serial.printf("[Web] BMS: %s\n", g_state->bms_enabled ? "Enabled" : "Disabled");
+        nvs_settings_save(g_state);
+    } else if (strstr(buf, "\"ban_shield\"")) {
+        g_state->ban_shield = (strstr(buf, "true") != nullptr);
+        if (!g_state->ban_shield) {
+            g_state->ban_shield_armed = false;
+            g_state->ban_shield_blocks = 0;
+            memset(g_state->ban_shield_snapshot_valid, 0, sizeof(g_state->ban_shield_snapshot_valid));
+        }
+        Serial.printf("[Web] BAN Shield: %s\n", g_state->ban_shield ? "Enabled" : "Disabled");
+        nvs_settings_save(g_state);
+        } else if (strstr(buf, "\"dump\"")) {
+          bool want = (strstr(buf, "true") != nullptr);
+          if (want) can_dump_start();
+          else      can_dump_stop();
+          Serial.printf("[Web] CAN Dump: %s\n", want ? "START" : "STOP");
     }
 }
 
@@ -536,6 +709,49 @@ static void handle_sdformat() {
     g_http.send(200, "application/json", result);
 }
 
+static void handle_reboot() {
+    g_http.send(200, "text/plain", "Rebooting...");
+    g_http.client().flush();
+    delay(200);
+    ESP.restart();
+}
+
+static String extract_json_str(const String &body, const char *key) {
+    String needle = String("\"") + key + "\":\"";
+    int idx = body.indexOf(needle);
+    if (idx < 0) return "";
+    int start = idx + needle.length();
+    int end   = body.indexOf('"', start);
+    if (end < 0) return "";
+    return body.substring(start, end);
+}
+
+static void handle_wificreds() {
+    if (g_http.method() == HTTP_GET) {
+        // Return current SSID only (never expose password)
+        String j = "{\"ssid\":\""; j += wifi_ap_ssid(); j += "\"}";
+        g_http.send(200, "application/json", j);
+        return;
+    }
+    // POST — save new credentials
+    String body = g_http.arg("plain");
+    String ssid = extract_json_str(body, "ssid");
+    String pass = extract_json_str(body, "pass");
+    if (ssid.length() < 1 || ssid.length() > 32) {
+        g_http.send(400, "application/json",
+            "{\"ok\":false,\"msg\":\"Invalid SSID (1-32 chars)\"}" );
+        return;
+    }
+    if (pass.length() > 0 && pass.length() < 8) {
+        g_http.send(400, "application/json",
+            "{\"ok\":false,\"msg\":\"Password too short (min 8)\"}" );
+        return;
+    }
+    nvs_wifi_save(ssid.c_str(), pass.c_str());
+    g_http.send(200, "application/json",
+        "{\"ok\":true,\"msg\":\"Saved \\u2014 reboot to apply\"}" );
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 void web_dashboard_init(FSDState *state, CanDriver *can) {
     g_state       = state;
@@ -545,9 +761,12 @@ void web_dashboard_init(FSDState *state, CanDriver *can) {
     g_last_rx     = state ? state->rx_count : 0;
     g_last_can_seen_ms = (state && state->rx_count > 0) ? millis() : 0;
 
-    g_http.on("/",           HTTP_GET, handle_root);
-    g_http.on("/api/status", HTTP_GET, handle_status);
-    g_http.on("/sdformat",   HTTP_GET, handle_sdformat);
+    g_http.on("/",           HTTP_GET,  handle_root);
+    g_http.on("/api/status", HTTP_GET,  handle_status);
+    g_http.on("/sdformat",   HTTP_GET,  handle_sdformat);
+    g_http.on("/reboot",     HTTP_GET,  handle_reboot);
+    g_http.on("/wificreds",  HTTP_GET,  handle_wificreds);
+    g_http.on("/wificreds",  HTTP_POST, handle_wificreds);
     g_http.begin();
 
     g_ws.begin();

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -597,11 +597,7 @@ static String build_json() {
     j += "\",";
     j += "\"wifi_pass\":\"";
     String ap_pass = String(wifi_ap_pass());
-    for (size_t i = 0; i < ap_pass.length(); i++) {
-        char c = ap_pass[i];
-        if (c == '"' || c == '\\') j += '\\';
-        j += c;
-    }
+    j += (ap_pass.length() > 0) ? "***" : "";
     j += "\",";
     j += "\"wifi_clients\":";  j += (int)WiFi.softAPgetStationNum();
     j += '}';
@@ -686,11 +682,6 @@ static void ws_event(uint8_t num, WStype_t type,
         }
         Serial.printf("[Web] BAN Shield: %s\n", g_state->ban_shield ? "Enabled" : "Disabled");
         nvs_settings_save(g_state);
-        } else if (strstr(buf, "\"dump\"")) {
-          bool want = (strstr(buf, "true") != nullptr);
-          if (want) can_dump_start();
-          else      can_dump_stop();
-          Serial.printf("[Web] CAN Dump: %s\n", want ? "START" : "STOP");
     }
 }
 

--- a/esp32/.firmware/wifi_manager.cpp
+++ b/esp32/.firmware/wifi_manager.cpp
@@ -1,19 +1,26 @@
 #include "wifi_manager.h"
+#include "nvs_settings.h"
 #include <WiFi.h>
 #include <Arduino.h>
 
-static const char AP_SSID[] = "Tesla-FSD";
-static const char AP_PASS[] = "12345678";
+static char g_ssid[33] = "Tesla-FSD";
+static char g_pass[64] = "12345678";
 
 bool wifi_ap_init() {
+    // Load credentials from NVS (defaults kept if keys absent)
+    nvs_wifi_load(g_ssid, sizeof(g_ssid), g_pass, sizeof(g_pass));
+
     WiFi.mode(WIFI_AP);
-    bool ok = WiFi.softAP(AP_SSID, AP_PASS);
+    bool ok = WiFi.softAP(g_ssid, g_pass);
     if (ok) {
         Serial.printf("[WiFi] AP: \"%s\"  IP: %s\n",
-            AP_SSID, WiFi.softAPIP().toString().c_str());
+            g_ssid, WiFi.softAPIP().toString().c_str());
         Serial.println("[WiFi] Dashboard: http://192.168.4.1");
     } else {
         Serial.println("[WiFi] AP start FAILED — continuing without web");
     }
     return ok;
 }
+
+const char *wifi_ap_ssid() { return g_ssid; }
+const char *wifi_ap_pass() { return g_pass; }

--- a/esp32/.firmware/wifi_manager.h
+++ b/esp32/.firmware/wifi_manager.h
@@ -3,9 +3,15 @@
 /**
  * wifi_manager.h — WiFi Access Point initialisation
  *
- * Starts a soft-AP with the fixed credentials below.
- * Call once from setup(); non-fatal on failure.
+ * Credentials are loaded from NVS on init; defaults: "Tesla-FSD" / "12345678".
+ * Call wifi_ap_init() once from setup(); non-fatal on failure.
  */
 
-/** Start the WiFi AP.  Returns true on success. */
+/** Start the WiFi AP. Returns true on success. */
 bool wifi_ap_init();
+
+/** Return the SSID currently in use by the AP. */
+const char *wifi_ap_ssid();
+
+/** Return the password currently in use by the AP. */
+const char *wifi_ap_pass();

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -11,11 +11,6 @@ Unlock Tesla FSD with an ESP32 + CAN transceiver via OBD-II. No Flipper Zero nee
 >
 > **If you test this on another vehicle model, please report your results in this PR thread.**
 
-> [!WARNING]
-> **BMS section is currently not working in real vehicle usage.**
->
-> The BMS parser and dashboard fields are implemented in code, but on current tested setup they do not provide reliable/usable live data yet.
-
 > [!IMPORTANT]
 > The device boots in **Listen-Only mode** by default and will **not transmit any CAN frames** until the user explicitly switches to Active mode via the physical button or Web Dashboard UI. This ensures safe first-boot behavior.
 
@@ -35,8 +30,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - Speed profile mapping from follow-distance stalk
 - OTA update detection and automatic TX suspension
 - ISA speed warning chime suppression (HW4)
-- BMS data parsing logic (voltage, current, SOC, temperature) — currently not reliable in real use
-- Battery precondition trigger
+- TLSSC Restore via DAS config spoof (`0x331`)
 - CRC/checksum recalculation after frame modification
 - DLC length validation on all handlers
 
@@ -46,21 +40,19 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 
 - **WiFi AP mode** — connects without internet, SSID: `Tesla-FSD`, password: `12345678`
 - **Tesla dark theme UI** — mobile-first responsive design (optimized for phone in portrait)
+  - Tabbed interface: Dashboard, Controls, CAN Bus, Device
   - Dark background (#0a0a1a) with accent gradients, inspired by Tesla's in-car UI
   - All HTML/CSS/JS embedded in firmware (no external CDN dependencies)
 - **Real-time WebSocket push** — 1 Hz state updates via WebSocket on port 81
-- **FSD Status Panel** — FSD active/waiting, Listen-Only/Active mode, HW version, NAG Killer state
-- **Battery SOC Ring** — animated circular progress bar with color coding (green >60%, yellow >30%, red ≤30%)
-- **BMS Live Data UI hooks** — fields exist in UI/API, but BMS section is currently not working reliably on tested vehicle setup
-- **CAN Bus Stats** — RX frame count, TX modified count, CRC errors, frames/second
-- **Web Controls** — toggle buttons for:
-  - Activate/Stop FSD (Listen-Only ↔ Active mode switch)
-  - NAG Killer on/off
-  - BMS serial output on/off
-  - Force FSD toggle
-- **OTA Warning Banner** — pulsing red alert when vehicle OTA update is detected
+- **Dashboard tab** — FSD status, operation mode, HW version, vehicle detection
+- **Controls tab** — Toggle switches for all features + mode activation button
+- **CAN Bus tab** — RX frame count, TX modified count, CRC errors, frames/second, NAG echo and TLSSC restore counters
+- **Device tab** — firmware build date, uptime counter, WiFi client count, speed profile
+- **OTA Warning Banner** — pulsing red alert when vehicle OTA update is detected (installing only)
+- **Sleep Banner** — purple alert when car is asleep (no CAN traffic)
 - **Connection Status** — green/red dot indicator with auto-reconnect on WebSocket disconnect
-- **Device Info** — firmware build date, uptime counter, WiFi client count
+- **NVS Persistence** — all toggle settings saved to flash and restored on boot
+- **Auto-Activate on Wake** — optional: automatically switch to Active mode on car wake or ESP32 boot
 - **REST API** — `GET /api/status` returns full JSON state
 
 ### CAN Driver Abstraction
@@ -73,19 +65,35 @@ Dual CAN driver support (compile-time switch):
 
 ## Features
 
-| Feature | CAN ID | Description |
-|---------|--------|-------------|
-| **FSD Unlock** | `0x3FD` mux0 | bit46 = 1 activates FSD (HW3/HW4/Legacy) |
-| **NAG Killer** | `0x370` | Suppresses hands-on-wheel reminder |
-| **Speed Profile** | `0x3FD` mux2 | Follow-distance stalk maps to speed offset |
-| **ISA Chime Suppress** | `0x399` | Kills speed warning chime (HW4 only) |
-| **Battery Precondition** | `0x082` | Frame builder implemented; no user control exposed yet |
-| **BMS Dashboard** | `0x132`/`0x292`/`0x312` | Parsing/UI path implemented, but currently not working reliably |
-| **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected |
-| **HW Auto-Detect** | `0x398` | Reads GTW_carConfig for HW version |
-| **Listen-Only Mode** | — | Default on boot, passive monitoring only |
-| **Wiring Check** | — | rx_count + CRC error monitoring |
-| **WiFi Dashboard** | — | Real-time web UI at 192.168.4.1 |
+| Feature | CAN ID | HW Compat | Description |
+|---------|--------|-----------|-------------|
+| **FSD Unlock** | `0x3FD` mux0 | All (Legacy/HW3/HW4) | bit46 = 1 activates FSD |
+| **NAG Killer** | `0x370` | All | Suppresses hands-on-wheel reminder via counter+1 echo |
+| **Force FSD** | `0x3FD` mux0 | All | Bypass UI selection check — FSD always active |
+| **Speed Profile** | `0x3FD` mux2 | All | Follow-distance stalk maps to speed offset |
+| **TLSSC Restore** | `0x331` | All | DAS config spoof — restores tier via autopilot config |
+| **ISA Chime Suppress** | `0x399` | **HW4 only** | Kills speed warning chime |
+| **Emergency Vehicle Detect** | `0x3FD` mux0 bit59 | **HW4 only** | Enables emergency vehicle detection bit |
+| **OTA Protection** | `0x318` | All | Auto-stops TX when OTA *installing* detected |
+| **Car Sleep / Wake** | — | All | Detects car sleep (no CAN), auto-resumes on wake |
+| **Auto-Activate on Wake** | — | All | Automatically switches to Active mode on wake / boot |
+| **HW Auto-Detect** | `0x398` | All | Reads GTW_carConfig with fallback detection |
+| **Listen-Only Mode** | — | All | Default on boot, passive monitoring only |
+| **NVS Persistence** | — | All | Saves toggle settings to flash (survives reboot) |
+| **WiFi Dashboard** | — | All | Real-time web UI at 192.168.4.1 |
+
+### Persisted Settings (NVS)
+
+These settings are saved to flash and restored automatically on boot:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| NAG Killer | ON | Suppress hands-on-wheel nag |
+| Speed Chime Suppress | ON | ISA chime suppress (HW4 only) |
+| Force FSD | OFF | Bypass FSD UI selection check |
+| TLSSC Restore | OFF | DAS config spoof for tier restore |
+| Auto-Activate on Wake | OFF | Auto-switch to Active on boot/wake |
+| Emergency Vehicle Detect | OFF | Enable EVD bit (HW4 only) |
 
 ---
 
@@ -146,11 +154,8 @@ Located in the rear center console area:
 | CAN ID | Name | Purpose |
 |--------|------|---------|
 | `0x045` | STW_ACTN_RQ | Steering stalk (Legacy follow distance) |
-| `0x082` | TRIP_PLANNING | Battery precondition trigger |
-| `0x132` | BMS_HV_BUS | Battery voltage / current |
-| `0x292` | BMS_SOC | Battery state of charge |
-| `0x312` | BMS_THERMAL | Battery temperature |
 | `0x318` | GTW_CAR_STATE | Vehicle state (OTA detection) |
+| `0x331` | DAS_AP_CONFIG | DAS autopilot config (TLSSC restore target) |
 | `0x370` | EPAS_STATUS | EPAS status (NAG killer target) |
 | `0x398` | GTW_CAR_CONFIG | HW version detection |
 | `0x399` | ISA_SPEED | Speed warning chime (HW4) |
@@ -164,11 +169,11 @@ Bus speed: **500 kbps**
 
 ## HW Support
 
-| Tesla HW | Bits Modified | Speed Profile |
-|----------|---------------|---------------|
-| Legacy (HW1/HW2) | bit46 | 3 levels (0-2) |
-| HW3 | bit46 | 3 levels (0-2) |
-| HW4 (FSD V14+) | bit46 + bit60, bit47 | 5 levels (0-4) |
+| Tesla HW | Bits Modified | Speed Profile | Exclusive Features |
+|----------|---------------|---------------|--------------------|
+| Legacy (HW1/HW2) | bit46 | 3 levels (0-2) | — |
+| HW3 | bit46 | 3 levels (0-2) + speed offset | — |
+| HW4 (FSD V14+) | bit46 + bit60, bit47 | 5 levels (0-4) | ISA chime suppress, Emergency vehicle detect |
 
 ---
 
@@ -200,13 +205,13 @@ pio device monitor -b 115200
 ============================
  Tesla FSD Unlock — ESP32
 ============================
-[FSD] Build: Apr  8 2026 18:59:17
+[FSD] Build: Apr 19 2026 12:00:00
 [CAN] Driver: ESP32 TWAI (M5Stack ATOM Lite + ATOMIC CAN Base)
+[NVS] Loaded: nag=1 chime=1 force=0 tlssc=0 auto_wake=0 emerg=0
 [CAN] 500 kbps — Listen-Only
 [BTN] Single click : toggle Listen-Only / Active
 [BTN] Long press 3s: toggle NAG Killer
-[BTN] Double click : toggle BMS serial output
-[LED] Blue=Listen  Green=Active  Yellow=OTA  Red=Error
+[LED] Blue=Listen  Green=Active  Yellow=OTA  Purple=Sleep  Red=Error
 [WiFi] AP: "Tesla-FSD"  IP: 192.168.4.1
 [WiFi] Dashboard: http://192.168.4.1
 [Web] HTTP :80  WS :81 — ready
@@ -230,7 +235,6 @@ pio device monitor -b 115200
 |---------------|----------|
 | Single click | Toggle Listen-Only ↔ Active mode |
 | Long press (3s) | Toggle NAG Killer on/off |
-| Double click | Toggle BMS serial output |
 
 ### LED Status
 
@@ -239,22 +243,24 @@ pio device monitor -b 115200
 | 🔵 Blue | Listen-Only (passive monitoring) |
 | 🟢 Green | Active (FSD enabled, transmitting) |
 | 🟡 Yellow | OTA detected (TX suspended) |
-| 🔴 Red | Error (no CAN signal / CRC errors) |
+| 🟣 Purple | Car asleep (no CAN traffic) |
+| 🔴 Red | Error (no CAN signal after 5s) |
 
 ### WiFi Dashboard
 
 1. Connect phone to WiFi: **Tesla-FSD** (password: **12345678**)
 2. Open browser: **http://192.168.4.1**
-3. Monitor and control everything from the web UI
+3. Monitor and control everything from the tabbed web UI
 4. REST API available at `http://192.168.4.1/api/status`
 
 ---
 
 ## Safety
 
-- **OTA Protection** — automatically stops all CAN TX when a software update is detected on `0x318`
+- **OTA Protection** — automatically stops all CAN TX when a software update is *installing* (raw state = 2 on `0x318`); "update available" (state 1) does NOT suspend TX
 - **Listen-Only default** — device will not modify any CAN frames until explicitly switched to Active mode
-- **Wiring diagnostics** — monitors rx_count and CRC error counter; red LED if no CAN traffic
+- **Sleep detection** — suspends TX when car goes to sleep (no CAN traffic for 3s), resumes on wake
+- **Wiring diagnostics** — monitors rx_count and CRC error counter; red LED if no CAN traffic after 5s
 - **DLC validation** — checks frame data length before parsing to prevent buffer overflows
 - **Unplug = reset** — remove the device and restart the car to clear any modified state
 - **WiFi isolated** — AP mode only, no internet connection, no data leaves the device
@@ -281,13 +287,14 @@ This table is informational from field reports/upstream notes. The ESP32 code it
 ```
 esp32/
 ├── .firmware/
-│   ├── main.cpp            — Init, button handling, main loop
+│   ├── main.cpp            — Init, button handling, CAN dispatch, main loop
 │   ├── fsd_handler.cpp/h   — CAN protocol logic (ported from hypery11)
 │   ├── can_driver.cpp/h    — CAN driver abstraction (TWAI / MCP2515)
 │   ├── wifi_manager.cpp/h  — WiFi AP setup
 │   ├── web_dashboard.cpp/h — HTTP server + WebSocket + embedded UI
+│   ├── nvs_settings.cpp/h  — NVS persistence for toggle settings
 │   ├── led.cpp/h           — NeoPixel LED status control
-│   └── config.h            — CAN IDs and pin definitions
+│   └── config.h            — CAN IDs, pin definitions, timing constants
 ├── platformio.ini          — Build configs (m5stack-atom / esp32-mcp2515)
 └── README.md
 ```

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -33,6 +33,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - TLSSC Restore via DAS config spoof (`0x331`)
 - CRC/checksum recalculation after frame modification
 - DLC length validation on all handlers
+- **BAN Shield** (`0x7FF` GTW_carConfig_ETH) — snapshot-based ban-push blocker (⚠️ untested on vehicle)
 
 ### What Was Added (New)
 
@@ -40,13 +41,14 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 
 - **WiFi AP mode** — connects without internet, SSID: `Tesla-FSD`, password: `12345678`
 - **Tesla dark theme UI** — mobile-first responsive design (optimized for phone in portrait)
-  - Tabbed interface: Dashboard, Controls, CAN Bus, Device
+  - Tabbed interface: **Dashboard, Controls, CAN Bus, BMS, Device** (5 tabs)
   - Dark background (#0a0a1a) with accent gradients, inspired by Tesla's in-car UI
   - All HTML/CSS/JS embedded in firmware (no external CDN dependencies)
 - **Real-time WebSocket push** — 1 Hz state updates via WebSocket on port 81
 - **Dashboard tab** — FSD status, operation mode, HW version, vehicle detection
 - **Controls tab** — Toggle switches for all features + mode activation button
 - **CAN Bus tab** — RX frame count, TX modified count, CRC errors, frames/second, NAG echo and TLSSC restore counters
+- **BMS tab** ⚠️ — Battery data (voltage, current, SoC, temps) with enable/disable toggle — **NOT YET TESTED**
 - **Device tab** — firmware build date, uptime counter, WiFi client count, speed profile
 - **OTA Warning Banner** — pulsing red alert when vehicle OTA update is detected (installing only)
 - **Sleep Banner** — purple alert when car is asleep (no CAN traffic)
@@ -65,22 +67,32 @@ Dual CAN driver support (compile-time switch):
 
 ## Features
 
-| Feature | CAN ID | HW Compat | Description |
-|---------|--------|-----------|-------------|
-| **FSD Unlock** | `0x3FD` mux0 | All (Legacy/HW3/HW4) | bit46 = 1 activates FSD |
-| **NAG Killer** | `0x370` | All | Suppresses hands-on-wheel reminder via counter+1 echo |
-| **Force FSD** | `0x3FD` mux0 | All | Bypass UI selection check — FSD always active |
-| **Speed Profile** | `0x3FD` mux2 | All | Follow-distance stalk maps to speed offset |
-| **TLSSC Restore** | `0x331` | All | DAS config spoof — restores tier via autopilot config |
-| **ISA Chime Suppress** | `0x399` | **HW4 only** | Kills speed warning chime |
-| **Emergency Vehicle Detect** | `0x3FD` mux0 bit59 | **HW4 only** | Enables emergency vehicle detection bit |
-| **OTA Protection** | `0x318` | All | Auto-stops TX when OTA *installing* detected |
-| **Car Sleep / Wake** | — | All | Detects car sleep (no CAN), auto-resumes on wake |
-| **Auto-Activate on Wake** | — | All | Automatically switches to Active mode on wake / boot |
-| **HW Auto-Detect** | `0x398` | All | Reads GTW_carConfig with fallback detection |
-| **Listen-Only Mode** | — | All | Default on boot, passive monitoring only |
-| **NVS Persistence** | — | All | Saves toggle settings to flash (survives reboot) |
-| **WiFi Dashboard** | — | All | Real-time web UI at 192.168.4.1 |
+> [!WARNING]
+> Three features listed below are **implemented but NOT yet tested on a real vehicle**. Enable them only if you're willing to experiment and report results.
+> - **Force FSD** — bypass UI selection check so FSD is always active
+> - **BAN Shield** — blocks server-side ban pushes via `0x7FF` snapshot overwrite
+> - **BMS Monitor** — read-only battery data sniffing via `0x132` / `0x292` / `0x312`
+>
+> **Feedback welcome!** If you test any of these features on your vehicle, please open an issue or post in the PR thread with your results (vehicle model, HW version, firmware, observed behaviour). Your reports help validate and improve the implementation.
+
+| Feature | CAN ID | HW Compat | Status | Description |
+|---------|--------|-----------|--------|-------------|
+| **FSD Unlock** | `0x3FD` mux0 | All (Legacy/HW3/HW4) | ✅ Tested | bit46 = 1 activates FSD |
+| **NAG Killer** | `0x370` | All | ✅ Tested | Suppresses hands-on-wheel reminder via counter+1 echo |
+| **Force FSD** | `0x3FD` mux0 | All | ⚠️ **UNTESTED** | Bypass UI selection check — FSD always active |
+| **Speed Profile** | `0x3FD` mux2 | All | ✅ Tested | Follow-distance stalk maps to speed offset |
+| **TLSSC Restore** | `0x331` | All | ✅ Tested | DAS config spoof — restores tier via autopilot config |
+| **ISA Chime Suppress** | `0x399` | **HW4 only** | ✅ Tested | Kills speed warning chime |
+| **Emergency Vehicle Detect** | `0x3FD` mux0 bit59 | **HW4 only** | ✅ Tested | Enables emergency vehicle detection bit |
+| **OTA Protection** | `0x318` | All | ✅ Tested | Auto-stops TX when OTA *installing* detected |
+| **Car Sleep / Wake** | — | All | ✅ Tested | Detects car sleep (no CAN), auto-resumes on wake |
+| **Auto-Activate on Wake** | — | All | ✅ Tested | Automatically switches to Active mode on wake / boot |
+| **HW Auto-Detect** | `0x398` | All | ✅ Tested | Reads GTW_carConfig with fallback detection |
+| **Listen-Only Mode** | — | All | ✅ Tested | Default on boot, passive monitoring only |
+| **NVS Persistence** | — | All | ✅ Tested | Saves toggle settings to flash (survives reboot) |
+| **WiFi Dashboard** | — | All | ✅ Tested | Real-time web UI at 192.168.4.1 |
+| **BAN Shield** | `0x7FF` | All | ⚠️ **UNTESTED** | Snapshot-based blocker: overrides server ban-pushes on GTW_carConfig_ETH |
+| **BMS Monitor** | `0x132` `0x292` `0x312` | All | ⚠️ **UNTESTED** | Read-only: pack voltage, current, SoC %, min/max temps |
 
 ### Persisted Settings (NVS)
 
@@ -90,10 +102,12 @@ These settings are saved to flash and restored automatically on boot:
 |---------|---------|-------------|
 | NAG Killer | ON | Suppress hands-on-wheel nag |
 | Speed Chime Suppress | ON | ISA chime suppress (HW4 only) |
-| Force FSD | OFF | Bypass FSD UI selection check |
+| Force FSD | OFF | Bypass FSD UI selection check (⚠️ untested — feedback welcome) |
 | TLSSC Restore | OFF | DAS config spoof for tier restore |
 | Auto-Activate on Wake | OFF | Auto-switch to Active on boot/wake |
 | Emergency Vehicle Detect | OFF | Enable EVD bit (HW4 only) |
+| BAN Shield | **ON** | Block server-side ban pushes via 0x7FF snapshot (⚠️ untested — feedback welcome) |
+| BMS Monitor | OFF | Enable read-only battery data sniffing (⚠️ untested — feedback welcome) |
 
 ---
 
@@ -154,6 +168,9 @@ Located in the rear center console area:
 | CAN ID | Name | Purpose |
 |--------|------|---------|
 | `0x045` | STW_ACTN_RQ | Steering stalk (Legacy follow distance) |
+| `0x132` | BMS_HV_BUS | Pack voltage & current — BMS monitor ⚠️ untested |
+| `0x292` | BMS_SOC | State of charge — BMS monitor ⚠️ untested |
+| `0x312` | BMS_THERMAL | Battery temperatures — BMS monitor ⚠️ untested |
 | `0x318` | GTW_CAR_STATE | Vehicle state (OTA detection) |
 | `0x331` | DAS_AP_CONFIG | DAS autopilot config (TLSSC restore target) |
 | `0x370` | EPAS_STATUS | EPAS status (NAG killer target) |
@@ -162,6 +179,7 @@ Located in the rear center console area:
 | `0x3EE` | AP_LEGACY | Autopilot control (Legacy / HW1 / HW2) |
 | `0x3F8` | FOLLOW_DIST | Follow distance / speed profile |
 | `0x3FD` | AP_CONTROL | **Autopilot control (HW3/HW4) — core** |
+| `0x7FF` | GTW_CONFIG_ETH | GTW_carConfig_ETH — BAN Shield target ⚠️ untested |
 
 Bus speed: **500 kbps**
 
@@ -289,9 +307,11 @@ esp32/
 ├── .firmware/
 │   ├── main.cpp            — Init, button handling, CAN dispatch, main loop
 │   ├── fsd_handler.cpp/h   — CAN protocol logic (ported from hypery11)
+│   │                           incl. BAN Shield (0x7FF) and BMS parsers (0x132/292/312)
 │   ├── can_driver.cpp/h    — CAN driver abstraction (TWAI / MCP2515)
 │   ├── wifi_manager.cpp/h  — WiFi AP setup
 │   ├── web_dashboard.cpp/h — HTTP server + WebSocket + embedded UI
+│   │                           5 tabs: Dashboard / Controls / CAN Bus / BMS / Device
 │   ├── nvs_settings.cpp/h  — NVS persistence for toggle settings
 │   ├── led.cpp/h           — NeoPixel LED status control
 │   └── config.h            — CAN IDs, pin definitions, timing constants


### PR DESCRIPTION
## feat(esp32): NVS persistence, BMS monitor, BAN Shield, WiFi credentials & web dashboard overhaul

Two commits on top of upstream `ed05003`.

### feat(nvs): NVS persistence for user toggle settings (`a4762d9`)

- New `nvs_settings.cpp/h` — loads and saves all user toggles to flash (survives reboot)
- Persisted settings: NAG Killer, speed chime suppress, Force FSD, TLSSC Restore, Auto-Activate on Wake, Emergency Vehicle Detect
- Refactored `main.cpp` to load NVS on boot and propagate values to `fsd_handler`
- CAN driver abstraction improvements (`can_driver.cpp/h`)
- README updated to document persisted settings table and new dashboard tabs

### feat: BMS monitor, BAN Shield, WiFi credentials, web dashboard overhaul (`14aab94`)

- **BMS Monitor** — passive sniffing of `0x132` / `0x292` / `0x312` (pack voltage, current, SoC, temps); enable/disable toggle
- **BAN Shield** — `0x7FF` GTW_carConfig_ETH snapshot-based ban-push blocker; enabled by default
- **WiFi credentials** — SSID and password now configurable and persisted to NVS (no recompile needed)
- **Web dashboard** — new BMS tab, WiFi settings tab, updated Controls tab with new toggles
- `fsd_inject_enabled` and `ban_shield` state variables added to NVS schema
- README updated to reflect feature statuses (Force FSD, BAN Shield, BMS Monitor all flagged ⚠️ UNTESTED — feedback welcome)

### Notes

- No changes to core FSD/NAG/TLSSC CAN logic
- BAN Shield and BMS Monitor are implemented but **not yet validated on a real vehicle** — reports welcome
- Force FSD flag corrected from ✅ Tested → ⚠️ UNTESTED in docs