### PR TITLE
refactor(esp32): name Tesla CAN signal layouts

### DIFF
--- a/esp32/.firmware/can_signals.h
+++ b/esp32/.firmware/can_signals.h
@@ -1,0 +1,128 @@
+#pragma once
+/**
+ * Tesla CAN signal layout constants.
+ *
+ * Keep CAN IDs in config.h. Keep byte positions, bit masks, shifts, mux IDs,
+ * bit positions, and encoded values here so vehicle/firmware adaptations do
+ * not require hunting through handler logic.
+ */
+
+// Common CAN frame layout
+#define CAN_FRAME_MAX_BITS                 64
+#define CAN_FRAME_MAX_DATA_LEN              8
+
+#define CAN_MUX_BYTE                        0
+#define CAN_MUX_MASK                     0x07u
+#define CAN_MUX_0                           0u
+#define CAN_MUX_1                           1u
+#define CAN_MUX_2                           2u
+
+// GTW_carConfig (0x398)
+#define SIG_GTW_DAS_HW_BYTE                 0
+#define SIG_GTW_DAS_HW_SHIFT                6
+#define SIG_GTW_DAS_HW_MASK              0x03u
+#define SIG_GTW_DAS_HW_LEGACY_0             0u
+#define SIG_GTW_DAS_HW_LEGACY_1             1u
+#define SIG_GTW_DAS_HW_HW3                  2u
+#define SIG_GTW_DAS_HW_HW4                  3u
+
+// GTW_carState (0x318)
+#define SIG_GTW_UPDATE_IN_PROGRESS_BYTE     6
+#define SIG_GTW_UPDATE_IN_PROGRESS_MASK  0x03u
+
+// UI/DAS autopilot control (0x3FD / 0x3EE)
+#define SIG_AP_UI_FSD_SELECTED_BYTE         4
+#define SIG_AP_UI_FSD_SELECTED_SHIFT        6
+#define SIG_AP_UI_FSD_SELECTED_MASK      0x01u
+
+#define SIG_AP_FSD_ENABLE_BIT              46
+#define SIG_AP_NAG_CLEAR_BIT               19
+#define SIG_AP_HW4_FSD_ENABLE_BIT          60
+#define SIG_AP_HW4_EMERGENCY_VEHICLE_BIT   59
+#define SIG_AP_HW4_NAG_CONFIRM_BIT         47
+
+#define SIG_AP_HW3_SPEED_RAW_BYTE           3
+#define SIG_AP_HW3_SPEED_RAW_SHIFT          1
+#define SIG_AP_HW3_SPEED_RAW_MASK        0x3Fu
+#define SIG_AP_HW3_SPEED_RAW_ZERO          30
+#define SIG_AP_HW3_SPEED_OFFSET_STEP        5
+#define SIG_AP_HW3_SPEED_OFFSET_MIN         0
+#define SIG_AP_HW3_SPEED_OFFSET_MAX       100
+
+#define SIG_AP_SPEED_PROFILE_BYTE           6
+#define SIG_AP_SPEED_PROFILE_MASK        0x06u
+#define SIG_AP_SPEED_PROFILE_SHIFT          1
+#define SIG_AP_SPEED_PROFILE_VALUE_MASK  0x03u
+
+#define SIG_AP_HW3_SPEED_OFFSET_LOW_BYTE    0
+#define SIG_AP_HW3_SPEED_OFFSET_HIGH_BYTE   1
+#define SIG_AP_HW3_SPEED_OFFSET_LOW_MASK 0xC0u
+#define SIG_AP_HW3_SPEED_OFFSET_HIGH_MASK 0x3Fu
+#define SIG_AP_HW3_SPEED_OFFSET_LOW_VALUE_MASK 0x03u
+#define SIG_AP_HW3_SPEED_OFFSET_LOW_SHIFT   6
+#define SIG_AP_HW3_SPEED_OFFSET_HIGH_SHIFT  2
+
+#define SIG_AP_HW4_SPEED_PROFILE_BYTE       7
+#define SIG_AP_HW4_SPEED_PROFILE_SHIFT      5
+#define SIG_AP_HW4_SPEED_PROFILE_MASK    0x07u
+
+// Follow distance / legacy stalk
+#define SIG_FOLLOW_DIST_BYTE                5
+#define SIG_FOLLOW_DIST_MASK             0xE0u
+#define SIG_FOLLOW_DIST_SHIFT               5
+#define SIG_LEGACY_STALK_POS_BYTE           1
+#define SIG_LEGACY_STALK_POS_SHIFT          5
+
+// ISA speed limit (0x399, HW4 only)
+#define SIG_ISA_SOUND_ACTIVE_BYTE           1
+#define SIG_ISA_SOUND_ACTIVE_MASK        0x20u
+
+// EPAS3P_sysStatus (0x370)
+#define SIG_EPAS_HANDS_ON_BYTE              4
+#define SIG_EPAS_HANDS_ON_SHIFT             6
+#define SIG_EPAS_HANDS_ON_MASK           0x03u
+#define SIG_EPAS_HANDS_ON_OK                1u
+#define SIG_EPAS_HANDS_ON_SPOOF_VALUE    0x40u
+#define SIG_EPAS_HANDS_ON_CLEAR_MASK     0xC0u
+
+#define SIG_EPAS_COUNTER_BYTE               6
+#define SIG_EPAS_COUNTER_MASK            0x0Fu
+#define SIG_EPAS_COUNTER_KEEP_MASK       0xF0u
+
+#define SIG_EPAS_TORQUE_HIGH_BYTE           2
+#define SIG_EPAS_TORQUE_LOW_BYTE            3
+#define SIG_EPAS_TORQUE_HIGH_KEEP_MASK   0xF0u
+#define SIG_EPAS_TORQUE_HIGH_VALUE_MASK  0x0Fu
+#define SIG_EPAS_TORQUE_HIGH_SHIFT          8
+#define SIG_EPAS_TORQUE_LOW_MASK         0xFFu
+
+// BMS frames
+#define SIG_BMS_VOLTAGE_L_BYTE              0
+#define SIG_BMS_VOLTAGE_H_BYTE              1
+#define SIG_BMS_VOLTAGE_SCALE            0.01f
+#define SIG_BMS_CURRENT_L_BYTE              2
+#define SIG_BMS_CURRENT_H_BYTE              3
+#define SIG_BMS_CURRENT_SCALE             0.1f
+#define SIG_BMS_SOC_L_BYTE                  0
+#define SIG_BMS_SOC_H_BYTE                  1
+#define SIG_BMS_SOC_H_MASK               0x03u
+#define SIG_BMS_SOC_SCALE                 0.1f
+#define SIG_BMS_TEMP_MIN_BYTE               4
+#define SIG_BMS_TEMP_MAX_BYTE               5
+#define SIG_BMS_TEMP_OFFSET                40
+
+// Trip planning / precondition (0x082)
+#define SIG_TRIP_PLANNING_FLAGS_BYTE        0
+#define SIG_TRIP_PLANNING_PRECONDITION   0x05u
+
+// DAS autopilot config / TLSSC restore (0x331)
+#define SIG_DAS_AP_CONFIG_TIER_BYTE         0
+#define SIG_DAS_AP_CONFIG_KEEP_MASK      0xC0u
+#define SIG_DAS_AP_CONFIG_SELF_DRIVING   0x1Bu
+
+// DAS status (0x39B in the current handler)
+#define SIG_DAS_HANDS_ON_STATE_BYTE         5
+#define SIG_DAS_HANDS_ON_STATE_SHIFT        2
+#define SIG_DAS_HANDS_ON_STATE_MASK      0x0Fu
+#define SIG_DAS_HANDS_ON_NOT_REQUIRED       0u
+#define SIG_DAS_HANDS_ON_SUSPENDED          8u

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -10,12 +10,13 @@
  */
 
 #include "fsd_handler.h"
+#include "can_signals.h"
 #include <string.h>
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 static void set_bit(CanFrame *frame, int bit, bool value) {
-    if (bit < 0 || bit >= 64) return;
+    if (bit < 0 || bit >= CAN_FRAME_MAX_BITS) return;
     int byte_idx = bit / 8;
     int bit_idx  = bit % 8;
     uint8_t mask = (uint8_t)(1U << bit_idx);
@@ -27,7 +28,7 @@ static void set_bit(CanFrame *frame, int bit, bool value) {
 
 static uint8_t read_mux_id(const CanFrame *frame) {
     // MUX ID is the lower 3 bits of byte 0
-    return frame->data[0] & 0x07;
+    return frame->data[CAN_MUX_BYTE] & CAN_MUX_MASK;
 }
 
 static bool is_fsd_selected(const CanFrame *frame, bool force_fsd, bool china_mode) {
@@ -37,7 +38,8 @@ static bool is_fsd_selected(const CanFrame *frame, bool force_fsd, bool china_mo
     // DAS_autopilotControl byte 4 bits [7:6] = UI "FSD selected" flag (bit 38 in the 64-bit data
     // field).  Note: bit 46 is the *output* FSD-activation bit written to the modified frame —
     // a different field at byte 5 bit 6.
-    return (frame->data[4] >> 6) & 0x01;
+    return (frame->data[SIG_AP_UI_FSD_SELECTED_BYTE] >> SIG_AP_UI_FSD_SELECTED_SHIFT) &
+           SIG_AP_UI_FSD_SELECTED_MASK;
 }
 
 // ── State init ────────────────────────────────────────────────────────────────
@@ -90,12 +92,14 @@ bool fsd_can_transmit(const FSDState *state) {
 TeslaHWVersion fsd_detect_hw_version(const CanFrame *frame) {
     if (frame->id != CAN_ID_GTW_CAR_CONFIG) return TeslaHW_Unknown;
     // DAS_HWversion field: bits 7:6 of byte 0  (das_hw)
-    uint8_t das_hw = (frame->data[0] >> 6) & 0x03;
+    uint8_t das_hw = (frame->data[SIG_GTW_DAS_HW_BYTE] >> SIG_GTW_DAS_HW_SHIFT) &
+                     SIG_GTW_DAS_HW_MASK;
     switch (das_hw) {
-        case 0:
-        case 1:  return TeslaHW_Legacy;   // HW1/HW2/EAP retrofit — uses 0x3EE/0x045
-        case 2:  return TeslaHW_HW3;
-        case 3:  return TeslaHW_HW4;
+        case SIG_GTW_DAS_HW_LEGACY_0:
+        case SIG_GTW_DAS_HW_LEGACY_1:
+            return TeslaHW_Legacy;   // HW1/HW2/EAP retrofit — uses 0x3EE/0x045
+        case SIG_GTW_DAS_HW_HW3: return TeslaHW_HW3;
+        case SIG_GTW_DAS_HW_HW4: return TeslaHW_HW4;
         default: return TeslaHW_Unknown;
     }
 }
@@ -106,7 +110,8 @@ void fsd_handle_gtw_car_state(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 7) return;
     // GTW_updateInProgress: bits 1:0 of byte 6.
     // Filter transient / incompatible values to avoid false positives.
-    uint8_t raw = frame->data[6] & 0x03u;
+    uint8_t raw = frame->data[SIG_GTW_UPDATE_IN_PROGRESS_BYTE] &
+                  SIG_GTW_UPDATE_IN_PROGRESS_MASK;
     state->ota_raw_state = raw;
 
     bool in_progress = (raw == OTA_IN_PROGRESS_RAW_VALUE);
@@ -128,7 +133,8 @@ void fsd_handle_gtw_car_state(FSDState *state, const CanFrame *frame) {
 void fsd_handle_follow_distance(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 6) return;
     // Follow distance stalk position: bits 7:5 of byte 5
-    uint8_t fd = (frame->data[5] & 0xE0) >> 5;
+    uint8_t fd = (frame->data[SIG_FOLLOW_DIST_BYTE] & SIG_FOLLOW_DIST_MASK) >>
+                 SIG_FOLLOW_DIST_SHIFT;
 
     if (state->hw_version == TeslaHW_HW3) {
         // HW3: 3 levels  (fd 1→profile 2, 2→1, 3→0)
@@ -164,59 +170,71 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
     bool    modified = false;
 
     // mux 0 is the authoritative "is FSD requested" mux
-    if (mux == 0) state->fsd_enabled = fsd_ui;
+    if (mux == CAN_MUX_0) state->fsd_enabled = fsd_ui;
 
     if (state->hw_version == TeslaHW_HW3) {
         // ── HW3 ──────────────────────────────────────────────────────────────
-        if (mux == 0 && state->fsd_enabled) {
+        if (mux == CAN_MUX_0 && state->fsd_enabled) {
             // Compute speed offset from current speed signal (bits 6:1 of byte 3)
-            int raw    = (int)((frame->data[3] >> 1) & 0x3F) - 30;
-            int offset = raw * 5;
-            if (offset < 0)   offset = 0;
-            if (offset > 100) offset = 100;
+            int raw = (int)((frame->data[SIG_AP_HW3_SPEED_RAW_BYTE] >>
+                             SIG_AP_HW3_SPEED_RAW_SHIFT) &
+                            SIG_AP_HW3_SPEED_RAW_MASK) - SIG_AP_HW3_SPEED_RAW_ZERO;
+            int offset = raw * SIG_AP_HW3_SPEED_OFFSET_STEP;
+            if (offset < SIG_AP_HW3_SPEED_OFFSET_MIN) offset = SIG_AP_HW3_SPEED_OFFSET_MIN;
+            if (offset > SIG_AP_HW3_SPEED_OFFSET_MAX) offset = SIG_AP_HW3_SPEED_OFFSET_MAX;
             state->speed_offset = offset;
 
             // Activate FSD: set bit 46
-            set_bit(frame, 46, true);
+            set_bit(frame, SIG_AP_FSD_ENABLE_BIT, true);
 
             // Write speed profile into bits 2:1 of byte 6
-            frame->data[6] &= ~0x06u;
-            frame->data[6] |= (uint8_t)((state->speed_profile & 0x03) << 1);
+            frame->data[SIG_AP_SPEED_PROFILE_BYTE] &= (uint8_t)(~SIG_AP_SPEED_PROFILE_MASK);
+            frame->data[SIG_AP_SPEED_PROFILE_BYTE] |=
+                (uint8_t)((state->speed_profile & SIG_AP_SPEED_PROFILE_VALUE_MASK) <<
+                          SIG_AP_SPEED_PROFILE_SHIFT);
             modified = true;
         }
-        if (mux == 1) {
+        if (mux == CAN_MUX_1) {
             // Nag suppression via bit 19 (clear = no hands-on-wheel request)
-            set_bit(frame, 19, false);
+            set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);
             state->nag_suppressed = true;
             modified = true;
         }
-        if (mux == 2 && state->fsd_enabled) {
+        if (mux == CAN_MUX_2 && state->fsd_enabled) {
             // Write speed offset into bits 7:6 of byte 0 and bits 5:0 of byte 1
-            frame->data[0] &= ~0xC0u;
-            frame->data[1] &= ~0x3Fu;
-            frame->data[0] |= (uint8_t)((state->speed_offset & 0x03) << 6);
-            frame->data[1] |= (uint8_t)(state->speed_offset >> 2);
+            frame->data[SIG_AP_HW3_SPEED_OFFSET_LOW_BYTE] &=
+                (uint8_t)(~SIG_AP_HW3_SPEED_OFFSET_LOW_MASK);
+            frame->data[SIG_AP_HW3_SPEED_OFFSET_HIGH_BYTE] &=
+                (uint8_t)(~SIG_AP_HW3_SPEED_OFFSET_HIGH_MASK);
+            frame->data[SIG_AP_HW3_SPEED_OFFSET_LOW_BYTE] |=
+                (uint8_t)((state->speed_offset & SIG_AP_HW3_SPEED_OFFSET_LOW_VALUE_MASK) <<
+                          SIG_AP_HW3_SPEED_OFFSET_LOW_SHIFT);
+            frame->data[SIG_AP_HW3_SPEED_OFFSET_HIGH_BYTE] |=
+                (uint8_t)(state->speed_offset >> SIG_AP_HW3_SPEED_OFFSET_HIGH_SHIFT);
             modified = true;
         }
     } else {
         // ── HW4 ──────────────────────────────────────────────────────────────
-        if (mux == 0 && state->fsd_enabled) {
-            set_bit(frame, 46, true);   // FSD activation
-            set_bit(frame, 60, true);   // HW4 additional FSD bit
+        if (mux == CAN_MUX_0 && state->fsd_enabled) {
+            set_bit(frame, SIG_AP_FSD_ENABLE_BIT, true);       // FSD activation
+            set_bit(frame, SIG_AP_HW4_FSD_ENABLE_BIT, true);   // HW4 additional FSD bit
             if (state->emergency_vehicle_detect)
-                set_bit(frame, 59, true);  // emergency vehicle detection
+                set_bit(frame, SIG_AP_HW4_EMERGENCY_VEHICLE_BIT, true);
             modified = true;
         }
-        if (mux == 1) {
-            set_bit(frame, 19, false);  // clear hands-on-wheel nag
-            set_bit(frame, 47, true);   // HW4 nag-suppression confirmation bit
+        if (mux == CAN_MUX_1) {
+            set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);      // clear hands-on-wheel nag
+            set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true); // HW4 nag-suppression confirmation bit
             state->nag_suppressed = true;
             modified = true;
         }
-        if (mux == 2) {
+        if (mux == CAN_MUX_2) {
             // Write speed profile into bits 6:4 of byte 7
-            frame->data[7] &= ~(uint8_t)(0x07u << 5);
-            frame->data[7] |=  (uint8_t)((state->speed_profile & 0x07u) << 5);
+            frame->data[SIG_AP_HW4_SPEED_PROFILE_BYTE] &=
+                (uint8_t)(~(SIG_AP_HW4_SPEED_PROFILE_MASK << SIG_AP_HW4_SPEED_PROFILE_SHIFT));
+            frame->data[SIG_AP_HW4_SPEED_PROFILE_BYTE] |=
+                (uint8_t)((state->speed_profile & SIG_AP_HW4_SPEED_PROFILE_MASK) <<
+                          SIG_AP_HW4_SPEED_PROFILE_SHIFT);
             modified = true;
         }
     }
@@ -231,7 +249,7 @@ void fsd_handle_legacy_stalk(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 2) return;
     // STW_ACTN_RQ: stalk position encoded in bits 7:5 of byte 1
     // 0x00=Pos1, 0x21=Pos2, 0x42=Pos3, 0x64=Pos4, 0x85=Pos5, 0xA6=Pos6, 0xC8=Pos7
-    uint8_t pos = frame->data[1] >> 5;
+    uint8_t pos = frame->data[SIG_LEGACY_STALK_POS_BYTE] >> SIG_LEGACY_STALK_POS_SHIFT;
     if (pos <= 1)
         state->speed_profile = 2;
     else if (pos == 2)
@@ -247,17 +265,19 @@ bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame) {
     bool    fsd_ui = is_fsd_selected(frame, state->force_fsd, state->china_mode);
     bool    modified = false;
 
-    if (mux == 0) state->fsd_enabled = fsd_ui;
+    if (mux == CAN_MUX_0) state->fsd_enabled = fsd_ui;
 
-    if (mux == 0 && state->fsd_enabled) {
-        set_bit(frame, 46, true);
+    if (mux == CAN_MUX_0 && state->fsd_enabled) {
+        set_bit(frame, SIG_AP_FSD_ENABLE_BIT, true);
         // Speed profile in bits 2:1 of byte 6 (same encoding as HW3)
-        frame->data[6] &= ~0x06u;
-        frame->data[6] |= (uint8_t)((state->speed_profile & 0x03) << 1);
+        frame->data[SIG_AP_SPEED_PROFILE_BYTE] &= (uint8_t)(~SIG_AP_SPEED_PROFILE_MASK);
+        frame->data[SIG_AP_SPEED_PROFILE_BYTE] |=
+            (uint8_t)((state->speed_profile & SIG_AP_SPEED_PROFILE_VALUE_MASK) <<
+                      SIG_AP_SPEED_PROFILE_SHIFT);
         modified = true;
     }
-    if (mux == 1) {
-        set_bit(frame, 19, false);
+    if (mux == CAN_MUX_1) {
+        set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);
         state->nag_suppressed = true;
         modified = true;
     }
@@ -271,7 +291,7 @@ bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame) {
 bool fsd_handle_isa_speed_chime(CanFrame *frame) {
     if (frame->dlc < 8) return false;
     // Set "ISA_speedLimitSoundActive" flag: bit 5 of byte 1
-    frame->data[1] |= 0x20u;
+    frame->data[SIG_ISA_SOUND_ACTIVE_BYTE] |= SIG_ISA_SOUND_ACTIVE_MASK;
     // Recalculate Tesla checksum: sum(byte0..6) + low(CAN_ID) + high(CAN_ID)
     // CAN_ID_ISA_SPEED = 0x399 → low=0x99, high=0x03
     uint8_t sum = 0;
@@ -319,13 +339,15 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
     if (!state->nag_killer) return false;
 
     // EPAS handsOnLevel: bits 7:6 of byte 4.  Skip only when level==1 (hands OK).
-    uint8_t hands_on = (frame->data[4] >> 6) & 0x03u;
-    if (hands_on == 1) return false;
+    uint8_t hands_on = (frame->data[SIG_EPAS_HANDS_ON_BYTE] >> SIG_EPAS_HANDS_ON_SHIFT) &
+                       SIG_EPAS_HANDS_ON_MASK;
+    if (hands_on == SIG_EPAS_HANDS_ON_OK) return false;
 
     // DAS-aware gating — skip echo when DAS itself is satisfied.
     if (state->das_seen) {
         uint8_t das = state->das_hands_on_state;
-        if (das == 0 || das == 8) return false;
+        if (das == SIG_DAS_HANDS_ON_NOT_REQUIRED || das == SIG_DAS_HANDS_ON_SUSPENDED)
+            return false;
     }
 
     // Organic torque random walk
@@ -353,15 +375,21 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
 
     out->data[0] = frame->data[0];
     out->data[1] = frame->data[1];
-    out->data[2] = (frame->data[2] & 0xF0u) | (uint8_t)((torq >> 8) & 0x0Fu);
-    out->data[3] = (uint8_t)(torq & 0xFFu);
-    out->data[4] = (frame->data[4] & ~0xC0u) | 0x40u;  // handsOnLevel = 1
+    out->data[SIG_EPAS_TORQUE_HIGH_BYTE] =
+        (frame->data[SIG_EPAS_TORQUE_HIGH_BYTE] & SIG_EPAS_TORQUE_HIGH_KEEP_MASK) |
+        (uint8_t)((torq >> SIG_EPAS_TORQUE_HIGH_SHIFT) &
+                  SIG_EPAS_TORQUE_HIGH_VALUE_MASK);
+    out->data[SIG_EPAS_TORQUE_LOW_BYTE] = (uint8_t)(torq & SIG_EPAS_TORQUE_LOW_MASK);
+    out->data[SIG_EPAS_HANDS_ON_BYTE] =
+        (frame->data[SIG_EPAS_HANDS_ON_BYTE] & (uint8_t)(~SIG_EPAS_HANDS_ON_CLEAR_MASK)) |
+        SIG_EPAS_HANDS_ON_SPOOF_VALUE;  // handsOnLevel = 1
     out->data[5] = frame->data[5];
 
     // counter+1: lower nibble of byte 6
-    uint8_t cnt = (frame->data[6] & 0x0Fu);
-    cnt = (cnt + 1u) & 0x0Fu;
-    out->data[6] = (frame->data[6] & 0xF0u) | cnt;
+    uint8_t cnt = (frame->data[SIG_EPAS_COUNTER_BYTE] & SIG_EPAS_COUNTER_MASK);
+    cnt = (cnt + 1u) & SIG_EPAS_COUNTER_MASK;
+    out->data[SIG_EPAS_COUNTER_BYTE] =
+        (frame->data[SIG_EPAS_COUNTER_BYTE] & SIG_EPAS_COUNTER_KEEP_MASK) | cnt;
 
     // Checksum
     uint16_t sum = 0;
@@ -380,27 +408,32 @@ bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out
 void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 4) return;
     // Voltage: uint16 little-endian bytes 1:0, LSB = 0.01 V
-    uint16_t raw_v = ((uint16_t)frame->data[1] << 8) | frame->data[0];
+    uint16_t raw_v = ((uint16_t)frame->data[SIG_BMS_VOLTAGE_H_BYTE] << 8) |
+                     frame->data[SIG_BMS_VOLTAGE_L_BYTE];
     // Current: int16 little-endian bytes 3:2, LSB = 0.1 A (signed)
-    int16_t  raw_i = (int16_t)(((uint16_t)frame->data[3] << 8) | frame->data[2]);
-    state->pack_voltage_v = raw_v * 0.01f;
-    state->pack_current_a = raw_i * 0.1f;
+    int16_t raw_i = (int16_t)(((uint16_t)frame->data[SIG_BMS_CURRENT_H_BYTE] << 8) |
+                              frame->data[SIG_BMS_CURRENT_L_BYTE]);
+    state->pack_voltage_v = raw_v * SIG_BMS_VOLTAGE_SCALE;
+    state->pack_current_a = raw_i * SIG_BMS_CURRENT_SCALE;
     state->bms_seen = true;
 }
 
 void fsd_handle_bms_soc(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 2) return;
     // SoC: 10-bit little-endian (bits 9:0 across bytes 1:0), LSB = 0.1 %
-    uint16_t raw = ((uint16_t)(frame->data[1] & 0x03u) << 8) | frame->data[0];
-    state->soc_percent = raw * 0.1f;
+    uint16_t raw = ((uint16_t)(frame->data[SIG_BMS_SOC_H_BYTE] & SIG_BMS_SOC_H_MASK) << 8) |
+                   frame->data[SIG_BMS_SOC_L_BYTE];
+    state->soc_percent = raw * SIG_BMS_SOC_SCALE;
     state->bms_seen = true;
 }
 
 void fsd_handle_bms_thermal(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 6) return;
     // Temperatures: raw byte − 40 = °C
-    state->batt_temp_min_c = (int8_t)((int)frame->data[4] - 40);
-    state->batt_temp_max_c = (int8_t)((int)frame->data[5] - 40);
+    state->batt_temp_min_c = (int8_t)((int)frame->data[SIG_BMS_TEMP_MIN_BYTE] -
+                                      SIG_BMS_TEMP_OFFSET);
+    state->batt_temp_max_c = (int8_t)((int)frame->data[SIG_BMS_TEMP_MAX_BYTE] -
+                                      SIG_BMS_TEMP_OFFSET);
     state->bms_seen = true;
 }
 
@@ -411,7 +444,7 @@ void fsd_build_precondition_frame(CanFrame *frame) {
     frame->id  = CAN_ID_TRIP_PLANNING;
     frame->dlc = 8;
     // byte0: bit0 = tripPlanningActive, bit2 = requestActiveBatteryHeating
-    frame->data[0] = 0x05u;
+    frame->data[SIG_TRIP_PLANNING_FLAGS_BYTE] = SIG_TRIP_PLANNING_PRECONDITION;
 }
 
 // ── TLSSC Restore (0x331) ─────────────────────────────────────────────────────
@@ -420,12 +453,13 @@ bool fsd_handle_tlssc_restore(FSDState *state, CanFrame *frame) {
     if (!state->tlssc_restore) return false;
     if (frame->dlc < 1) return false;
 
-    uint8_t original = frame->data[0];
-    uint8_t modified = (original & 0xC0u) | 0x1Bu;
+    uint8_t original = frame->data[SIG_DAS_AP_CONFIG_TIER_BYTE];
+    uint8_t modified = (original & SIG_DAS_AP_CONFIG_KEEP_MASK) |
+                       SIG_DAS_AP_CONFIG_SELF_DRIVING;
 
     if (modified == original) return false;
 
-    frame->data[0] = modified;
+    frame->data[SIG_DAS_AP_CONFIG_TIER_BYTE] = modified;
     state->tlssc_restore_count++;
     return true;
 }
@@ -435,6 +469,8 @@ bool fsd_handle_tlssc_restore(FSDState *state, CanFrame *frame) {
 void fsd_handle_das_status(FSDState *state, const CanFrame *frame) {
     if (frame->dlc < 6) return;
     // DAS_autopilotHandsOnState: bit42|4 LE → byte5 bits[5:2]
-    state->das_hands_on_state = (frame->data[5] >> 2) & 0x0Fu;
+    state->das_hands_on_state =
+        (frame->data[SIG_DAS_HANDS_ON_STATE_BYTE] >> SIG_DAS_HANDS_ON_STATE_SHIFT) &
+        SIG_DAS_HANDS_ON_STATE_MASK;
     state->das_seen = true;
 }


### PR DESCRIPTION
Refactors ESP32 CAN frame handling by moving hardcoded Tesla CAN byte/bit/mask values into can_signals.h. This is a cleanup-only PR intended to make later protocol changes easier to review and less error-prone, without changing runtime behavior.