### PR TITLE
feat(esp32): add FSD unlock and OTA override toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 - Vehicle speed, steering angle, motor torque, brake state
 - DAS status: autopilot state, hands-on nag level, lane change state, blind spot warning, FCW, vision speed limit
 - GTW autopilot tier readback (NONE/HIGHWAY/ENHANCED/SELF_DRIVING/BASIC)
-- OTA detection with debounce — auto-suspends TX during firmware updates
+- OTA detection with debounce — auto-suspends TX during firmware updates unless the explicit Ignore OTA override is enabled
 
 ### Settings (runtime toggles)
 
@@ -92,6 +92,7 @@
 | **Mode** | `Active` / `Listen-Only` / `Service`. Listen-Only is the **first-boot default** — MCP2515 is in hardware listen-only mode and physically cannot TX. |
 | **Nag Killer** | DAS-aware EPAS counter+1 echo with organic torque variation. |
 | **Force FSD** | Bypass the `isFSDSelectedInUI` check. Does not bypass Tesla's server-side entitlement — only affects local CAN frame flow. |
+| **Ignore OTA** | Allows CAN TX in Active mode even when `0x318` reports a Tesla OTA update in progress. Default is off. |
 | **TLSSC Restore** | 0x331 DAS config spoof to recover TLSSC on banned vehicles. Triggers MCU reboot. |
 | **AP-First (14.x)** | Delay 0x3FD injection until AP is engaged. Required for Tesla firmware 2026.14.x. |
 | **Ban Shield** | Rewrite `GTW_carConfig` (0x7FF) broadcasts back to a learned-healthy pattern. CAN-broadcast-layer mask only — does not undo NVRAM or backend-side ban flags. Defense-in-depth, no confirmed ban-prevention case ([#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60)). |

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -48,8 +48,10 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->op_mode    = OpMode_ListenOnly;  // safe default — never TX on boot
 
     // Feature flags: nag killer and chime suppress default ON; others OFF
+    state->fsd_unlock          = true;
     state->nag_killer           = true;
     state->suppress_speed_chime = true;
+    state->ignore_ota           = false;
     state->emergency_vehicle_detect = false;
     state->force_fsd            = false;
     state->china_mode           = false;
@@ -81,7 +83,7 @@ void fsd_apply_hw_version(FSDState *state, TeslaHWVersion hw) {
 
 bool fsd_can_transmit(const FSDState *state) {
     if (state->op_mode == OpMode_ListenOnly) return false;
-    if (state->tesla_ota_in_progress)        return false;
+    if (state->tesla_ota_in_progress && !state->ignore_ota) return false;
     return true;
 }
 
@@ -166,6 +168,8 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
     // mux 0 is the authoritative "is FSD requested" mux
     if (mux == 0) state->fsd_enabled = fsd_ui;
 
+    if (!state->fsd_unlock) return false;
+
     if (state->hw_version == TeslaHW_HW3) {
         // ── HW3 ──────────────────────────────────────────────────────────────
         if (mux == 0 && state->fsd_enabled) {
@@ -248,6 +252,8 @@ bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame) {
     bool    modified = false;
 
     if (mux == 0) state->fsd_enabled = fsd_ui;
+
+    if (!state->fsd_unlock) return false;
 
     if (mux == 0 && state->fsd_enabled) {
         set_bit(frame, 46, true);

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -39,8 +39,10 @@ struct FSDState {
                                     // (autopilot mods + nag echoes + ISA + TLSSC + precond)
 
     // ── Feature flags (runtime-toggleable) ───────────────────────────────────
+    bool           fsd_unlock;              // modify autopilot FSD unlock frames
     bool           force_fsd;               // bypass UI selection check
     bool           suppress_speed_chime;    // ISA chime suppress (HW4, 0x399)
+    bool           ignore_ota;              // allow TX while Tesla OTA is detected
     bool           china_mode;              // bypass FSD UI selection check for China vehicles
     bool           emergency_vehicle_detect;// set bit59 in mux0 (HW4)
     bool           nag_killer;              // 0x370 counter+1 echo

--- a/esp32/.firmware/led.h
+++ b/esp32/.firmware/led.h
@@ -5,7 +5,7 @@ typedef enum {
     LED_OFF    = 0,
     LED_BLUE,     // Listen-Only mode (passive, no TX)
     LED_GREEN,    // Active mode (FSD transmitting)
-    LED_YELLOW,   // OTA detected (TX suspended)
+    LED_YELLOW,   // OTA detected
     LED_RED,      // Error (no CAN traffic / wiring fault)
     LED_SLEEP,    // About to deep-sleep (dim purple)
     LED_WHITE,    // Factory reset armed (full brightness)

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -275,14 +275,20 @@ static void process_frame(const CanFrame &frame) {
         bool was_ota = g_state.tesla_ota_in_progress;
         fsd_handle_gtw_car_state(&g_state, &frame);
         bool is_ota = g_state.tesla_ota_in_progress;
+        bool ignore_ota = g_state.ignore_ota;
         uint8_t raw = g_state.ota_raw_state;
         state_exit();
         if (!was_ota && is_ota) {
-            Serial.printf("[OTA] Update in progress (raw=%u) - TX suspended\n", raw);
-            can_dump_log("OTA  started — TX suspended");
+            if (ignore_ota) {
+                Serial.printf("[OTA] Update in progress (raw=%u) - TX allowed by Ignore OTA\n", raw);
+                can_dump_log("OTA  started - TX allowed by Ignore OTA");
+            } else {
+                Serial.printf("[OTA] Update in progress (raw=%u) - TX suspended\n", raw);
+                can_dump_log("OTA  started - TX suspended");
+            }
         } else if (was_ota && !is_ota) {
             Serial.printf("[OTA] Update finished (raw=%u) - TX resumed\n", raw);
-            can_dump_log("OTA  finished — TX resumed");
+            can_dump_log("OTA  finished - TX resumed");
         }
         return;
     }
@@ -499,7 +505,9 @@ void setup() {
     // Explicit safe defaults — will be overridden after HW auto-detect
     g_state.op_mode               = OpMode_ListenOnly;
     g_state.nag_killer            = true;
+    g_state.fsd_unlock            = true;
     g_state.suppress_speed_chime  = true;
+    g_state.ignore_ota            = false;
     g_state.emergency_vehicle_detect = false;
     g_state.force_fsd             = false;
     g_state.china_mode            = false;

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -12,7 +12,9 @@ void prefs_load(FSDState *state) {
         return;
     }
     state->nag_killer               = g_prefs.getBool("nag",    true);
+    state->fsd_unlock               = g_prefs.getBool("unlock", true);
     state->suppress_speed_chime     = g_prefs.getBool("chime",  true);
+    state->ignore_ota               = g_prefs.getBool("ignota", false);
     state->force_fsd                = g_prefs.getBool("force",  false);
     state->china_mode               = g_prefs.getBool("china",  false);
     state->tlssc_restore            = g_prefs.getBool("tlssc",  false);
@@ -33,8 +35,9 @@ void prefs_load(FSDState *state) {
 
     state->op_mode = (OpMode)g_prefs.getUChar("mode", (uint8_t)OpMode_ListenOnly);
     
-    Serial.printf("[NVS] Loaded: NAG=%d China=%d Chime=%d Sleep=%u SSID=\"%s\" HIDDEN=%d\n",
-                  state->nag_killer, state->china_mode, state->suppress_speed_chime,
+    Serial.printf("[NVS] Loaded: Unlock=%d NAG=%d IgnoreOTA=%d China=%d Chime=%d Sleep=%u SSID=\"%s\" HIDDEN=%d\n",
+                  state->fsd_unlock, state->nag_killer, state->ignore_ota,
+                  state->china_mode, state->suppress_speed_chime,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_hidden);
     g_prefs.end();
 }
@@ -50,7 +53,9 @@ void prefs_save(const FSDState *state) {
     g_prefs.begin(NS, /*readOnly=*/false);
     g_prefs.putBool("ok",     true);
     g_prefs.putBool("nag",    state->nag_killer);
+    g_prefs.putBool("unlock", state->fsd_unlock);
     g_prefs.putBool("chime",  state->suppress_speed_chime);
+    g_prefs.putBool("ignota", state->ignore_ota);
     g_prefs.putBool("force",  state->force_fsd);
     g_prefs.putBool("china",  state->china_mode);
     g_prefs.putBool("tlssc",  state->tlssc_restore);
@@ -71,8 +76,9 @@ void prefs_save(const FSDState *state) {
 
     g_prefs.putUChar("mode",  (uint8_t)state->op_mode);
     
-    Serial.printf("[NVS] Saved: NAG=%d China=%d Chime=%d Sleep=%u SSID=\"%s\" HIDDEN=%d\n",
-                  state->nag_killer, state->china_mode, state->suppress_speed_chime,
+    Serial.printf("[NVS] Saved: Unlock=%d NAG=%d IgnoreOTA=%d China=%d Chime=%d Sleep=%u SSID=\"%s\" HIDDEN=%d\n",
+                  state->fsd_unlock, state->nag_killer, state->ignore_ota,
+                  state->china_mode, state->suppress_speed_chime,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_hidden);
     g_prefs.end();
 }

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -330,6 +330,14 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   <div class="card-head"><div class="icon ic-c">C</div><h2>Controls</h2></div>
   <button id="btnMode" class="btn-main btn-act" onclick="toggleMode()">ACTIVATE FSD</button>
   <div class="row">
+    <span class="lbl">FSD Unlock</span>
+    <label class="sw"><input type="checkbox" id="swFsdUnlock" onchange="cmd('fsd_unlock',this.checked)"><span class="sl2"></span></label>
+  </div>
+  <div class="row">
+    <span class="lbl">Ignore OTA</span>
+    <label class="sw"><input type="checkbox" id="swIgnoreOta" onchange="cmd('ignore_ota',this.checked)"><span class="sl2"></span></label>
+  </div>
+  <div class="row">
     <span class="lbl">NAG Killer</span>
     <label class="sw"><input type="checkbox" id="swNag" onchange="cmd('nag',this.checked)"><span class="sl2"></span></label>
   </div>
@@ -520,7 +528,10 @@ function upd(d){
 
   // OTA banner
   var otaB=document.getElementById('otaBanner');
-  if(otaB) otaB.style.display=d.ota?'block':'none';
+  if(otaB){
+    otaB.style.display=d.ota?'block':'none';
+    if(d.ota) otaB.innerHTML=d.ignore_ota?'&#9888;&#xFE0F; OTA UPDATE IN PROGRESS &mdash; TX ALLOWED BY IGNORE OTA':'&#9888;&#xFE0F; OTA UPDATE IN PROGRESS &mdash; CAN TX SUSPENDED';
+  }
 
   // Mode button
   var act=d.op_mode===1;
@@ -531,6 +542,8 @@ function upd(d){
   }
 
   // Switches sync
+  if(document.getElementById('swFsdUnlock')) document.getElementById('swFsdUnlock').checked=d.fsd_unlock;
+  if(document.getElementById('swIgnoreOta')) document.getElementById('swIgnoreOta').checked=d.ignore_ota;
   if(document.getElementById('swNag')) document.getElementById('swNag').checked=d.nag_killer;
   if(document.getElementById('swBms')) document.getElementById('swBms').checked=d.bms_output;
   if(document.getElementById('swFsd')) document.getElementById('swFsd').checked=d.force_fsd;
@@ -823,6 +836,8 @@ static String build_json() {
     j += "\"op_mode\":";       j += (int)state.op_mode;                j += ',';
     j += "\"hw_version\":";    j += (int)state.hw_version;             j += ',';
     j += "\"ota\":";           j += state.tesla_ota_in_progress        ? "true" : "false"; j += ',';
+    j += "\"fsd_unlock\":";    j += state.fsd_unlock                   ? "true" : "false"; j += ',';
+    j += "\"ignore_ota\":";    j += state.ignore_ota                   ? "true" : "false"; j += ',';
     j += "\"nag_killer\":";    j += state.nag_killer                   ? "true" : "false"; j += ',';
     j += "\"bms_output\":";    j += state.bms_output                   ? "true" : "false"; j += ',';
     j += "\"force_fsd\":";     j += state.force_fsd                    ? "true" : "false"; j += ',';
@@ -894,6 +909,30 @@ static void ws_event(uint8_t num, WStype_t type,
         if (g_can) g_can->setListenOnly(!active);
         Serial.println(active ? "[Web] → Active mode" : "[Web] → Listen-Only mode");
         prefs_save(&saved);
+    } else if (strstr(buf, "\"fsd_unlock\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->fsd_unlock = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] FSD Unlock: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"ignore_ota\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->ignore_ota = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Ignore OTA: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
     } else if (strstr(buf, "\"nag\"")) {
         if (vptr) {
             while (*vptr == ' ' || *vptr == ':') vptr++;

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -33,7 +33,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - HW3/HW4/Legacy auto-detection via `0x398` GTW_carConfig
 - NAG Killer (EPAS `0x370` counter+1 echo with handsOnLevel spoofing)
 - Speed profile mapping from follow-distance stalk
-- OTA update detection and automatic TX suspension
+- OTA update detection with automatic TX suspension by default, plus an explicit Ignore OTA override
 - ISA speed warning chime suppression (HW4)
 - BMS data parsing logic (voltage, current, SOC, temperature) — currently not reliable in real use
 - Battery precondition trigger
@@ -55,6 +55,8 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - **CAN Bus Stats** — RX frame count, TX modified count, CRC errors, frames/second
 - **Web Controls** — toggle buttons for:
   - Activate/Stop FSD (Listen-Only ↔ Active mode switch)
+  - FSD Unlock on/off (allows Active mode without modifying autopilot FSD unlock frames)
+  - Ignore OTA on/off (allows Active mode TX during a detected Tesla OTA)
   - NAG Killer on/off
   - BMS serial output on/off
   - Force FSD toggle
@@ -82,7 +84,7 @@ Dual CAN driver support (compile-time switch):
 | **ISA Chime Suppress** | `0x399` | Kills speed warning chime (HW4 only) |
 | **Battery Precondition** | `0x082` | Frame builder implemented; no user control exposed yet |
 | **BMS Dashboard** | `0x132`/`0x292`/`0x312` | Parsing/UI path implemented, but currently not working reliably |
-| **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected |
+| **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected unless Ignore OTA is enabled |
 | **HW Auto-Detect** | `0x398` | Reads GTW_carConfig for HW version |
 | **Listen-Only Mode** | — | Default on boot, passive monitoring only |
 | **Wiring Check** | — | rx_count + CRC error monitoring |
@@ -264,7 +266,7 @@ pio device monitor -b 115200
 |-------|-------|
 | 🔵 Blue | Listen-Only (passive monitoring) |
 | 🟢 Green | Active (FSD enabled, transmitting) |
-| 🟡 Yellow | OTA detected (TX suspended) |
+| 🟡 Yellow | OTA detected |
 | 🔴 Red | Error (no CAN signal / CRC errors) |
 
 ### WiFi Dashboard
@@ -278,7 +280,7 @@ pio device monitor -b 115200
 
 ## Safety
 
-- **OTA Protection** — automatically stops all CAN TX when a software update is detected on `0x318`
+- **OTA Protection** — automatically stops all CAN TX when a software update is detected on `0x318`; Ignore OTA can override this in Active mode
 - **Listen-Only default** — device will not modify any CAN frames until explicitly switched to Active mode
 - **Wiring diagnostics** — monitors rx_count and CRC error counter; red LED if no CAN traffic
 - **DLC validation** — checks frame data length before parsing to prevent buffer overflows


### PR DESCRIPTION
Adds two ESP32 runtime safety controls to the dashboard and NVS persistence: FSD Unlock, which allows Active mode without modifying autopilot unlock frames, and Ignore OTA, an explicit override that allows CAN TX during detected Tesla OTA updates. Defaults preserve current safe behavior.
