### PR TITLE
Rename "Ban Shield" → "GTW Config Replay"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Flipper target](https://img.shields.io/badge/Flipper%20target-7%20%2F%20API%2087.1-orange?style=flat-square)](https://github.com/flipperdevices/flipperzero-firmware)
 [![Tracked on FSD CAN Mod Hub](https://img.shields.io/badge/tracked%20on-FSD%20CAN%20Mod%20Hub-orange?style=flat-square)](https://fsdcanmod.com/project/hypery11-flipper-zero)
 
-> **Open-source Tesla CAN bus toolkit for Flipper Zero and ESP32.** FSD region-gate bypass, TLSSC Restore for VIN-banned cars, nag killer with organic torque variation, Ban Shield, live BMS dashboard, and 30+ CAN handlers across Model 3, Model Y, Model S, and Model X. Supports HW3, HW4, and Legacy HW1/HW2. Free alternative to the $200+ S3XY Commander — total cost from **$14** with the [ESP32 port](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32).
+> **Open-source Tesla CAN bus toolkit for Flipper Zero and ESP32.** FSD region-gate bypass, TLSSC Restore for VIN-banned cars, nag killer with organic torque variation, GTW Config Replay, live BMS dashboard, and 30+ CAN handlers across Model 3, Model Y, Model S, and Model X. Supports HW3, HW4, and Legacy HW1/HW2. Free alternative to the $200+ S3XY Commander — total cost from **$14** with the [ESP32 port](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32).
 
 > [!IMPORTANT]
 > **An active FSD package is required for FSD features** — either purchased or subscribed. This tool enables FSD functionality at the CAN bus level, but the vehicle still needs a valid FSD entitlement from Tesla. Non-FSD features (nag killer, BMS dashboard, diagnostics) work without any subscription.
@@ -61,10 +61,11 @@
 - Does NOT restore full FSD visualization — only TLSSC (stop signs / traffic lights)
 - **Recommended banned-car combination**: enable **TLSSC Restore** + **TLSSC bit38** (`0x3FD` mux 0 bit 38) together — confirmed reliable on HW3 / 2026.2.6 by @RoyRakete ([#18](https://github.com/hypery11/flipper-tesla-fsd/issues/18#issuecomment-4413430516)). Either toggle alone is unreliable on some banned firmware; the pair re-enables AP/TACC engagement
 
-### Ban Shield (v2.9+)
-- Watches `GTW_carConfig` (`0x7FF`) and rewrites the bus broadcast back to its learned-healthy pattern in real time
+### GTW Config Replay (v2.9+, renamed from "Ban Shield" in v2.15)
+- Watches `GTW_carConfig` (`0x7FF`) and replays the learned-healthy bus broadcast in real time when the gateway emits a modified frame
 - Learns all 8 mux frames on first run, then auto-arms
-- **Important caveat:** this is a **CAN-broadcast-layer mask**, not entitlement-layer protection. Tesla's ban writes to GTW NVRAM (which survives reboots) and to server-side flags; Ban Shield only rewrites what other on-bus ECUs see, not the underlying NVRAM state or Tesla's backend record. No empirical case where Ban Shield prevented a ban has been confirmed — it is a defense-in-depth measure based on attack-surface analysis. See [#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60) for the full honest writeup
+- **What it actually does:** broadcast-layer mask only. When armed, the AP ECU sees the replayed healthy frame instead of the gateway's modified one. Tesla's ban writes to GTW NVRAM (which survives reboots) and to server-side flags; this feature does not undo NVRAM state or backend records, only what other on-bus ECUs see in real time.
+- **What it doesn't do:** prevent bans, undo bans, or change Tesla's server-side entitlement record. No empirical case of ban prevention has been confirmed in 6 weeks of v2.9-v2.14 deployment. Honest framing per [#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60) and [#67](https://github.com/hypery11/flipper-tesla-fsd/issues/67). The v2.14 name "Ban Shield" overpromised — the v2.15 rename reflects what the code actually does.
 
 ### Nag Killer (v2.1+)
 - DAS-aware gating — only echoes when DAS is actually demanding hands-on, zero bus traffic when DAS is satisfied
@@ -75,7 +76,7 @@
 ### AP-First mode (v2.14+, for 2026.14.x firmware)
 - Tesla 2026.14.x added a preflight check that blocks AP/TACC engagement if CAN injection is already active
 - When **AP-First** is enabled, the app monitors `DAS_autopilotState` from `0x39B` and only starts injecting `0x3FD` after AP is engaged. On ESP32, the DAS status source follows detected HW version.
-- Nag killer, TLSSC Restore, and Ban Shield are unaffected (they target different CAN IDs)
+- Nag killer, TLSSC Restore, and GTW Config Replay are unaffected (they target different CAN IDs)
 
 ### Diagnostics (read-only, no FSD required)
 - Live BMS dashboard: pack voltage, current, SoC, temperature range, **energy consumption (Wh/km)**
@@ -96,7 +97,7 @@
 | **Ignore OTA** | Allows CAN TX in Active mode even when `0x318` reports a Tesla OTA update in progress. Default is off. |
 | **TLSSC Restore** | 0x331 DAS config spoof to recover TLSSC on banned vehicles. Triggers MCU reboot. |
 | **AP-First (14.x)** | Delay 0x3FD injection until AP is engaged. Required for Tesla firmware 2026.14.x. |
-| **Ban Shield** | Rewrite `GTW_carConfig` (0x7FF) broadcasts back to a learned-healthy pattern. CAN-broadcast-layer mask only — does not undo NVRAM or backend-side ban flags. Defense-in-depth, no confirmed ban-prevention case ([#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60)). |
+| **GTW Config Replay** | Replay learned-healthy `GTW_carConfig` (0x7FF) broadcasts when the gateway emits modified frames. CAN-broadcast-layer mask only — does not undo NVRAM or backend-side ban flags, does not prevent bans. Renamed from "Ban Shield" in v2.15 ([#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60), [#67](https://github.com/hypery11/flipper-tesla-fsd/issues/67)). |
 | **Suppress Chime** | Kill the ISA speed warning chime (HW4 only, `0x399`). On ESP32 this is active only after HW4 detection; Legacy/HW3 use `0x399` as DAS status instead. |
 | **Emerg. Vehicle** | Enable emergency vehicle detection flag (HW4 only, bit59). |
 | **Precondition** | Battery preheat trigger via `0x082`. |
@@ -109,7 +110,7 @@
 | **Nav FSD Route** | `0x3F8` bits 13/48/49 | Enable nav-based FSD routing (EU/restricted regions) |
 | **TLSSC bit38** | `0x3FD` mux0 bit38 | Explicit TLSSC enable; pair with TLSSC Restore (0x331) as the recommended banned-car combo |
 | **Lane Graph** | `0x3FD` mux1 bit45 | UI_showLaneGraph — lane visualization on non-FSD tier |
-| **Tier Override** | `0x7FF` mux=2 | Force GTW_autopilot to SELF_DRIVING (more aggressive than Ban Shield) |
+| **Tier Override** | `0x7FF` mux=2 | Force GTW_autopilot to SELF_DRIVING (more aggressive than GTW Config Replay — actively writes rather than replays) |
 | **Dev Mode** | `0x3F8` bit5 | UI_dasDeveloper flag |
 | **Force LHD** | `0x3F8` bits 40-41 | UI_drivingSide signal override. **Empirically does not change FSD lane-side behavior** (tested on banned RHD HW3 / 2026.2.6 — values 0, 1, 2 all leave FSD on the LHD side; see [#66](https://github.com/hypery11/flipper-tesla-fsd/issues/66)). Likely a UI-only signal. **Slated for removal in v2.15** if no value-3 / DAS_settings counter-evidence surfaces |
 | **Hands-Off** | `0x3F8` bit14 | UI-level hands-on disable (second nag vector) |
@@ -255,7 +256,7 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 | `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route, hands-off, dev mode, LHD, telemetry (beta) |
 | `0x3EE` | `UI_autopilotControl` | TX | FSD unlock — Legacy HW1/HW2 |
 | `0x3C2` | `VCLEFT_switchStatus` | TX | ScrollPress AP — right-scroll injection on mux=1 (HW4, Service mode, beta) |
-| `0x7FF` | `GTW_carConfig` | TX | Ban Shield freeze + active tier override |
+| `0x7FF` | `GTW_carConfig` | TX | GTW Config Replay + active tier override |
 | `0x082` | `UI_tripPlanning` | TX | Battery preconditioning trigger |
 | `0x398` | `GTW_carConfig` | RX | HW version detection |
 | `0x318` | `GTW_carState` | RX | OTA detection (auto-suspend TX) |
@@ -279,7 +280,7 @@ No. Real-time frame modification. Unplug = back to stock.
 FSD features (TLSSC, traffic light/stop sign control) require the FSD entitlement from Tesla. Without it, the AP ECU has no neural network weights loaded. Non-FSD features (nag killer, BMS dashboard, speed chime suppress, diagnostics) work on any AP-capable car.
 
 **What about VIN-level bans?**
-Tesla has been banning VINs server-side since April 2026. The ban downgrades `GTW_autopilot` tier from SELF_DRIVING to ENHANCED and removes the TLSSC toggle. The **TLSSC Restore** feature (0x331) can recover stop sign/traffic light control on Palladium and HW4. See [issue #18](https://github.com/hypery11/flipper-tesla-fsd/issues/18) for the full research. The **Ban Shield** (0x7FF) can block ban pushes if the AP ECU reads 0x7FF from CAN.
+Tesla has been banning VINs server-side since April 2026. The ban downgrades `GTW_autopilot` tier from SELF_DRIVING to ENHANCED and removes the TLSSC toggle. The **TLSSC Restore** feature (0x331) can recover stop sign/traffic light control on Palladium and HW4. See [issue #18](https://github.com/hypery11/flipper-tesla-fsd/issues/18) for the full research. **GTW Config Replay** (0x7FF, formerly "Ban Shield") can replay the learned-healthy configuration in real time, but only at the CAN broadcast layer — it does not undo the underlying NVRAM or server-side state.
 
 **Flipper Zero vs ESP32 — which should I get?**
 ESP32 is cheaper ($14 vs $200+), has WiFi dashboard, NVS persistence, and deep sleep. Flipper is more portable and has a built-in screen. Both run the same CAN logic. If you don't already own a Flipper, get the ESP32.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,8 +87,9 @@ project's TX path can write to:
   Hands-Off (bit14), Dev Mode (bit5), Force LHD (bits 40-41),
   Telemetry Off (bit43); only when the corresponding Settings toggle
   is ON
-- `0x7FF` `GTW_carConfig` — retransmits the healthy snapshot when Ban
-  Shield detects a server-side change; only when Ban Shield is armed
+- `0x7FF` `GTW_carConfig` — replays the learned-healthy snapshot when
+  GTW Config Replay (formerly "Ban Shield") detects the gateway has
+  modified a frame; only when the feature is armed
 - `0x3C2` `VCLEFT_switchStatus` — on mux=1 frames, runs a time-based
   scroll-wheel engage gesture: holds `swcRightPressed` (bits 12-13)
   ~250 ms, emits `swcRightScrollTicks` up (bits 24-29) ~150 ms, holds

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -461,17 +461,21 @@ void fsd_handle_gtw_autopilot_tier(FSDState* state, const CANFRAME* frame) {
     state->gtw_autopilot_tier = (int8_t)((frame->buffer[5] >> 2) & 0x07);
 }
 
-// --- 0x7FF Shield (ban defense) ---
+// --- 0x7FF GTW Config Replay (formerly "Ban Shield") ---
 //
-// Phase 1 (shield NOT armed): learn the "healthy" 0x7FF state by
-// capturing each mux frame. Once all 8 muxes are seen, the snapshot
-// is complete and can be armed.
+// Phase 1 (NOT armed): learn the "healthy" 0x7FF state by capturing
+// each mux frame. Once all 8 muxes are seen, the snapshot is complete
+// and the replayer auto-arms.
 //
-// Phase 2 (shield armed): compare every incoming 0x7FF against the
-// snapshot. If ANY byte differs, overwrite the frame data with the
-// snapshot and return true — the caller retransmits immediately,
-// racing the Gateway's banned frame so the AP ECU sees our healthy
+// Phase 2 (armed): compare every incoming 0x7FF against the snapshot.
+// If ANY byte differs, replay the snapshot bytes into the frame and
+// return true — the caller retransmits immediately, racing the
+// gateway's modified frame so the AP ECU sees the learned-healthy
 // version.
+//
+// This is a CAN-broadcast-layer mask only. It does not undo NVRAM
+// changes the gateway has already written, nor any backend-side
+// entitlement flags. Honest framing per #60.
 
 bool fsd_handle_gtw_shield(FSDState* state, CANFRAME* frame) {
     if(frame->data_lenght < 8) return false;
@@ -518,7 +522,8 @@ bool fsd_handle_gtw_shield(FSDState* state, CANFRAME* frame) {
 
 // --- 0x7FF Active Tier Override ---
 // Force GTW_autopilot to SELF_DRIVING (3) on every mux=2 frame.
-// More aggressive than Ban Shield — doesn't just freeze, actively writes.
+// More aggressive than GTW Config Replay — doesn't just replay learned state,
+// actively writes tier=3 regardless of what the gateway broadcasts.
 // Source: Shayennn/FUCKYOU-TESLA-FSD vehicle_logic.h
 
 bool fsd_handle_gtw_tier_override(FSDState* state, CANFRAME* frame) {

--- a/fsd_logic/fsd_handler.h
+++ b/fsd_logic/fsd_handler.h
@@ -141,15 +141,15 @@ typedef struct {
     // Source: ev-open-can-tools readGTWAutopilot()
     int8_t gtw_autopilot_tier;   // -1 = not yet read
 
-    // --- 0x7FF shield (ban defense) ---
-    // Snapshots of all 8 GTW_carConfig mux frames in "healthy" state.
-    // When shield is armed: any incoming 0x7FF that differs from snapshot
-    // is immediately retransmitted with the snapshot data, blocking
-    // server-side ban pushes at the CAN layer.
+    // --- 0x7FF GTW Config Replay (formerly "Ban Shield") ---
+    // Snapshots of all 8 GTW_carConfig mux frames in their learned-healthy
+    // state. When armed: any incoming 0x7FF byte that differs from the
+    // snapshot is replayed with the snapshot value, racing the gateway's
+    // modified frame at the CAN layer.
     uint8_t gtw_snapshot[8][8];  // [mux][byte0..7], 64 bytes total
     bool gtw_snapshot_valid[8];  // per-mux: has this mux been captured?
-    bool gtw_shield_armed;       // true = actively blocking changes
-    uint32_t gtw_shield_blocks;  // counter: how many frames we've blocked
+    bool gtw_shield_armed;       // true = actively replaying changes
+    uint32_t gtw_shield_blocks;  // counter: how many frames we've replayed
 
     // --- upstream feature flags ---
     bool enhanced_autopilot;     // when true, mux=1 also sets bit46 (EAP/summon)
@@ -326,17 +326,18 @@ void fsd_handle_das_settings(FSDState* state, const CANFRAME* frame);
  *  Source: ev-open-can-tools readGTWAutopilot(). */
 void fsd_handle_gtw_autopilot_tier(FSDState* state, const CANFRAME* frame);
 
-/** 0x7FF shield — snapshot healthy state and block changes.
- *  Call on every 0x7FF frame. When shield is not armed, captures the
- *  current frame as the "healthy" snapshot. When armed, compares
+/** 0x7FF GTW Config Replay — snapshot learned-healthy state and replay
+ *  any gateway-modified frames. Call on every 0x7FF frame. When not armed,
+ *  captures the current frame as a "healthy" snapshot. When armed, compares
  *  incoming frame against snapshot and returns true if the frame was
- *  modified (caller should retransmit the modified frame to override
- *  the Gateway's banned version). */
+ *  modified (caller should retransmit so the AP ECU sees the replayed
+ *  version rather than the gateway's). Renamed from "Ban Shield" in v2.15
+ *  to reflect actual behavior — broadcast-layer mask, not ban prevention. */
 bool fsd_handle_gtw_shield(FSDState* state, CANFRAME* frame);
 
 /** Modify 0x7FF mux=2 to force GTW_autopilot tier=SELF_DRIVING (3).
- *  More aggressive than shield — actively writes tier instead of freezing.
- *  Returns true if frame was modified. */
+ *  More aggressive than GTW Config Replay — actively writes tier instead
+ *  of replaying learned state. Returns true if frame was modified. */
 bool fsd_handle_gtw_tier_override(FSDState* state, CANFRAME* frame);
 
 /** Modify 0x3F8 UI_driverAssistControl with region/nav/hands-off overrides.

--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -119,7 +119,7 @@ static int32_t fsd_running_worker(void* context) {
     state.extra_highbeam_strobe = app->extra_highbeam_strobe;
     state.extra_turn_left = app->extra_turn_left;
     state.extra_turn_right = app->extra_turn_right;
-    // Ban Shield: don't arm immediately — learn healthy state first.
+    // GTW Config Replay: don't arm immediately — learn healthy state first.
     // gtw_shield_armed starts false; fsd_handle_gtw_shield() auto-arms
     // after all 8 mux snapshots are captured.
     bool shield_enabled = app->gtw_shield;
@@ -303,9 +303,9 @@ static int32_t fsd_running_worker(void* context) {
                 }
                 else if(frame.canId == CAN_ID_GTW_CONFIG_ETH) {
                     fsd_handle_gtw_autopilot_tier(&state, &frame);
-                    // Shield and tier override are mutually exclusive on the
-                    // same frame — shield freezes existing state, override
-                    // forces tier=3. Don't send two conflicting copies.
+                    // GTW Config Replay and Tier Override are mutually exclusive
+                    // on the same frame — replay re-emits the learned healthy state,
+                    // override forces tier=3. Don't send two conflicting copies.
                     if(shield_enabled) {
                         if(fsd_handle_gtw_shield(&state, &frame) && tx_allowed) {
                             send_can_frame(mcp, &frame);

--- a/scenes/settings.c
+++ b/scenes/settings.c
@@ -161,7 +161,7 @@ void tesla_fsd_scene_settings_on_enter(void* context) {
     ADD_TOGGLE("Force FSD",        force_fsd_changed,        force_fsd)
     ADD_TOGGLE("TLSSC Restore",    tlssc_restore_changed,    tlssc_restore)
     ADD_TOGGLE("AP-First (14.x)",  ap_first_changed,         ap_first)
-    ADD_TOGGLE("Ban Shield",       shield_changed,           gtw_shield)
+    ADD_TOGGLE("GTW Cfg Replay",   shield_changed,           gtw_shield)
     ADD_TOGGLE("Suppress Chime",   chime_changed,            suppress_speed_chime)
     ADD_TOGGLE("Emerg. Vehicle",   emerg_changed,            emergency_vehicle_detect)
     ADD_TOGGLE("Precondition",     precondition_changed,     precondition)

--- a/tesla_fsd_app.h
+++ b/tesla_fsd_app.h
@@ -67,7 +67,7 @@ typedef struct {
     bool precondition;       // periodic 0x082 inject for battery preheat
     OpMode op_mode;          // Active / ListenOnly / Service
     uint8_t mcp_clock;       // 0 = 16MHz (default), 1 = 8MHz
-    bool gtw_shield;         // 0x7FF ban defense shield
+    bool gtw_shield;         // 0x7FF GTW Config Replay — replay learned-healthy frames
     bool tlssc_restore;      // 0x331 DAS config spoof to restore TLSSC
     bool ap_first;           // 2026.14.x: delay injection until AP is engaged
     bool gtw_tier_override;  // 0x7FF active tier=SELF_DRIVING override


### PR DESCRIPTION
## Summary

Renames the "Ban Shield" feature to "GTW Config Replay" everywhere user-facing. The old name overpromised — the feature is a CAN-broadcast-layer mask that replays a learned-healthy `GTW_carConfig (0x7FF)` snapshot when the gateway emits modified frames. It does **not** undo NVRAM, undo backend records, or prevent bans. In six weeks of v2.9-v2.14 deployment, no empirical ban-prevention case has been confirmed (#60, #67). The vote deadline (2026-05-22) passed with no counter-evidence. Renaming to match what the code actually does.

Landing this ahead of v2.15 per [#67 discussion](https://github.com/hypery11/flipper-tesla-fsd/issues/67#issuecomment-4556863598) so the rename can ship without waiting on the full v2.15 feature set.

## Scope

| Change | Where |
|---|---|
| Menu label: `"Ban Shield"` → `"GTW Cfg Replay"` | `scenes/settings.c` (abbreviated to fit 14-char menu budget) |
| Section heading + description rewrite | `README.md` Ban Shield section |
| Feature table row + Tier Override description | `README.md` Settings tables |
| TX/RX CAN ID table + ban writeup | `README.md` |
| Mention in active write list | `SECURITY.md` |
| Block comment rewrite | `fsd_logic/fsd_handler.c` (`fsd_handle_gtw_shield` doc) |
| Tier override `// More aggressive than...` comment | `fsd_logic/fsd_handler.c` |
| Struct field comments + function decl docstring | `fsd_logic/fsd_handler.h` |
| Comment headers in scene loop | `scenes/fsd_running.c` |
| `gtw_shield` flag comment | `tesla_fsd_app.h` |

## Not changed

- **Internal field/function names** (`gtw_shield_armed`, `gtw_shield_blocks`, `fsd_handle_gtw_shield`, `app->gtw_shield`) — preserved for NVS migration safety. The `gtw_*` prefix was already semi-accurate and renaming internal symbols would invalidate persisted toggle state across the v2.14 → v2.15 upgrade for thousands of users.
- **`changelog.md` historical entries** (v2.9, v2.12, v2.14) — point-in-time release notes, not retconned. v2.15 changelog entry will note the rename at release.
- **`README_zh-CN.md` / `README_zh-TW.md`** — already stale with disclaimer, do not contain Ban Shield content. Will be refreshed together with the next translation sync, not piecemeal.

## Test plan

- [ ] Flipper Zero: settings menu shows "GTW Cfg Replay" instead of "Ban Shield"; toggle still saves and persists across reboots
- [ ] Toggle behavior unchanged — sampling phase still captures 8 mux snapshots, armed phase still replays modified frames
- [ ] `gtw_shield_blocks` counter still increments correctly
- [ ] Mutual exclusivity with Tier Override still holds (verified by reading `scenes/fsd_running.c` lines 302-311)

## Discoverability

All renamed sections include "(formerly Ban Shield)" parenthetical so users searching the old name still land on the right docs/code.

Closes part of #67.