### PR TITLE
feat(0x3C2): Scroll-Press AP Engage — first 2026.14.x bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@
 
 | Setting | CAN ID | Description |
 |---------|--------|-------------|
-| **ScrollPress AP** | `0x3C2` mux=1, bits 12-13 | **HW4-only, Service mode only.** Injects the right-scrollwheel-down sequence (`swcRightPressed` = 1, 2, 2, 1) when `DAS_autopilotState` rises 0→1, engaging AP via the chassis sidechannel instead of touching `0x3FD`. First known 2026.14.x bypass — works on Highland HW4 / 2026.14.2 per @JakNo's bench testing in [#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43). HW3 disabled in v2.15 after @DmitroPanteliuk reported emergency-brake event on Intel HW3 2026.14.6 |
+| **ScrollPress AP** | `0x3C2` mux=1 | **HW4-only, Service mode only.** Engages AP via a time-based, human-like scroll-wheel gesture (press ~250ms → scroll-up ~150ms → press ~250ms → scroll-up) on `swcRightPressed` (bits 12-13) + `swcRightScrollTicks` (bits 24-29), fired when `DAS_autopilotState` rises 0→1 — no `0x3FD` touch. First known 2026.14.x bypass; discovered + bench-verified on Highland HW4 / 2026.14.2 by @JakNo ([#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43), timed flow [#82](https://github.com/hypery11/flipper-tesla-fsd/pull/82)). HW3 disabled in v2.15 after @DmitroPanteliuk's emergency-brake report on Intel HW3 2026.14.6 |
 | **Nav FSD Route** | `0x3F8` bits 13/48/49 | Enable nav-based FSD routing (EU/restricted regions) |
 | **TLSSC bit38** | `0x3FD` mux0 bit38 | Explicit TLSSC enable; pair with TLSSC Restore (0x331) as the recommended banned-car combo |
 | **Lane Graph** | `0x3FD` mux1 bit45 | UI_showLaneGraph — lane visualization on non-FSD tier |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 
 | Setting | CAN ID | Description |
 |---------|--------|-------------|
+| **ScrollPress AP** | `0x3C2` mux=1, bits 12-13 | **HW4-only, Service mode only.** Injects the right-scrollwheel-down sequence (`swcRightPressed` = 1, 2, 2, 1) when `DAS_autopilotState` rises 0→1, engaging AP via the chassis sidechannel instead of touching `0x3FD`. First known 2026.14.x bypass — works on Highland HW4 / 2026.14.2 per @JakNo's bench testing in [#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43). HW3 disabled in v2.15 after @DmitroPanteliuk reported emergency-brake event on Intel HW3 2026.14.6 |
 | **Nav FSD Route** | `0x3F8` bits 13/48/49 | Enable nav-based FSD routing (EU/restricted regions) |
 | **TLSSC bit38** | `0x3FD` mux0 bit38 | Explicit TLSSC enable; pair with TLSSC Restore (0x331) as the recommended banned-car combo |
 | **Lane Graph** | `0x3FD` mux1 bit45 | UI_showLaneGraph — lane visualization on non-FSD tier |
@@ -253,6 +254,7 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 | `0x3FD` | `UI_autopilotControl` | TX | FSD unlock — bit46/60 (HW3/HW4), TLSSC bit38, lane graph bit45 |
 | `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route, hands-off, dev mode, LHD, telemetry (beta) |
 | `0x3EE` | `UI_autopilotControl` | TX | FSD unlock — Legacy HW1/HW2 |
+| `0x3C2` | `VCLEFT_switchStatus` | TX | ScrollPress AP — right-scroll injection on mux=1 (HW4, Service mode, beta) |
 | `0x7FF` | `GTW_carConfig` | TX | Ban Shield freeze + active tier override |
 | `0x082` | `UI_tripPlanning` | TX | Battery preconditioning trigger |
 | `0x398` | `GTW_carConfig` | RX | HW version detection |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,12 +89,13 @@ project's TX path can write to:
   is ON
 - `0x7FF` `GTW_carConfig` — retransmits the healthy snapshot when Ban
   Shield detects a server-side change; only when Ban Shield is armed
-- `0x3C2` `VCLEFT_switchStatus` — overwrites the `swcRightPressed`
-  bit-pair (bits 12-13) on mux=1 frames with the 4-frame sequence
-  `1, 2, 2, 1` to simulate a right-scrollwheel press; only when the
-  ScrollPress AP setting is ON, op mode is Service, HW is detected
-  as HW4, and `DAS_autopilotState` has transitioned from UNAVAIL to
-  AVAIL since the last firing
+- `0x3C2` `VCLEFT_switchStatus` — on mux=1 frames, runs a time-based
+  scroll-wheel engage gesture: holds `swcRightPressed` (bits 12-13)
+  ~250 ms, emits `swcRightScrollTicks` up (bits 24-29) ~150 ms, holds
+  `swcRightPressed` ~250 ms, then one final scroll-up. Only when the
+  ScrollPress AP setting is ON, op mode is Service, HW is detected as
+  HW4, and `DAS_autopilotState` has transitioned from UNAVAIL to AVAIL
+  since the last firing. Does not write to `0x3FD`
 
 It does NOT write to:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,6 +89,12 @@ project's TX path can write to:
   is ON
 - `0x7FF` `GTW_carConfig` — retransmits the healthy snapshot when Ban
   Shield detects a server-side change; only when Ban Shield is armed
+- `0x3C2` `VCLEFT_switchStatus` — overwrites the `swcRightPressed`
+  bit-pair (bits 12-13) on mux=1 frames with the 4-frame sequence
+  `1, 2, 2, 1` to simulate a right-scrollwheel press; only when the
+  ScrollPress AP setting is ON, op mode is Service, HW is detected
+  as HW4, and `DAS_autopilotState` has transitioned from UNAVAIL to
+  AVAIL since the last firing
 
 It does NOT write to:
 

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -625,6 +625,75 @@ bool fsd_handle_track_mode_inject(FSDState* state, CANFRAME* frame) {
     return true;
 }
 
+// --- Scroll-Press AP Engage (0x3C2, HW4-only) ---
+//
+// Per @JakNo's bench testing in #43: injecting the right-scrollwheel-down
+// sequence on VCLEFT_switchStatus mux=1 engages AP and the car treats it as
+// indistinguishable from a physical scrollwheel press. No counter, no CRC —
+// just replace the swcRightPressed bit-pair in 4 consecutive mux=1 frames.
+//
+// State machine across 0x3C2 mux=1 frames:
+//   state=0, armed=false  : initial; wait for das_ap_state==0 before arming
+//   state=0, armed=true   : armed; will fire when das_ap_state transitions to 1
+//   state=1..4            : actively firing frame N of the sequence
+//   state=5               : cooldown; wait for das_ap_state==0 before re-arming
+//
+// Sequence: swcRightPressed = 1, 2, 2, 1 across 4 consecutive frames.
+// Field is bits 12-13 of the 64-bit frame = byte 1 bits 4-5.
+
+bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame) {
+    if(!state->scroll_press_ap) return false;
+    if(state->hw_version != TeslaHW_HW4) return false;     // HW4-only per v2.15 scope
+    if(state->op_mode != OpMode_Service) return false;     // Service mode safety gate
+    if(frame->data_lenght < 2) return false;
+
+    // VCLEFT_switchStatusIndex (mux) at byte 0 bits 0-1. Right-scroll lives on mux=1.
+    uint8_t mux = frame->buffer[0] & 0x03;
+    if(mux != 1) return false;
+
+    uint8_t ap = state->das_ap_state;
+
+    // Arm tracking: require a UNAVAIL observation before any fire, then before each re-fire.
+    if(ap == 0) {
+        state->scroll_press_armed = true;
+        if(state->scroll_press_state == 5) {
+            state->scroll_press_state = 0; // cleared cooldown
+        }
+    }
+
+    // Rising-edge fire trigger: 0→1 transition while armed.
+    if(state->scroll_press_state == 0 && state->scroll_press_armed && ap == 1) {
+        state->scroll_press_state = 1;
+        state->scroll_press_armed = false;
+    }
+
+    if(state->scroll_press_state < 1 || state->scroll_press_state > 4) {
+        return false;
+    }
+
+    // Emit sequence frame
+    uint8_t value;
+    switch(state->scroll_press_state) {
+    case 1: value = 1; break;
+    case 2: value = 2; break;
+    case 3: value = 2; break;
+    case 4: value = 1; break;
+    default: return false;
+    }
+
+    // swcRightPressed = byte 1 bits 4-5
+    frame->buffer[1] = (frame->buffer[1] & ~0x30u) | ((value & 0x03) << 4);
+
+    if(state->scroll_press_state >= 4) {
+        state->scroll_press_state = 5; // enter cooldown until AP drops
+    } else {
+        state->scroll_press_state++;
+    }
+
+    state->frames_modified++;
+    return true;
+}
+
 // --- SCCM_leftStalk (0x249) builders — Party CAN, 3 bytes ---
 // Frame layout:
 //   byte0: CRC = (0x49 + 0x02 + byte1 + byte2) & 0xFF

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -641,11 +641,29 @@ bool fsd_handle_track_mode_inject(FSDState* state, CANFRAME* frame) {
 // Sequence: swcRightPressed = 1, 2, 2, 1 across 4 consecutive frames.
 // Field is bits 12-13 of the 64-bit frame = byte 1 bits 4-5.
 
-bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame) {
+// VCLEFT_switchStatus mux=1 signal positions (opendbc tesla_model3_vehicle.dbc):
+//   swcRightPressed    : startbit 12, 2 bits  → byte 1 bits 4-5
+//   swcRightScrollTicks: startbit 24, 6 bits signed → byte 3 bits 0-5
+#define SCROLL_SWC_PRESSED_PRESSED   1u   // "pressed" value (per @JakNo bench; pending re-confirm)
+#define SCROLL_SWC_SCROLLTICKS_UP    1u   // one detent up; 6-bit signed (+1). Direction pending @JakNo confirm
+// Phase durations per @JakNo's #82 flow (milliseconds, approximate — tune on-car)
+#define SCROLL_T_PRESS1_MS  250u
+#define SCROLL_T_SCROLL1_MS 150u
+#define SCROLL_T_PRESS2_MS  250u
+
+static void scroll_set_pressed(CANFRAME* frame, uint8_t v) {
+    frame->buffer[1] = (frame->buffer[1] & ~0x30u) | ((v & 0x03u) << 4);
+}
+
+static void scroll_set_scrollticks(CANFRAME* frame, uint8_t v) {
+    frame->buffer[3] = (frame->buffer[3] & ~0x3Fu) | (v & 0x3Fu);
+}
+
+bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame, uint32_t now_ms) {
     if(!state->scroll_press_ap) return false;
     if(state->hw_version != TeslaHW_HW4) return false;     // HW4-only per v2.15 scope
     if(state->op_mode != OpMode_Service) return false;     // Service mode safety gate
-    if(frame->data_lenght < 2) return false;
+    if(frame->data_lenght < 4) return false;               // need byte 3 for scrollTicks
 
     // VCLEFT_switchStatusIndex (mux) at byte 0 bits 0-1. Right-scroll lives on mux=1.
     uint8_t mux = frame->buffer[0] & 0x03;
@@ -657,41 +675,60 @@ bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame) {
     if(ap == 0) {
         state->scroll_press_armed = true;
         if(state->scroll_press_state == 5) {
-            state->scroll_press_state = 0; // cleared cooldown
+            state->scroll_press_state = 0; // cooldown cleared, ready to re-arm
         }
     }
 
-    // Rising-edge fire trigger: 0→1 transition while armed.
+    // Rising-edge fire trigger: AP UNAVAIL(0)→AVAIL(1) while armed.
     if(state->scroll_press_state == 0 && state->scroll_press_armed && ap == 1) {
-        state->scroll_press_state = 1;
+        state->scroll_press_state = 1;          // enter phase 1 (press1)
         state->scroll_press_armed = false;
+        state->scroll_press_phase_ms = now_ms;
     }
 
     if(state->scroll_press_state < 1 || state->scroll_press_state > 4) {
         return false;
     }
 
-    // Emit sequence frame
-    uint8_t value;
+    uint32_t elapsed = now_ms - state->scroll_press_phase_ms;
+    bool modified = false;
+
     switch(state->scroll_press_state) {
-    case 1: value = 1; break;
-    case 2: value = 2; break;
-    case 3: value = 2; break;
-    case 4: value = 1; break;
-    default: return false;
+    case 1: // 1st press, hold for ~250 ms
+        scroll_set_pressed(frame, SCROLL_SWC_PRESSED_PRESSED);
+        modified = true;
+        if(elapsed >= SCROLL_T_PRESS1_MS) {
+            state->scroll_press_state = 2;
+            state->scroll_press_phase_ms = now_ms;
+        }
+        break;
+    case 2: // scroll up, hold for ~150 ms
+        scroll_set_scrollticks(frame, SCROLL_SWC_SCROLLTICKS_UP);
+        modified = true;
+        if(elapsed >= SCROLL_T_SCROLL1_MS) {
+            state->scroll_press_state = 3;
+            state->scroll_press_phase_ms = now_ms;
+        }
+        break;
+    case 3: // 2nd press, hold for ~250 ms
+        scroll_set_pressed(frame, SCROLL_SWC_PRESSED_PRESSED);
+        modified = true;
+        if(elapsed >= SCROLL_T_PRESS2_MS) {
+            state->scroll_press_state = 4;
+            state->scroll_press_phase_ms = now_ms;
+        }
+        break;
+    case 4: // final scroll up, single frame, then cooldown
+        scroll_set_scrollticks(frame, SCROLL_SWC_SCROLLTICKS_UP);
+        modified = true;
+        state->scroll_press_state = 5; // cooldown until AP drops to UNAVAIL
+        break;
+    default:
+        return false;
     }
 
-    // swcRightPressed = byte 1 bits 4-5
-    frame->buffer[1] = (frame->buffer[1] & ~0x30u) | ((value & 0x03) << 4);
-
-    if(state->scroll_press_state >= 4) {
-        state->scroll_press_state = 5; // enter cooldown until AP drops
-    } else {
-        state->scroll_press_state++;
-    }
-
-    state->frames_modified++;
-    return true;
+    if(modified) state->frames_modified++;
+    return modified;
 }
 
 // --- SCCM_leftStalk (0x249) builders — Party CAN, 3 bytes ---

--- a/fsd_logic/fsd_handler.h
+++ b/fsd_logic/fsd_handler.h
@@ -43,6 +43,7 @@
 #define CAN_ID_APS_EACMON    0x27D  // 637  - APS_eacMonitor (steering permission — Party CAN)
 #define CAN_ID_ENERGY_CONS   0x33A  // 826  - UI_ratedConsumption (energy Wh/km — Party CAN)
 #define CAN_ID_DRIVER_ASSIST 0x3F8  // 1016 - UI_driverAssistControl (also follow distance — Party CAN)
+#define CAN_ID_VCLEFT_SWITCH 0x3C2  // 962  - VCLEFT_switchStatus (steering-wheel scrollwheel buttons — Vehicle CAN)
 
 typedef enum {
     TeslaHW_Unknown = 0,
@@ -103,6 +104,16 @@ typedef struct {
     // --- AP-first mode (2026.14.x compatibility) ---
     bool ap_first;               // delay 0x3FD injection until AP is engaged
     uint8_t das_ap_state;        // DAS_autopilotState: 0=UNAVAIL 1=AVAIL 2=ACTIVE_NOMINAL 3+=active
+
+    // --- Scroll-Press AP Engage (0x3C2 VCLEFT_switchStatus, HW4-only, Service mode) ---
+    // Injects the right-scrollwheel-down sequence (swcRightPressed 1→2→2→1 across
+    // 4 consecutive mux=1 frames) when DAS_autopilotState transitions from UNAVAIL
+    // to AVAIL. Discovered + bench-verified on Highland HW4 / 2026.14.2 by @JakNo
+    // in #43 — first known sidechannel that engages AP without touching 0x3FD.
+    // Per #43 + HW3 negative test from @DmitroPanteliuk, restricted to HW4 in v2.15.
+    bool scroll_press_ap;        // user toggle
+    uint8_t scroll_press_state;  // 0=idle, 1..4=firing frame N, 5=cooldown (awaiting AP drop)
+    bool scroll_press_armed;     // true once we have observed das_ap_state==0 (required before first fire)
 
     // --- DAS state (from 0x39B / 0x389 — Party CAN, read-only) ---
     uint8_t das_hands_on_state;  // 0-15 (4-bit nag level from DAS, more precise than EPAS 2-bit)
@@ -331,6 +342,13 @@ void fsd_handle_energy_consumption(FSDState* state, const CANFRAME* frame);
  *  byte[0] bits 1:0 = 0x01 (kTrackModeRequestOn) + recalc checksum byte[7].
  *  Source: ev-open-can-tools setTrackModeRequest(). */
 bool fsd_handle_track_mode_inject(FSDState* state, CANFRAME* frame);
+
+/** Inject right-scrollwheel press on 0x3C2 mux=1 to engage AP via the chassis
+ *  sidechannel — no 0x3FD touch required. Fires the 4-frame sequence
+ *  swcRightPressed = 1, 2, 2, 1 (bits 12-13 of the 0x3C2 mux=1 frame) when
+ *  das_ap_state rises 0→1. HW4 + Service mode only. Returns true if frame
+ *  was modified (caller should retransmit). Source: @JakNo in #43. */
+bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame);
 
 /** Build a SCCM_leftStalk (0x249) frame for high beam strobe.
  *  SCCM_highBeamStalkStatus (bit12|2) = 1 (PULL) for flash.

--- a/fsd_logic/fsd_handler.h
+++ b/fsd_logic/fsd_handler.h
@@ -106,14 +106,23 @@ typedef struct {
     uint8_t das_ap_state;        // DAS_autopilotState: 0=UNAVAIL 1=AVAIL 2=ACTIVE_NOMINAL 3+=active
 
     // --- Scroll-Press AP Engage (0x3C2 VCLEFT_switchStatus, HW4-only, Service mode) ---
-    // Injects the right-scrollwheel-down sequence (swcRightPressed 1→2→2→1 across
-    // 4 consecutive mux=1 frames) when DAS_autopilotState transitions from UNAVAIL
-    // to AVAIL. Discovered + bench-verified on Highland HW4 / 2026.14.2 by @JakNo
-    // in #43 — first known sidechannel that engages AP without touching 0x3FD.
-    // Per #43 + HW3 negative test from @DmitroPanteliuk, restricted to HW4 in v2.15.
-    bool scroll_press_ap;        // user toggle
-    uint8_t scroll_press_state;  // 0=idle, 1..4=firing frame N, 5=cooldown (awaiting AP drop)
-    bool scroll_press_armed;     // true once we have observed das_ap_state==0 (required before first fire)
+    // Engages AP via the steering scroll wheel without touching 0x3FD — the first
+    // known sidechannel past 2026.14.x preflight enforcement. Discovered + bench-
+    // verified on Highland HW4 / 2026.14.2 by @JakNo (#43).
+    //
+    // Per @JakNo's #82 refinement, the injection is TIME-BASED to mimic a real
+    // human engage gesture (a single frame-burst is less convincing):
+    //   phase 1: hold swcRightPressed         for ~250 ms   (1st press)
+    //   phase 2: emit  swcRightScrollTicks up  for ~150 ms   (scroll up)
+    //   phase 3: hold swcRightPressed         for ~250 ms   (2nd press)
+    //   phase 4: emit  swcRightScrollTicks up  once          (final scroll up)
+    // Fires on a DAS_autopilotState rising edge UNAVAIL(0)→AVAIL(1); one cycle
+    // per engage, re-arms only after AP drops back to UNAVAIL.
+    // Restricted to HW4 in v2.15 (HW3 emergency-brake report from @DmitroPanteliuk, #43).
+    bool scroll_press_ap;            // user toggle
+    uint8_t scroll_press_state;      // 0=idle/armed-track, 1=press1, 2=scroll1, 3=press2, 4=scroll-final, 5=cooldown
+    bool scroll_press_armed;         // true once das_ap_state==0 observed (required before each fire)
+    uint32_t scroll_press_phase_ms;  // now_ms at the start of the current phase (timing reference)
 
     // --- DAS state (from 0x39B / 0x389 — Party CAN, read-only) ---
     uint8_t das_hands_on_state;  // 0-15 (4-bit nag level from DAS, more precise than EPAS 2-bit)
@@ -343,12 +352,13 @@ void fsd_handle_energy_consumption(FSDState* state, const CANFRAME* frame);
  *  Source: ev-open-can-tools setTrackModeRequest(). */
 bool fsd_handle_track_mode_inject(FSDState* state, CANFRAME* frame);
 
-/** Inject right-scrollwheel press on 0x3C2 mux=1 to engage AP via the chassis
- *  sidechannel — no 0x3FD touch required. Fires the 4-frame sequence
- *  swcRightPressed = 1, 2, 2, 1 (bits 12-13 of the 0x3C2 mux=1 frame) when
- *  das_ap_state rises 0→1. HW4 + Service mode only. Returns true if frame
- *  was modified (caller should retransmit). Source: @JakNo in #43. */
-bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame);
+/** Inject a human-like scroll-wheel AP engage gesture on 0x3C2 mux=1 — no 0x3FD
+ *  touch required. Time-based state machine (press / scroll-up / press / scroll-up)
+ *  per @JakNo's #82 design, fired on a das_ap_state UNAVAIL→AVAIL rising edge.
+ *  `now_ms` is a millisecond clock (Flipper passes furi_get_tick(), 1 kHz).
+ *  HW4 + Service mode only. Returns true if the frame was modified (caller
+ *  should retransmit). Source: @JakNo in #43 / #82. */
+bool fsd_handle_scroll_press_inject(FSDState* state, CANFRAME* frame, uint32_t now_ms);
 
 /** Build a SCCM_leftStalk (0x249) frame for high beam strobe.
  *  SCCM_highBeamStalkStatus (bit12|2) = 1 (PULL) for flash.

--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -130,6 +130,7 @@ static int32_t fsd_running_worker(void* context) {
     state.scroll_press_ap = app->scroll_press_ap;
     state.scroll_press_state = 0;
     state.scroll_press_armed = false;
+    state.scroll_press_phase_ms = 0;
     state.assist_nav_enable = app->assist_nav_enable;
     state.assist_hands_off = app->assist_hands_off;
     state.assist_dev_mode = app->assist_dev_mode;
@@ -387,7 +388,7 @@ static int32_t fsd_running_worker(void* context) {
                         send_can_frame(mcp, &frame);
                     }
                 } else if(frame.canId == CAN_ID_VCLEFT_SWITCH) {
-                    if(fsd_handle_scroll_press_inject(&state, &frame) && tx_allowed) {
+                    if(fsd_handle_scroll_press_inject(&state, &frame, now) && tx_allowed) {
                         send_can_frame(mcp, &frame);
                     }
                 }

--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -127,6 +127,9 @@ static int32_t fsd_running_worker(void* context) {
     state.tlssc_restore = app->tlssc_restore;
     state.ap_first = app->ap_first;
     state.gtw_tier_override = app->gtw_tier_override;
+    state.scroll_press_ap = app->scroll_press_ap;
+    state.scroll_press_state = 0;
+    state.scroll_press_armed = false;
     state.assist_nav_enable = app->assist_nav_enable;
     state.assist_hands_off = app->assist_hands_off;
     state.assist_dev_mode = app->assist_dev_mode;
@@ -381,6 +384,10 @@ static int32_t fsd_running_worker(void* context) {
                     }
                 } else if(frame.canId == CAN_ID_AP_CONTROL) {
                     if(fsd_handle_autopilot_frame(&state, &frame) && tx_allowed) {
+                        send_can_frame(mcp, &frame);
+                    }
+                } else if(frame.canId == CAN_ID_VCLEFT_SWITCH) {
+                    if(fsd_handle_scroll_press_inject(&state, &frame) && tx_allowed) {
                         send_can_frame(mcp, &frame);
                     }
                 }

--- a/scenes/settings.c
+++ b/scenes/settings.c
@@ -67,6 +67,13 @@ static void tier_override_changed(VariableItem* item) {
     app->gtw_tier_override = (idx == 1);
 }
 
+static void scroll_press_changed(VariableItem* item) {
+    TeslaFSDApp* app = variable_item_get_context(item);
+    uint8_t idx = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, toggle_text[idx]);
+    app->scroll_press_ap = (idx == 1);
+}
+
 static void nav_enable_changed(VariableItem* item) {
     TeslaFSDApp* app = variable_item_get_context(item);
     uint8_t idx = variable_item_get_current_value_index(item);
@@ -161,6 +168,7 @@ void tesla_fsd_scene_settings_on_enter(void* context) {
 
     // ── Beta features (report results in GitHub issues) ──
     variable_item_list_add(list, "-- Beta (report!) --", 0, NULL, NULL);
+    ADD_TOGGLE("ScrollPress AP",  scroll_press_changed,      scroll_press_ap)
     ADD_TOGGLE("Nav FSD Route",  nav_enable_changed,       assist_nav_enable)
     ADD_TOGGLE("TLSSC bit38",   tlssc_bit38_changed,      assist_tlssc_bit38)
     ADD_TOGGLE("Lane Graph",    lane_graph_changed,        assist_show_lane_graph)

--- a/tesla_fsd_app.h
+++ b/tesla_fsd_app.h
@@ -71,6 +71,7 @@ typedef struct {
     bool tlssc_restore;      // 0x331 DAS config spoof to restore TLSSC
     bool ap_first;           // 2026.14.x: delay injection until AP is engaged
     bool gtw_tier_override;  // 0x7FF active tier=SELF_DRIVING override
+    bool scroll_press_ap;    // 0x3C2 scroll-press AP engage (HW4-only, Service mode)
 
     // driver assist overrides (0x3F8 + 0x3FD)
     bool assist_nav_enable;      // nav-based FSD routing (EU/restricted)


### PR DESCRIPTION
## Summary

v2.15 flagship feature. Implements @JakNo's `0x3C2 VCLEFT_switchStatus` finding from #43 — injecting the right-scrollwheel-down sequence on mux=1 engages AP **without touching `0x3FD`**, which is the first known concrete bypass of Tesla's 2026.14.x preflight enforcement.

Verified by @JakNo on Highland HW4 / 2026.14.2:
- No counter, no checksum on `0x3C2`
- Sequence `swcRightPressed = 1, 2, 2, 1` (4 consecutive mux=1 frames) triggers a real AP engagement
- `DAS_autopilotState` reaches and **stays** at `ACTIVE_NOMINAL` — indistinguishable from a physical scrollwheel press
- No `Autopilot temporarily unavailable` warning observed post-injection

## ⚠️ Hardware prerequisite — read before testing

**`0x3C2` is NOT forwarded on X179 pin 13/14 (Bus 6).**
The most common ESP32 tap point — X179 pins 13/14 — is on Bus 6, which is a *selectively forwarded* subset of Vehicle CAN. `0x3C2` is not in the forwarded set. Testers on this tap will see ZERO `ScrollPress:` log messages and zero injection because the gateway never broadcasts the frame onto Bus 6 for the firmware to see.

To use this feature, tap one of:
- **X179 pin 9/10** — Vehicle CAN Bus 2 direct (full Vehicle CAN traffic). Confirmed by @JakNo to carry `0x3C2`.
- **OBD-II pins 6/14** — also Vehicle CAN. Confirmed by @JakNo as the verification tap.

Negative case confirmation: @jewelrylin tested PR #82 backports on X179 pin 13/14 and got the exact symptom predicted by the bus theory — full v2.15 stack running, but ScrollPress state machine never fires because the frame isn't visible. Full diagnostic in [#73 comment](https://github.com/hypery11/flipper-tesla-fsd/issues/73#issuecomment-4560326988).

Bus 6 limitation now documented in HARDWARE.md (commit `19d33c6`). A dual-CAN board variant (LILYGO T-2CAN) is slated as a v2.16 platformio env so a single device can hit both Bus 6 features (0x3FD/0x370/0x3F8/TLSSC) and direct Vehicle CAN (0x3C2).

## Design

| Concern | Decision |
|---|---|
| HW scope | **HW4-only in v2.15**. HW3 disabled after @DmitroPanteliuk reported emergency-brake event on Intel HW3 / 2026.14.6 ([#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43#issuecomment-4522759116)). Now that PR #92 has the proper HW3 0x399 DAS readback merged, HW3 retest is on the v2.16 path. |
| Mode gate | **Service mode required**. Matches existing pattern for high-risk inject features (Track Mode, Hazard, Wiper Off, Turn Signal). |
| Default | OFF |
| Trigger | Rising-edge `das_ap_state` 0→1 (UNAVAIL→AVAIL). Avoids fire-on-startup if AP is already active when toggle gets enabled. |
| Cooldown | Requires `das_ap_state==0` observation before re-arming — one fire per drive cycle. |
| Frame model | Frame-replacement (modify in-bus mux=1 frame, retransmit). Matches @JakNo's verified approach rather than blast-injection. |

## State machine

State variable `scroll_press_state` on each `0x3C2 mux=1` frame:

```
0, armed=false  → initial; waiting to observe UNAVAIL before any arm
0, armed=true   → armed; will fire when AP transitions to AVAIL
1..4            → actively firing frame N of the swcRightPressed sequence
5               → cooldown; waiting for AP to drop back to UNAVAIL
```

## Files changed

| File | Δ |
|---|---|
| `fsd_logic/fsd_handler.h` | +18 — `CAN_ID_VCLEFT_SWITCH`, FSDState fields, function decl |
| `fsd_logic/fsd_handler.c` | +69 — `fsd_handle_scroll_press_inject()` implementation |
| `tesla_fsd_app.h` | +1 — `bool scroll_press_ap` toggle |
| `scenes/settings.c` | +8 — `scroll_press_changed` callback + Beta menu entry |
| `scenes/fsd_running.c` | +7 — state copy + dispatch case for `0x3C2` |
| `README.md` | +1/-0 — Beta settings table + CAN IDs table |
| `SECURITY.md` | +6/-0 — explicit write disclosure |

## Test plan

- [x] Build: clean against ufbt SDK API 87.1 ✅ (verified locally)
- [ ] Toggle persists across reboot via existing NVS path
- [ ] Visible in Settings → Beta section, label "ScrollPress AP"
- [ ] On HW3-detected car: toggle is visible but handler short-circuits (HW gate)
- [ ] On HW4 + Service mode + correct bus tap: fires sequence when AP becomes available
- [ ] Cooldown holds — does not re-fire while AP stays active
- [ ] Re-fires after disengage + re-enable cycle

## Open questions for @JakNo

Two things would help validate the implementation matches what worked on your bench:

1. **Mux gate**: I'm gating on `byte 0 & 0x03 == 1` (lower 2 bits of byte 0 as the mux index). Does that match how you identified the mux=1 frames in your capture, or were you also checking the upper bits of byte 0?
2. **Send rate during sequence**: My implementation modifies the 4 consecutive mux=1 frames it sees (whatever the bus delivers them at). If your bench was injecting at a specific cadence rather than passively waiting for the gateway frame, the behavior may differ. Worth flagging if the sequence needs precise timing.

Either question can wait until v2.15 beta — happy to leave both as "test on real car" verification points.

## Refs

- Original discovery + bench verification: [#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43) (@JakNo)
- HW3 negative test (scope decision): [#43 comment from @DmitroPanteliuk](https://github.com/hypery11/flipper-tesla-fsd/issues/43#issuecomment-4522759116)
- Pre-Highland stalk variant (0x229 SCCM_rightStalk) deferred to v2.16: [#43 from @JakNo](https://github.com/hypery11/flipper-tesla-fsd/issues/43#issuecomment-4529411812)
- Bus 6 vs Bus 2 forwarding clarification with full diagnostic: [#73 from @jewelrylin](https://github.com/hypery11/flipper-tesla-fsd/issues/73#issuecomment-4560326988) + [pin 9/10 confirmation from @JakNo](https://github.com/hypery11/flipper-tesla-fsd/issues/73#issuecomment-4561121515)
- HARDWARE.md Bus 6 forwarded-subset note: commit `19d33c6`