### PR TITLE
Split/03 esp32 nag killer ap gated

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 ## Features
 
 ### Core FSD
-- Auto-detect HW3/HW4 from `GTW_carConfig` (`0x398`), with fallback detection via `0x3FD`/`0x399`/`0x3EE` when `0x398` isn't on the tapped bus
+- Auto-detect HW3/HW4 from `GTW_carConfig` (`0x398`), with fallback detection via `0x3FD`/`0x3EE` when `0x398` isn't on the tapped bus
 - **Legacy→HW3 auto-upgrade** for Palladium Model S/X — detects `das_hw=0` then upgrades when `0x3FD` appears on the bus
 - FSD unlock via bit manipulation on `UI_autopilotControl` (`0x3FD` / `0x3EE`)
 - **Legacy mode** for HW1/HW2 (Model S/X 2016-2019)
@@ -73,7 +73,7 @@
 
 ### AP-First mode (v2.14+, for 2026.14.x firmware)
 - Tesla 2026.14.x added a preflight check that blocks AP/TACC engagement if CAN injection is already active
-- When **AP-First** is enabled, the app monitors `DAS_autopilotState` from `0x39B` and only starts injecting `0x3FD` after AP is engaged
+- When **AP-First** is enabled, the app monitors `DAS_autopilotState` from `0x39B` and only starts injecting `0x3FD` after AP is engaged. On ESP32, the DAS status source follows detected HW version.
 - Nag killer, TLSSC Restore, and Ban Shield are unaffected (they target different CAN IDs)
 
 ### Diagnostics (read-only, no FSD required)
@@ -95,7 +95,7 @@
 | **TLSSC Restore** | 0x331 DAS config spoof to recover TLSSC on banned vehicles. Triggers MCU reboot. |
 | **AP-First (14.x)** | Delay 0x3FD injection until AP is engaged. Required for Tesla firmware 2026.14.x. |
 | **Ban Shield** | Rewrite `GTW_carConfig` (0x7FF) broadcasts back to a learned-healthy pattern. CAN-broadcast-layer mask only — does not undo NVRAM or backend-side ban flags. Defense-in-depth, no confirmed ban-prevention case ([#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60)). |
-| **Suppress Chime** | Kill the ISA speed warning chime (HW4 only, `0x399`). |
+| **Suppress Chime** | Kill the ISA speed warning chime (HW4 only, `0x399`). On ESP32 this is active only after HW4 detection; Legacy/HW3 use `0x399` as DAS status instead. |
 | **Emerg. Vehicle** | Enable emergency vehicle detection flag (HW4 only, bit59). |
 | **Precondition** | Battery preheat trigger via `0x082`. |
 
@@ -141,6 +141,14 @@
 ### ESP32 (from $14)
 
 Full-featured ESP32 port with WiFi web dashboard, NVS settings persistence, deep sleep, and factory reset. Same CAN logic as the Flipper app.
+
+The ESP32 firmware maps AP/DAS status by detected hardware version:
+
+| Detected HW | `0x399` | `0x39B` | ISA speed chime |
+|-------------|---------|---------|-----------------|
+| Legacy HW1/HW2 | `DAS_status` | not used | disabled |
+| HW3 | `DAS_status` | not used | disabled |
+| HW4 | `ISA_SPEED` | `DAS_status` | enabled |
 
 | Board | Cost | Build target |
 |-------|------|-------------|
@@ -239,7 +247,7 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 |--------|------|-----------|------|
 | `0x331` | `DAS_autopilotConfig` | TX | TLSSC Restore — set tier to SELF_DRIVING |
 | `0x370` | `EPAS3P_sysStatus` | TX | Nag killer — counter+1 echo with organic torque |
-| `0x399` | `ISA_speedLimit` | TX | Speed chime suppression (HW4) |
+| `0x399` | `ISA_speedLimit` / `DAS_status` | TX/RX | ESP32 HW-dependent: Legacy/HW3 read DAS status here; HW4 uses ISA speed chime suppression |
 | `0x3FD` | `UI_autopilotControl` | TX | FSD unlock — bit46/60 (HW3/HW4), TLSSC bit38, lane graph bit45 |
 | `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route, hands-off, dev mode, LHD, telemetry (beta) |
 | `0x3EE` | `UI_autopilotControl` | TX | FSD unlock — Legacy HW1/HW2 |
@@ -247,7 +255,7 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 | `0x082` | `UI_tripPlanning` | TX | Battery preconditioning trigger |
 | `0x398` | `GTW_carConfig` | RX | HW version detection |
 | `0x318` | `GTW_carState` | RX | OTA detection (auto-suspend TX) |
-| `0x39B` | `DAS_status` | RX | AP state (for AP-First), nag level, lane change, blind spot |
+| `0x39B` | `DAS_status` | RX | ESP32 HW4 DAS status source; AP state (for AP-First), nag level, lane change, blind spot |
 | `0x132` | `BMS_hvBusStatus` | RX | Pack voltage / current |
 | `0x292` | `BMS_socStatus` | RX | State of charge |
 | `0x312` | `BMS_thermalStatus` | RX | Battery temperature |

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -9,12 +9,13 @@
 #define CAN_ID_GTW_CAR_STATE  0x318u  // 792  - GTW_carState:    OTA detection
 #define CAN_ID_EPAS_STATUS    0x370u  // 880  - EPAS3P_sysStatus: nag killer target
 #define CAN_ID_GTW_CAR_CONFIG 0x398u  // 920  - GTW_carConfig:   HW version detection
-#define CAN_ID_ISA_SPEED      0x399u  // 921  - ISA speed limit:  HW4 chime suppress
 #define CAN_ID_AP_LEGACY      0x3EEu  // 1006 - DAS_autopilot:   Legacy / HW1 / HW2
 #define CAN_ID_FOLLOW_DIST    0x3F8u  // 1016 - DAS_followDistance: speed profile source
 #define CAN_ID_DAS_AP_CONFIG  0x331u  // 817  - DAS autopilot config (tier restore target, ~1 Hz)
 #define CAN_ID_AP_CONTROL     0x3FDu  // 1021 - DAS_autopilotControl: HW3 / HW4 core
-#define CAN_ID_DAS_STATUS     0x39Bu  // 923  - DAS_status: AP hands-on state (nag gating)
+#define CAN_ID_DAS_STATUS_HW3 0x399u  // 921  - DAS_status on Legacy/HW3 AP/DAS
+#define CAN_ID_ISA_SPEED      0x399u  // 921  - ISA speed limit on HW4 only
+#define CAN_ID_DAS_STATUS_HW4 0x39Bu  // 923  - DAS_status on HW4 AP/DAS
 
 // ── GPIO ──────────────────────────────────────────────────────────────────────
 #if defined(BOARD_LILYGO)

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -430,11 +430,37 @@ bool fsd_handle_tlssc_restore(FSDState *state, CanFrame *frame) {
     return true;
 }
 
-// ── DAS status (0x39B) — nag killer gating ───────────────────────────────────
+static void fsd_handle_das_status_common(FSDState *state, const CanFrame *frame) {
+    if (frame->dlc != 8) return;
 
-void fsd_handle_das_status(FSDState *state, const CanFrame *frame) {
-    if (frame->dlc < 6) return;
-    // DAS_autopilotHandsOnState: bit42|4 LE → byte5 bits[5:2]
+    state->das_speed_limit_1 = frame->data[1];
+    state->das_speed_limit_2 = frame->data[2];
+
+    // DAS_autopilotHandsOnState: byte5 bits[5:2].
     state->das_hands_on_state = (frame->data[5] >> 2) & 0x0Fu;
+    state->das_lane_change_state = frame->data[6];
+    state->das_counter = frame->data[6];
+    state->das_checksum = frame->data[7];
     state->das_seen = true;
+}
+
+// ── DAS status — nag killer gating / AP active status ────────────────────────
+
+void fsd_handle_das_status_hw3(FSDState *state, const CanFrame *frame) {
+    if (frame->dlc != 8) return;
+
+    // Legacy/HW3 0x399 layout: DAS_autopilotState is byte0 low nibble.
+    // Observed HW3 mapping: 2=available/ready, 3=engaged.
+    state->das_ap_state = frame->data[0] & 0x0Fu;
+    state->ap_active = state->das_ap_state == 3u;
+    fsd_handle_das_status_common(state, frame);
+}
+
+void fsd_handle_das_status_hw4(FSDState *state, const CanFrame *frame) {
+    if (frame->dlc != 8) return;
+
+    // HW4 0x39B layout from the original parser: bit12|4 = byte1 bits[7:4].
+    state->das_ap_state = (frame->data[1] >> 4) & 0x0Fu;
+    state->ap_active = state->das_ap_state >= 2u;
+    fsd_handle_das_status_common(state, frame);
 }

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -284,19 +284,19 @@ bool fsd_handle_isa_speed_chime(CanFrame *frame) {
 
 // ── NAG killer: counter+1 echo of EPAS3P_sysStatus (0x370) ──────────────────
 //
-// When handsOnLevel == 0 (nag imminent) or 3 (escalated alarm), we send a
+// When handsOnLevel == 0 (nag imminent), 2 (marginal), or 3 (escalated), we send a
 // spoofed EPAS frame with handsOnLevel=1 and counter+1 before the real frame
 // reaches the DAS.  The DAS sees "hands on" and drops the nag.
 //
-// DAS-aware gating: also checks das_hands_on_state from 0x39B.  States 0
+// DAS-aware gating: also checks das_hands_on_state from DAS_status.  States 0
 // (NOT_REQD) and 8 (SUSPENDED) mean DAS is already satisfied — skip the echo
-// to avoid ~25 spurious frames/sec on the bus.  If 0x39B has never been seen
-// (das_seen==false), we echo conservatively based on EPAS level alone.
+// to avoid ~25 spurious frames/sec on the bus.  The echo is also gated on
+// ap_active so Active mode does not spam EPAS echoes while the car is parked.
 //
-// Organic torque: torsionBarTorque uses a xorshift32 random walk [1.00–2.40 Nm]
-// with brief grip pulses [3.10–3.30 Nm] every 5–9 s.  A flat signal for 30+
-// minutes is a statistical impossibility from a real hand and is a known
-// telemetry detection vector.
+// Organic torque: torsionBarTorque uses a xorshift32 random walk [1.00–2.40 Nm].
+// On first spoof and on each handsOnLevel transition into an eligible nag state,
+// it sends an immediate 3-5 frame grip pulse [3.10–3.30 Nm], then resets the
+// periodic 5-9 s pulse countdown.
 //
 // Checksum: byte7 = (sum(byte0..6) + 0x70 + 0x03) & 0xFF  (CAN ID 0x370 split)
 
@@ -304,6 +304,8 @@ static uint32_t nag_prng_state       = 0xDEADBEEFu;
 static int16_t  nag_torq_walk        = 2230;   // raw init ≈ 1.80 Nm
 static uint8_t  nag_exc_frames       = 0;
 static uint16_t nag_frames_until_exc = 175;
+static uint8_t  nag_last_hands_on    = 0xFFu;
+static bool     nag_session_active   = false;
 
 static uint32_t nag_xorshift32() {
     uint32_t x = nag_prng_state;
@@ -314,37 +316,76 @@ static uint32_t nag_xorshift32() {
     return x;
 }
 
+static void nag_schedule_periodic_pulse() {
+    nag_frames_until_exc = (uint16_t)(125u + (nag_xorshift32() % 100u));
+}
+
+static void nag_start_grip_pulse() {
+    nag_exc_frames = (uint8_t)(3u + (nag_xorshift32() % 3u));
+    nag_schedule_periodic_pulse();
+}
+
+static void nag_reset_session(uint8_t hands_on) {
+    nag_last_hands_on  = hands_on;
+    nag_session_active = false;
+    nag_exc_frames     = 0;
+}
+
+static int16_t nag_grip_pulse_torque() {
+    // Raw torque: Nm = raw * 0.01 - 20.5. 2360-2380 => 3.10-3.30 Nm.
+    return (int16_t)(2360 + (int)(nag_xorshift32() % 21u));
+}
+
+static int16_t nag_random_walk_torque() {
+    int16_t step = (int16_t)((int)(nag_xorshift32() % 31u) - 15);
+    nag_torq_walk += step;
+    if (nag_torq_walk < 2150) nag_torq_walk = 2150;  // min ~1.00 Nm
+    if (nag_torq_walk > 2290) nag_torq_walk = 2290;  // max ~2.40 Nm
+    return nag_torq_walk;
+}
+
 bool fsd_handle_nag_killer(FSDState *state, const CanFrame *frame, CanFrame *out) {
-    if (frame->dlc < 8)     return false;
-    if (!state->nag_killer) return false;
+    if (frame->dlc < 8) return false;
 
     // EPAS handsOnLevel: bits 7:6 of byte 4.  Skip only when level==1 (hands OK).
     uint8_t hands_on = (frame->data[4] >> 6) & 0x03u;
-    if (hands_on == 1) return false;
+
+    if (!state->nag_killer || !state->ap_active) {
+        nag_reset_session(hands_on);
+        return false;
+    }
+
+    if (hands_on == 1) {
+        nag_reset_session(hands_on);
+        return false;
+    }
 
     // DAS-aware gating — skip echo when DAS itself is satisfied.
     if (state->das_seen) {
         uint8_t das = state->das_hands_on_state;
-        if (das == 0 || das == 8) return false;
+        if (das == 0 || das == 8) {
+            nag_reset_session(hands_on);
+            return false;
+        }
     }
 
-    // Organic torque random walk
+    if (!nag_session_active || nag_last_hands_on != hands_on) {
+        nag_session_active = true;
+        nag_torq_walk = 2300; // first post-transition baseline: ~2.50 Nm
+        nag_start_grip_pulse();
+    }
+    nag_last_hands_on = hands_on;
+
     int16_t torq;
     if (nag_exc_frames > 0) {
-        // Grip pulse: ~3.20 Nm ± noise
-        torq = 2350 + (int16_t)((int)(nag_xorshift32() % 41u) - 20);
+        torq = nag_grip_pulse_torque();
         nag_exc_frames--;
     } else {
-        int16_t step = (int16_t)((int)(nag_xorshift32() % 31u) - 15);
-        nag_torq_walk += step;
-        if (nag_torq_walk < 2150) nag_torq_walk = 2150;  // min ~1.00 Nm
-        if (nag_torq_walk > 2290) nag_torq_walk = 2290;  // max ~2.40 Nm
-        torq = nag_torq_walk;
+        torq = nag_random_walk_torque();
         if (nag_frames_until_exc > 0) {
             nag_frames_until_exc--;
         } else {
-            nag_exc_frames       = (uint8_t)(3u + (nag_xorshift32() % 3u));
-            nag_frames_until_exc = (uint16_t)(125u + (nag_xorshift32() % 100u));
+            nag_start_grip_pulse();
         }
     }
 

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -32,6 +32,7 @@ struct FSDState {
     int            speed_offset;    // HW3 only, 0-100
 
     bool           fsd_enabled;     // true when car's UI has FSD selected (mux0)
+    bool           ap_active;       // true when DAS reports AP/TACC active
     bool           nag_suppressed;  // true after first nag-killer echo sent
 
     uint32_t       frames_modified; // count of autopilot frames (0x3FD/0x3EE) we patched
@@ -40,7 +41,7 @@ struct FSDState {
 
     // ── Feature flags (runtime-toggleable) ───────────────────────────────────
     bool           force_fsd;               // bypass UI selection check
-    bool           suppress_speed_chime;    // ISA chime suppress (HW4, 0x399)
+    bool           suppress_speed_chime;    // HW4 ISA_SPEED chime suppress
     bool           china_mode;              // bypass FSD UI selection check for China vehicles
     bool           emergency_vehicle_detect;// set bit59 in mux0 (HW4)
     bool           nag_killer;              // 0x370 counter+1 echo
@@ -86,12 +87,19 @@ struct FSDState {
     bool           tlssc_restore;
     uint32_t       tlssc_restore_count;
 
-    // ── DAS status (0x39B) — nag killer gating ───────────────────────────────
+    // ── DAS status — nag killer gating ───────────────────────────────────────
+    // Legacy/HW3 source: 0x399. HW4 source: 0x39B.
     // 0=NOT_REQD, 8=SUSPENDED — both mean DAS is satisfied, skip echo.
-    // das_seen starts false; if 0x39B is absent from the tapped bus the nag
+    // das_seen starts false; if the status frame is absent from the tapped bus the nag
     // killer falls back to EPAS-level-only gating (conservative echo).
     bool           das_seen;
+    uint8_t        das_ap_state;
+    uint8_t        das_speed_limit_1;
+    uint8_t        das_speed_limit_2;
     uint8_t        das_hands_on_state;
+    uint8_t        das_lane_change_state;
+    uint8_t        das_counter;
+    uint8_t        das_checksum;
 #if defined(BOARD_TTGO_DISPLAY)
     bool           display_enabled;  // Toggle for T-Display LCD/backlight
     uint8_t        display_brightness; // 0-100%
@@ -131,7 +139,7 @@ void fsd_handle_legacy_stalk(FSDState *state, const CanFrame *frame);
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame);
 
-/** Modify ISA speed limit frame (0x399) to suppress speed chime (HW4).
+/** Modify ISA speed limit frame (0x399, HW4 only) to suppress speed chime.
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_isa_speed_chime(CanFrame *frame);
 
@@ -156,5 +164,8 @@ void fsd_build_precondition_frame(CanFrame *frame);
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_tlssc_restore(FSDState *state, CanFrame *frame);
 
-/** Parse DAS_status (0x39B) — updates das_hands_on_state for nag killer gating. */
-void fsd_handle_das_status(FSDState *state, const CanFrame *frame);
+/** Parse DAS_status from Legacy/HW3 0x399 — updates AP/speed/hands-on state. */
+void fsd_handle_das_status_hw3(FSDState *state, const CanFrame *frame);
+
+/** Parse DAS_status from HW4 0x39B — updates AP/speed/hands-on state. */
+void fsd_handle_das_status_hw4(FSDState *state, const CanFrame *frame);

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -54,6 +54,23 @@ static FSDState state_snapshot() {
     return s;
 }
 
+static bool hw_uses_hw3_das_status(TeslaHWVersion hw) {
+    return hw == TeslaHW_Legacy || hw == TeslaHW_HW3;
+}
+
+static bool hw_uses_hw4_das_status(TeslaHWVersion hw) {
+    return hw == TeslaHW_HW4;
+}
+
+static bool frame_looks_like_hw3_das_status(const CanFrame &frame) {
+    if (frame.id != CAN_ID_DAS_STATUS_HW3 || frame.dlc != 8) return false;
+
+    uint8_t ap_state = frame.data[0] & 0x0Fu;
+    uint8_t hands_on = (frame.data[5] >> 2) & 0x0Fu;
+
+    return ap_state <= 3u && hands_on <= 8u;
+}
+
 static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
     if (hw == TeslaHW_Unknown) return;
     state_enter();
@@ -293,7 +310,19 @@ static void process_frame(const CanFrame &frame) {
     if (frame.id == CAN_ID_BMS_THERMAL) { state_enter(); fsd_handle_bms_thermal(&g_state, &frame); state_exit(); return; }
 
     // ── DAS status (read-only, always) — gating for NAG killer ───────────────
-    if (frame.id == CAN_ID_DAS_STATUS)  { state_enter(); fsd_handle_das_status(&g_state, &frame);  state_exit(); return; }
+    FSDState das_state = state_snapshot();
+    if (hw_uses_hw3_das_status(das_state.hw_version) && frame.id == CAN_ID_DAS_STATUS_HW3) {
+        state_enter();
+        fsd_handle_das_status_hw3(&g_state, &frame);
+        state_exit();
+        return;
+    }
+    if (hw_uses_hw4_das_status(das_state.hw_version) && frame.id == CAN_ID_DAS_STATUS_HW4) {
+        state_enter();
+        fsd_handle_das_status_hw4(&g_state, &frame);
+        state_exit();
+        return;
+    }
 
     // ── Beyond here only run when TX is allowed ───────────────────────────────
     state_enter();
@@ -342,18 +371,25 @@ static void process_frame(const CanFrame &frame) {
     }
 
     // Fallback HW detection when 0x398 is unavailable on the tapped bus.
-    // Delay 0x3FD→HW3 fallback to avoid misclassifying HW4 (which also has
-    // 0x3FD) before 0x399 arrives. 0x3EE and 0x399 are unambiguous.
+    // Prefer explicit HW4 DAS_status (0x39B) when present. If the tap only sees
+    // HW3-style DAS_status on 0x399, classify as HW3 after repeated plausible
+    // samples so 0x399 can be parsed for AP/NAG gating.
     static uint32_t hw_fallback_3fd_count = 0;
+    static uint32_t hw_fallback_399_count = 0;
     if (state_snapshot().hw_version == TeslaHW_Unknown) {
         if (frame.id == CAN_ID_AP_LEGACY) {
             apply_detected_hw(TeslaHW_Legacy, "fallback:0x3EE");
-        } else if (frame.id == CAN_ID_ISA_SPEED) {
-            apply_detected_hw(TeslaHW_HW4, "fallback:0x399");
+        } else if (frame.id == CAN_ID_DAS_STATUS_HW4 && frame.dlc == 8) {
+            apply_detected_hw(TeslaHW_HW4, "fallback:0x39B");
             hw_fallback_3fd_count = 0;
+            hw_fallback_399_count = 0;
+        } else if (frame_looks_like_hw3_das_status(frame)) {
+            hw_fallback_399_count++;
+            if (hw_fallback_399_count >= 2u)
+                apply_detected_hw(TeslaHW_HW3, "fallback:0x399(DAS status)");
         } else if (frame.id == CAN_ID_AP_CONTROL) {
             hw_fallback_3fd_count++;
-            if (hw_fallback_3fd_count >= 50)
+            if (hw_fallback_3fd_count >= 10u)
                 apply_detected_hw(TeslaHW_HW3, "fallback:0x3FD(confirmed)");
         }
     }
@@ -637,9 +673,10 @@ void loop() {
             (s.hw_version == TeslaHW_HW3)    ? "HW3"    :
             (s.hw_version == TeslaHW_Legacy)  ? "Legacy" : "?";
         Serial.printf(
-            "[STA] HW:%-6s FSD:%-4s NAG:%-10s OTA:%-3s "
+            "[STA] HW:%-6s AP:%-4s FSD_UI:%-4s NAG:%-10s OTA:%-3s "
             "Profile:%d  RX:%lu TX:%lu Mod:%lu Err:%lu\n",
             hw_str,
+            s.ap_active       ? "ON"         : "wait",
             s.fsd_enabled     ? "ON"         : "wait",
             s.nag_suppressed  ? "suppressed"  : "active",
             s.tesla_ota_in_progress ? "YES"  : "no",

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -262,7 +262,7 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
 <div class="card">
   <div class="card-head"><div class="icon ic-s">S</div><h2>FSD Status</h2></div>
   <div class="row">
-    <span class="lbl">FSD Active</span>
+    <span class="lbl">AP Status</span>
     <span class="pill off" id="fsdSt"><span class="pd"></span>--</span>
   </div>
   <div class="row">
@@ -345,7 +345,7 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">China Mode</span>
     <label class="sw"><input type="checkbox" id="swChina" onchange="cmd('china_mode',this.checked)"><span class="sl2"></span></label>
   </div>
-  <div class="row">
+  <div class="row" id="rowChime">
     <span class="lbl">Suppress Chime</span>
     <label class="sw"><input type="checkbox" id="swChime" onchange="cmd('suppress_speed_chime',this.checked)"><span class="sl2"></span></label>
   </div>
@@ -503,7 +503,8 @@ function ring(p){
 function upd(d){
   if(!d || Date.now() < busy) return;
   // Status
-  pill('fsdSt', d.fsd_enabled, d.fsd_enabled?'Active':'Waiting');
+  var apActive=!!d.ap_active;
+  pill('fsdSt', apActive, apActive?'Active':'Waiting');
   pill('opMode', d.op_mode===1, d.op_mode===1?'Active':'Listen-Only');
 
   var hwEl=document.getElementById('hwVer');
@@ -536,6 +537,7 @@ function upd(d){
   if(document.getElementById('swFsd')) document.getElementById('swFsd').checked=d.force_fsd;
   if(document.getElementById('swChina')) document.getElementById('swChina').checked=d.china_mode;
   if(document.getElementById('swChime')) document.getElementById('swChime').checked=d.suppress_speed_chime;
+  if(document.getElementById('rowChime')) document.getElementById('rowChime').style.display=d.isa_speed_enabled?'flex':'none';
   if(document.getElementById('swTlssc')) document.getElementById('swTlssc').checked=d.tlssc_restore;
   if(document.getElementById('swDisp')) document.getElementById('swDisp').checked=!!d.display_enabled;
   if(document.activeElement.id!=='dispBr' && document.getElementById('dispBr'))
@@ -817,12 +819,22 @@ static String build_json() {
     snprintf(fps_s, sizeof(fps_s), "%.1f", g_fps);
 
     String j;
-    j.reserve(768);
+    bool isa_speed_enabled = state.hw_version == TeslaHW_HW4;
+    const char *ap_das_profile =
+        (state.hw_version == TeslaHW_HW4) ? "HW4: DAS 0x39B + ISA 0x399" :
+        (state.hw_version == TeslaHW_HW3) ? "HW3: DAS 0x399" :
+        (state.hw_version == TeslaHW_Legacy) ? "Legacy: DAS 0x399" :
+        "Waiting for HW detection";
+
+    j.reserve(900);
     j  = "{";
     j += "\"fsd_enabled\":";   j += state.fsd_enabled                 ? "true" : "false"; j += ',';
+    j += "\"ap_active\":";     j += state.ap_active                   ? "true" : "false"; j += ',';
     j += "\"op_mode\":";       j += (int)state.op_mode;                j += ',';
     j += "\"hw_version\":";    j += (int)state.hw_version;             j += ',';
     j += "\"ota\":";           j += state.tesla_ota_in_progress        ? "true" : "false"; j += ',';
+    j += "\"ap_das_profile\":\""; j += ap_das_profile;                 j += "\",";
+    j += "\"isa_speed_enabled\":"; j += isa_speed_enabled              ? "true" : "false"; j += ',';
     j += "\"nag_killer\":";    j += state.nag_killer                   ? "true" : "false"; j += ',';
     j += "\"bms_output\":";    j += state.bms_output                   ? "true" : "false"; j += ',';
     j += "\"force_fsd\":";     j += state.force_fsd                    ? "true" : "false"; j += ',';

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -34,7 +34,8 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - NAG Killer (EPAS `0x370` counter+1 echo with handsOnLevel spoofing)
 - Speed profile mapping from follow-distance stalk
 - OTA update detection and automatic TX suspension
-- ISA speed warning chime suppression (HW4)
+- HW-based AP/DAS mapping for Legacy/HW3 vs HW4 signal layouts
+- ISA speed warning chime suppression (HW4 only)
 - BMS data parsing logic (voltage, current, SOC, temperature) — currently not reliable in real use
 - Battery precondition trigger
 - CRC/checksum recalculation after frame modification
@@ -70,6 +71,18 @@ Dual CAN driver support (compile-time switch):
 - **ESP32 TWAI** — for M5Stack ATOM Lite + ATOMIC CAN Base (CA-IS3050G transceiver)
 - **MCP2515 SPI** — for generic ESP32 + MCP2515 CAN module setups
 
+### HW-Based AP/DAS Mapping
+
+The AP/DAS status source is selected at runtime from the detected Tesla hardware version:
+
+| Detected HW | DAS status | ISA_SPEED / chime suppress |
+|-------------|------------|-----------------------------|
+| Legacy HW1/HW2 | `0x399` | Disabled; `0x399` is treated as DAS status |
+| HW3 | `0x399` | Disabled; `0x399` is treated as DAS status |
+| HW4 | `0x39B` | Enabled on `0x399` |
+
+This avoids a manual AP/DAS profile. The dashboard hides the chime toggle until HW4 is detected.
+
 ---
 
 ## Features
@@ -79,7 +92,8 @@ Dual CAN driver support (compile-time switch):
 | **FSD Unlock** | `0x3FD` mux0 | bit46 = 1 activates FSD (HW3/HW4/Legacy) |
 | **NAG Killer** | `0x370` | Suppresses hands-on-wheel reminder |
 | **Speed Profile** | `0x3FD` mux2 | Follow-distance stalk maps to speed offset |
-| **ISA Chime Suppress** | `0x399` | Kills speed warning chime (HW4 only) |
+| **DAS Status** | `0x399` or `0x39B` | Runtime HW version selects status source |
+| **ISA Chime Suppress** | `0x399` | HW4 only; disabled for Legacy/HW3 because `0x399` is DAS status |
 | **Battery Precondition** | `0x082` | Frame builder implemented; no user control exposed yet |
 | **BMS Dashboard** | `0x132`/`0x292`/`0x312` | Parsing/UI path implemented, but currently not working reliably |
 | **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected |
@@ -169,6 +183,8 @@ Located in the rear center console area:
 
 ## CAN Bus Details
 
+Most IDs are common. The AP/DAS status and ISA-speed meaning depends on the detected Tesla hardware version.
+
 | CAN ID | Name | Purpose |
 |--------|------|---------|
 | `0x045` | STW_ACTN_RQ | Steering stalk (Legacy follow distance) |
@@ -179,10 +195,17 @@ Located in the rear center console area:
 | `0x318` | GTW_CAR_STATE | Vehicle state (OTA detection) |
 | `0x370` | EPAS_STATUS | EPAS status (NAG killer target) |
 | `0x398` | GTW_CAR_CONFIG | HW version detection |
-| `0x399` | ISA_SPEED | Speed warning chime (HW4) |
 | `0x3EE` | AP_LEGACY | Autopilot control (Legacy / HW1 / HW2) |
 | `0x3F8` | FOLLOW_DIST | Follow distance / speed profile |
 | `0x3FD` | AP_CONTROL | **Autopilot control (HW3/HW4) — core** |
+
+HW-specific IDs:
+
+| Detected HW | `0x399` | `0x39B` |
+|-------------|---------|---------|
+| Legacy HW1/HW2 | `DAS_STATUS` — AP / Autosteer state, speed-limit data, hands-on / lane-change state | Not used |
+| HW3 | `DAS_STATUS` — AP / Autosteer state, speed-limit data, hands-on / lane-change state | Not used |
+| HW4 | `ISA_SPEED` — speed warning chime | `DAS_STATUS` — AP / hands-on state (NAG killer gating) |
 
 Bus speed: **500 kbps**
 


### PR DESCRIPTION
Reworks ESP32 NAG killer behavior so EPAS spoofing only runs when AP/TACC is actually active. It also resets NAG spoofing sessions when AP is inactive or DAS is already satisfied, and adds transition-triggered grip pulses for more natural torque behavior. This PR depends on the HW/DAS mapping PR.

!!!!!!!!!!!!!!!!!!!!
**Dependency**: This PR depends on [fix(esp32): map DAS status by Tesla HW version](https://github.com/hypery11/flipper-tesla-fsd/pull/86) It uses the ap_active state added there to prevent NAG spoofing while AP/TACC is inactive. Ideally merge PR 2 first, then rebase/open this PR against updated main.
