### PR TITLE
feat(14x): firmware warning banner — Flipper + ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@
 - When **AP-First** is enabled, the app monitors `DAS_autopilotState` from `0x39B` and only starts injecting `0x3FD` after AP is engaged. On ESP32, the DAS status source follows detected HW version.
 - Nag killer, TLSSC Restore, and GTW Config Replay are unaffected (they target different CAN IDs)
 
+### 14.x firmware warning (v2.15+)
+- **Default ON.** Flipper running scene replaces the BMS / flags line with `!14.x: TX may stop AP` whenever the warning toggle is enabled. ESP32 web dashboard shows a dismissible yellow banner at the top.
+- Pessimistic default: most users on 14.x firmware don't know they're affected until autosteer disengages mid-drive. The warning reaches them before they enable any TX feature.
+- Opt-out via the **On 14.x?** Settings toggle (Flipper) or the **Dismiss** button on the banner (ESP32, persisted in NVS). Disable if you are sure you're on pre-14.x firmware.
+- Regional caveat: enforcement intensity varies by market. Some regions (markets without Tesla direct presence) appear to enforce less aggressively. See [#73](https://github.com/hypery11/flipper-tesla-fsd/issues/73) for the running 14.x tracker.
+
 ### Diagnostics (read-only, no FSD required)
 - Live BMS dashboard: pack voltage, current, SoC, temperature range, **energy consumption (Wh/km)**
 - Vehicle speed, steering angle, motor torque, brake state

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -57,6 +57,8 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->force_fsd            = false;
     state->china_mode           = false;
     state->bms_output           = false;
+    // 14.x warning default ON — most affected users don't know their firmware version
+    state->firmware_14x_warning = true;
 #if defined(BOARD_TTGO_DISPLAY)
     state->display_enabled      = true;
     state->display_brightness   = 50;

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -88,6 +88,13 @@ struct FSDState {
     bool           tlssc_restore;
     uint32_t       tlssc_restore_count;
 
+    // ── 2026.14.x firmware warning ───────────────────────────────────────────
+    // Default ON. When ON, the web dashboard shows a banner reminding the user
+    // that TX features (0x3FD bit46/60 inject) will immediately disable
+    // autosteer on 2026.14.x. Users on pre-14.x firmware can disable it.
+    // Persisted in NVS so the choice carries across deep sleep / reboot.
+    bool           firmware_14x_warning;
+
     // ── DAS status — nag killer gating ───────────────────────────────────────
     // Legacy/HW3 source: 0x399. HW4 source: 0x39B.
     // 0=NOT_REQD, 8=SUSPENDED — both mean DAS is satisfied, skip echo.

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -20,6 +20,7 @@ void prefs_load(FSDState *state) {
     state->precondition             = g_prefs.getBool("precond",false);
     state->emergency_vehicle_detect = g_prefs.getBool("emrg",   false);
     state->bms_output               = g_prefs.getBool("bms",    false);
+    state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
 #if defined(BOARD_TTGO_DISPLAY)
     state->display_enabled          = g_prefs.getBool("disp",   true);
     state->display_brightness       = g_prefs.getUChar("disp_br", 50);
@@ -60,6 +61,7 @@ void prefs_save(const FSDState *state) {
     g_prefs.putBool("precond",state->precondition);
     g_prefs.putBool("emrg",   state->emergency_vehicle_detect);
     g_prefs.putBool("bms",    state->bms_output);
+    g_prefs.putBool("14x",    state->firmware_14x_warning);
 #if defined(BOARD_TTGO_DISPLAY)
     g_prefs.putBool("disp",   state->display_enabled);
     g_prefs.putUChar("disp_br", state->display_brightness);

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -120,6 +120,17 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   animation:pulse 1s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.55}}
 
+/* ── 14.x firmware warning (static, non-animated) ── */
+.warn14x{display:none;background:rgba(252,196,25,.08);border:1px solid rgba(252,196,25,.45);
+  border-radius:12px;padding:10px 14px;margin-bottom:12px;color:#fcc419;font-size:.82em;
+  line-height:1.4;text-align:left}
+.warn14x .w-row{display:flex;justify-content:space-between;align-items:center;gap:12px}
+.warn14x .w-msg{flex:1}
+.warn14x .w-dismiss{background:transparent;border:1px solid rgba(252,196,25,.5);color:#fcc419;
+  padding:5px 10px;border-radius:6px;cursor:pointer;font-size:.8em;font-weight:600;
+  white-space:nowrap}
+.warn14x .w-dismiss:hover{background:rgba(252,196,25,.15)}
+
 /* ── Error banner ── */
 .err{display:none;color:var(--red);text-align:center;font-size:.78em;padding:8px;
   background:rgba(255,107,107,.07);border-radius:10px;margin-bottom:10px;
@@ -265,6 +276,20 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 
 <!-- OTA Warning -->
 <div id="otaBanner" class="ota">&#9888;&#xFE0F; OTA UPDATE IN PROGRESS &mdash; CAN TX SUSPENDED</div>
+
+<!-- 2026.14.x Firmware Warning -->
+<div id="warn14x" class="warn14x">
+  <div class="w-row">
+    <div class="w-msg">
+      <strong>&#9888;&#xFE0F; 2026.14.x firmware enforcement active.</strong>
+      Tesla added a preflight check in 2026.14.x that disables autosteer
+      the moment any CAN frame touches <code>0x3FD</code>. Listen-Only mode
+      is safe. Enable <strong>AP-First</strong> in settings to delay
+      injection until AP is engaged. Dismiss if you're on pre-14.x firmware.
+    </div>
+    <button class="w-dismiss" onclick="cmd('14x_warning',false)">Dismiss</button>
+  </div>
+</div>
 
 <!-- FSD Status -->
 <div class="card">
@@ -569,6 +594,10 @@ function upd(d){
     otaB.style.display=d.ota?'block':'none';
     if(d.ota) otaB.innerHTML=d.ignore_ota?'&#9888;&#xFE0F; OTA UPDATE IN PROGRESS &mdash; TX ALLOWED BY IGNORE OTA':'&#9888;&#xFE0F; OTA UPDATE IN PROGRESS &mdash; CAN TX SUSPENDED';
   }
+
+  // 14.x firmware warning banner
+  var w14x=document.getElementById('warn14x');
+  if(w14x) w14x.style.display=d.firmware_14x_warning?'block':'none';
 
   // Mode button
   var act=d.op_mode===1;
@@ -1096,6 +1125,7 @@ static String build_json() {
     j += "\"china_mode\":";    j += state.china_mode                   ? "true" : "false"; j += ',';
     j += "\"suppress_speed_chime\":"; j += state.suppress_speed_chime  ? "true" : "false"; j += ',';
     j += "\"tlssc_restore\":"; j += state.tlssc_restore                ? "true" : "false"; j += ',';
+    j += "\"firmware_14x_warning\":"; j += state.firmware_14x_warning  ? "true" : "false"; j += ',';
 #if defined(BOARD_TTGO_DISPLAY)
     j += "\"display_enabled\":"; j += state.display_enabled             ? "true" : "false"; j += ',';
     j += "\"display_brightness\":"; j += state.display_brightness;      j += ',';
@@ -1257,6 +1287,18 @@ static void ws_event(uint8_t num, WStype_t type,
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] TLSSC Restore: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"14x_warning\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->firmware_14x_warning = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] 14.x Warning: %s\n", enabled ? "ON" : "OFF");
             prefs_save(&saved);
         }
     } else if (strstr(buf, "\"force_fsd\"")) {

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -283,8 +283,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <div class="w-msg">
       <strong>&#9888;&#xFE0F; 2026.14.x firmware enforcement active.</strong>
       Tesla added a preflight check in 2026.14.x that disables autosteer
-      the moment any CAN frame touches <code>0x3FD</code>. Listen-Only mode
-      is safe. Enable <strong>AP-First</strong> in settings to delay
+      the moment any CAN frame touches <code>0x3FD</code>. Symptom on
+      the dash: <em>"Autopilot turning off"</em> appears within a second
+      of stalk engagement, then AP immediately disengages. Listen-Only
+      mode is safe. Enable <strong>AP-First</strong> in settings to delay
       injection until AP is engaged. Dismiss if you're on pre-14.x firmware.
     </div>
     <button class="w-dismiss" onclick="cmd('14x_warning',false)">Dismiss</button>

--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -72,9 +72,14 @@ static void fsd_update_display(TeslaFSDApp* app, uint32_t uptime_ms) {
     widget_add_string_element(
         app->widget, 2, 36, AlignLeft, AlignTop, FontSecondary, line3);
 
-    // Line 4: live BMS readout if we've seen any BMS frames, else feature flags
+    // Line 4: 14.x firmware warning takes priority, then BMS, then feature flags.
+    // 2026.14.x added an enforcement check that disables autosteer the moment any
+    // CAN injection touches 0x3FD. Warning is opt-out via the "On 14.x" toggle
+    // for users who know they're on pre-14.x firmware.
     char line4[48];
-    if(state.bms_seen) {
+    if(app->firmware_14x_warning) {
+        snprintf(line4, sizeof(line4), "!14.x: TX may stop AP");
+    } else if(state.bms_seen) {
         float kw = state.pack_voltage_v * state.pack_current_a / 1000.0f;
         snprintf(line4, sizeof(line4), "SoC:%.0f%% %.0fkW %d-%dC",
             (double)state.soc_percent, (double)kw,

--- a/scenes/settings.c
+++ b/scenes/settings.c
@@ -53,6 +53,13 @@ static void ap_first_changed(VariableItem* item) {
     app->ap_first = (idx == 1);
 }
 
+static void warning_14x_changed(VariableItem* item) {
+    TeslaFSDApp* app = variable_item_get_context(item);
+    uint8_t idx = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, toggle_text[idx]);
+    app->firmware_14x_warning = (idx == 1);
+}
+
 static void tlssc_restore_changed(VariableItem* item) {
     TeslaFSDApp* app = variable_item_get_context(item);
     uint8_t idx = variable_item_get_current_value_index(item);
@@ -161,6 +168,7 @@ void tesla_fsd_scene_settings_on_enter(void* context) {
     ADD_TOGGLE("Force FSD",        force_fsd_changed,        force_fsd)
     ADD_TOGGLE("TLSSC Restore",    tlssc_restore_changed,    tlssc_restore)
     ADD_TOGGLE("AP-First (14.x)",  ap_first_changed,         ap_first)
+    ADD_TOGGLE("On 14.x?",         warning_14x_changed,      firmware_14x_warning)
     ADD_TOGGLE("GTW Cfg Replay",   shield_changed,           gtw_shield)
     ADD_TOGGLE("Suppress Chime",   chime_changed,            suppress_speed_chime)
     ADD_TOGGLE("Emerg. Vehicle",   emerg_changed,            emergency_vehicle_detect)

--- a/tesla_fsd_app.c
+++ b/tesla_fsd_app.c
@@ -50,6 +50,10 @@ TeslaFSDApp* tesla_fsd_app_alloc(void) {
     app->emergency_vehicle_detect = false;
     app->nag_killer = false;
     app->precondition = false;
+    // 14.x firmware warning default ON (pessimistic) — most affected users don't
+    // know their firmware version, so the warning needs to reach them. Users who
+    // are sure they're on pre-14.x can disable it in Settings.
+    app->firmware_14x_warning = true;
     // First-boot default: Listen-Only. Forces the user to make an explicit
     // decision in Settings before any TX happens. Better for new users who
     // haven't read the README, and matches the safer default that the ESP32

--- a/tesla_fsd_app.h
+++ b/tesla_fsd_app.h
@@ -70,6 +70,7 @@ typedef struct {
     bool gtw_shield;         // 0x7FF GTW Config Replay — replay learned-healthy frames
     bool tlssc_restore;      // 0x331 DAS config spoof to restore TLSSC
     bool ap_first;           // 2026.14.x: delay injection until AP is engaged
+    bool firmware_14x_warning; // 2026.14.x: show TX-disables-AP warning in running scene (default ON, opt-out for pre-14.x users)
     bool gtw_tier_override;  // 0x7FF active tier=SELF_DRIVING override
     bool scroll_press_ap;    // 0x3C2 scroll-press AP engage (HW4-only, Service mode)
 


### PR DESCRIPTION
## Summary

v2.15 protection feature. Implements [#73](https://github.com/hypery11/flipper-tesla-fsd/issues/73) — a default-on warning that reaches 2026.14.x users **before** they enable any TX feature that would silently disable autosteer.

The core problem: most affected users discover the 2026.14.x enforcement only after their autosteer disengages mid-drive. The TLSSC bit46 / `0x3FD` injection path that worked through 2026.13.x is now actively detected. Listen-Only mode remains safe; AP-First mode (v2.14+) delays injection until AP is engaged, which works around the preflight check.

## Design

Per the design locked in #73:

- **Default ON** (pessimistic) — most affected users don't know their firmware version
- **Opt-out** via Settings toggle (Flipper) or Dismiss button (ESP32, persisted in NVS)
- **Regional caveat noted in copy** — enforcement intensity varies by market

## Flipper

- New \`firmware_14x_warning\` field in \`TeslaFSDApp\` (default true at alloc)
- "On 14.x?" toggle in Settings → Stable section, just below AP-First
- Running scene line 4 priority: **warning > BMS readout > extras flags**. When ON, line 4 shows \`!14.x: TX may stop AP\` instead of BMS / flags
- No NVS persistence — Flipper-side settings reset per-launch (matches existing pattern for all app toggles)

## ESP32

- \`firmware_14x_warning\` field in \`FSDState\`, defaults to true on init
- NVS persistence via \`prefs.cpp\` (\"14x\" key)
- Web dashboard banner div above the FSD Status card. Yellow color scheme (distinct from the red OTA banner). Static, non-animated. Body copy explains the enforcement, suggests AP-First or Listen-Only as the mitigations, and tells users on pre-14.x to dismiss.
- **Dismiss** button POSTs \`cmd:'14x_warning' value:false\`, which clears the flag and persists to NVS — survives reboot and deep sleep.

## Files changed

| File | Δ |
|---|---|
| \`tesla_fsd_app.h\` | +1 — \`firmware_14x_warning\` field |
| \`tesla_fsd_app.c\` | +4 — default-true init |
| \`scenes/settings.c\` | +8 — toggle + callback |
| \`scenes/fsd_running.c\` | +9/-2 — priority logic on line 4 |
| \`esp32/.firmware/fsd_handler.h\` | +7 — field + comment |
| \`esp32/.firmware/fsd_handler.cpp\` | +2 — init |
| \`esp32/.firmware/prefs.cpp\` | +2 — NVS save/load |
| \`esp32/.firmware/web_dashboard.cpp\` | +42 — CSS, HTML banner, JS show/hide, JSON state, POST handler |
| \`README.md\` | +6 — feature section under AP-First |

## Test plan

- [x] Flipper build clean (ufbt SDK API 87.1) — verified
- [x] ESP32 build clean (pio m5stack-atom env) — verified
- [ ] Flipper: Settings shows "On 14.x?" between "AP-First (14.x)" and "Ban Shield"; toggle off → warning text on running scene disappears
- [ ] Flipper: running scene line 4 shows \`!14.x: TX may stop AP\` when toggle is ON, hides when OFF
- [ ] ESP32: yellow warning banner visible above FSD Status card on first boot
- [ ] ESP32: Dismiss button hides banner and persists across power cycle
- [ ] ESP32: banner re-appears if user clears NVS / factory reset

## Implements

Closes #73 (14.x protection mode tracker).

## Refs

- 14.x enforcement original report: [#18 @dmagyar](https://github.com/hypery11/flipper-tesla-fsd/issues/18#issuecomment-4373138526)
- 14.6 Intel HW4 confirmation: [#73 @DmitroPanteliuk](https://github.com/hypery11/flipper-tesla-fsd/issues/73#issuecomment-4480021733)
- The \`0x3C2\` scroll-press bypass that works around the preflight: PR #82