### PR TITLE
feat(nag): on-demand grip pulse on nag-demand rising edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 ### Nag Killer (v2.1+)
 - DAS-aware gating — only echoes when DAS is actually demanding hands-on, zero bus traffic when DAS is satisfied
 - Organic torque variation — xorshift32 PRNG random walk in 1.00-2.40 Nm with grip pulse excursions to 3.10-3.30 Nm every 5-9 seconds
+- **On-demand grip pulse (v2.15+)** — when `handsOnLevel` rises into a nag-demand state (0 imminent / 3 escalated), an immediate grip pulse fires and the periodic schedule resets. Closes the 2-second yellow-escalation window that could open between scheduled pulses on v2.14 and earlier
 - EPAS counter+1 echo on `0x370` with level 0 (nag imminent) and level 3 (escalated alarm) suppression
 
 ### AP-First mode (v2.14+, for 2026.14.x firmware)

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -800,6 +800,19 @@ bool fsd_handle_nag_killer(FSDState* state, const CANFRAME* frame, CANFRAME* out
     uint8_t das = state->das_hands_on_state;
     if(das == 0 || das == 8) return false;
 
+    // On-demand grip pulse: fire an immediate excursion when handsOnLevel
+    // rises into a nag-demand state (0=imminent, 3=escalated). v2.14 only
+    // emitted grip pulses on a fixed 5-9 s schedule, which let the yellow
+    // 2-second escalation get there first when a nag arrived between pulses.
+    // Resets the periodic cooldown so we don't double-pulse.
+    // Source: @deftdawg variant tested on 2016 MX HW3 in #70.
+    bool demand_now = (hands_on == 0 || hands_on == 3);
+    if(demand_now && !state->nag_demand_active && nag_exc_frames == 0) {
+        nag_exc_frames = 3 + (nag_xorshift32() % 3);          // 3-5 frame pulse
+        nag_frames_until_exc = 125 + (nag_xorshift32() % 100); // reset 5-9 s cooldown
+    }
+    state->nag_demand_active = demand_now;
+
     // --- Organic torque variation ---
     // torsionBarTorque encoding: tRaw = (Nm + 20.5) / 0.01
     // d[2] lower nibble = tRaw >> 8, d[3] = tRaw & 0xFF

--- a/fsd_logic/fsd_handler.h
+++ b/fsd_logic/fsd_handler.h
@@ -70,6 +70,7 @@ typedef struct {
     bool emergency_vehicle_detect;
     bool nag_killer;           // CAN 880 counter echo method
     uint32_t nag_echo_count;
+    bool nag_demand_active;    // true while handsOnLevel == 0 or 3 — edge-detect source for on-demand grip pulse
 
     // operation mode + diagnostics
     OpMode op_mode;


### PR DESCRIPTION
## Summary

v2.15 nag-killer enhancement. Closes the 2-second yellow-escalation window that opened on v2.14 between scheduled grip pulses when a nag arrived mid-cooldown.

Per @deftdawg's variant tested on 2016 MX HW3 in [#70](https://github.com/hypery11/flipper-tesla-fsd/issues/70): detect rising edge of \`handsOnLevel\` into a nag-demand state (0 = imminent, 3 = escalated) and immediately fire a 3-5 frame grip pulse + reset the periodic cooldown.

## Behavior change

Before (v2.14):
- Grip pulses fire on a fixed 5-9 s schedule from PRNG cooldown
- When a nag arrives mid-cooldown, escalation reaches yellow before the next scheduled pulse

After (v2.15):
- Grip pulses still fire on the 5-9 s schedule as a baseline
- **Additionally**, a 3-5 frame grip pulse fires immediately when \`handsOnLevel\` rises into 0 or 3
- The scheduled-pulse cooldown resets after an on-demand fire to prevent double-pulsing
- Random-walk torque (1.00-2.40 Nm) between pulses is unchanged

## Implementation

Added \`nag_demand_active\` to FSDState as edge-detection latch. Inserted on-demand trigger logic in \`fsd_handle_nag_killer\` between the DAS-aware gating check and the torque computation:

\`\`\`c
bool demand_now = (hands_on == 0 || hands_on == 3);
if(demand_now && !state->nag_demand_active && nag_exc_frames == 0) {
    nag_exc_frames = 3 + (nag_xorshift32() % 3);
    nag_frames_until_exc = 125 + (nag_xorshift32() % 100);
}
state->nag_demand_active = demand_now;
\`\`\`

The \`!state->nag_demand_active\` guard ensures we only fire once per nag entry, not every frame while stuck at L0/L3.

## Files changed

| File | Δ |
|---|---|
| \`fsd_logic/fsd_handler.h\` | +1 — \`nag_demand_active\` field |
| \`fsd_logic/fsd_handler.c\` | +13 — on-demand pulse block in nag killer |
| \`README.md\` | +1 — Nag Killer section bullet |

## Why L2 is not in the demand-trigger set

Possible nag states from \`0x370\` byte 4 bits 6-7:
- L0 = nag imminent (countdown active) ← **trigger on rising edge**
- L1 = hands detected (deliberately skip — echoing on hands-detected is a fingerprint risk)
- L2 = transitional / \"marginal hands\" (undocumented; insufficient capture data)
- L3 = escalated alarm ← **trigger on rising edge**

L2 may correspond to a brief verification window. Adding L2 to the trigger could close more escalation windows but risks looking abnormal if Tesla's monitoring catches us pulsing during a moment they classify as \"hands marginally there.\" Slated as open investigation for v2.16 if @deftdawg or another tester can capture L1→L2 transitions on a banned car (low-risk capture, no behavior change required).

## Test plan

- [ ] Build: clean against ufbt SDK API 87.1 ✅ (verified locally)
- [ ] Unit: \`nag_demand_active\` transitions correctly on simulated frame sequences
- [ ] On-car: nag arrives → 3-5 frame pulse within 100 ms (vs ~5 s on v2.14)
- [ ] On-car: scheduled pulses still fire as baseline during long nag-free stretches
- [ ] On-car: yellow 2-second escalation no longer reached (the regression @deftdawg reported)

## Credit

Tester/integrator: @deftdawg.
Design source: third-party CAN device behavior observation (no specific author to credit, per @deftdawg's note in [#70](https://github.com/hypery11/flipper-tesla-fsd/issues/70#issuecomment-4519718951)).