### PR TITLE
feat(esp32): add HTTP CAN log stream

### DIFF
--- a/esp32/.firmware/http_can_stream.cpp
+++ b/esp32/.firmware/http_can_stream.cpp
@@ -1,0 +1,395 @@
+#include "http_can_stream.h"
+#include <WiFi.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HTTP_CAN_STREAM_PORT 82
+#define HTTP_CAN_STREAM_RING_SIZE 3072u
+#define HTTP_CAN_STREAM_FLUSH_BUDGET 160u
+#define HTTP_CAN_STREAM_MAX_FILTER_IDS 32u
+
+struct StreamFrame {
+    uint32_t elapsed_ms;
+    CanFrame frame;
+};
+
+static WiFiServer g_server(HTTP_CAN_STREAM_PORT);
+static WiFiClient g_client;
+static bool       g_started = false;
+static bool       g_active = false;
+static bool       g_enabled = true;
+static uint32_t   g_start_ms = 0;
+static uint32_t   g_sent = 0;
+static uint32_t   g_dropped = 0;
+static uint32_t   g_filtered = 0;
+static uint16_t   g_head = 0;
+static uint16_t   g_tail = 0;
+static StreamFrame g_ring[HTTP_CAN_STREAM_RING_SIZE];
+static uint32_t   g_filter_ids[HTTP_CAN_STREAM_MAX_FILTER_IDS];
+static uint8_t    g_filter_count = 0;
+
+static uint16_t ring_next(uint16_t index) {
+    return (uint16_t)((index + 1u) % HTTP_CAN_STREAM_RING_SIZE);
+}
+
+static bool ring_empty() {
+    return g_head == g_tail;
+}
+
+static bool ring_full() {
+    return ring_next(g_head) == g_tail;
+}
+
+static uint16_t ring_count() {
+    if (g_head >= g_tail) return (uint16_t)(g_head - g_tail);
+    return (uint16_t)(HTTP_CAN_STREAM_RING_SIZE - g_tail + g_head);
+}
+
+static void ring_reset() {
+    g_head = 0;
+    g_tail = 0;
+}
+
+static void filter_reset() {
+    g_filter_count = 0;
+}
+
+static bool filter_matches(uint32_t id) {
+    if (g_filter_count == 0) return true;
+    for (uint8_t i = 0; i < g_filter_count; i++) {
+        if (g_filter_ids[i] == id) return true;
+    }
+    return false;
+}
+
+static int from_hex_digit(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static bool url_decode(char *s) {
+    char *src = s;
+    char *dst = s;
+    while (*src) {
+        if (*src == '+') {
+            *dst++ = ' ';
+            src++;
+        } else if (*src == '%') {
+            int hi = from_hex_digit(src[1]);
+            int lo = from_hex_digit(src[2]);
+            if (hi < 0 || lo < 0) return false;
+            *dst++ = (char)((hi << 4) | lo);
+            src += 3;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+    return true;
+}
+
+static bool parse_filter(char *filter) {
+    filter_reset();
+    if (filter == nullptr || filter[0] == '\0') return true;
+    if (!url_decode(filter)) return false;
+
+    char *p = filter;
+    for (;;) {
+        while (*p == ' ' || *p == '\t' || *p == ',') p++;
+        if (*p == '\0') return true;
+
+        char *start = p;
+        while (*p != '\0' && *p != ',') p++;
+        char saved = *p;
+        *p = '\0';
+
+        char *end = start + strlen(start);
+        while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+            *--end = '\0';
+        }
+        if (*start == '\0') return false;
+        if (g_filter_count >= HTTP_CAN_STREAM_MAX_FILTER_IDS) return false;
+
+        char *parse_start = start;
+        if (parse_start[0] == '0' && (parse_start[1] == 'x' || parse_start[1] == 'X')) {
+            parse_start += 2;
+        }
+        char *parse_end = nullptr;
+        uint32_t id = (uint32_t)strtoul(parse_start, &parse_end, 16);
+        if (parse_end == parse_start || *parse_end != '\0') return false;
+        if (id > 0x1FFFFFFFu) return false;
+
+        bool duplicate = false;
+        for (uint8_t i = 0; i < g_filter_count; i++) {
+            if (g_filter_ids[i] == id) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (!duplicate) g_filter_ids[g_filter_count++] = id;
+
+        if (saved == '\0') return true;
+        *p++ = saved;
+    }
+}
+
+static bool configure_filter_from_path(char *path) {
+    char *query = strchr(path, '?');
+    if (query == nullptr) {
+        filter_reset();
+        return true;
+    }
+
+    *query++ = '\0';
+    filter_reset();
+    char *param = query;
+    while (param != nullptr && *param != '\0') {
+        char *next = strchr(param, '&');
+        if (next) *next++ = '\0';
+        if (strncmp(param, "ids=", 4) == 0) {
+            return parse_filter(param + 4);
+        }
+        param = next;
+    }
+    return true;
+}
+
+static void close_stream() {
+    if (g_client) {
+        g_client.flush();
+        g_client.stop();
+    }
+    if (g_active) {
+        Serial.printf("[HTTP-CAN] Stream stopped  sent=%lu dropped=%lu\n",
+                      (unsigned long)g_sent, (unsigned long)g_dropped);
+    }
+    g_active = false;
+    ring_reset();
+}
+
+static void send_response(WiFiClient &client, int code, const char *status, const char *body) {
+    client.printf("HTTP/1.1 %d %s\r\n", code, status);
+    client.print("Content-Type: text/plain; charset=utf-8\r\n");
+    client.print("Cache-Control: no-store\r\n");
+    client.print("Access-Control-Allow-Origin: *\r\n");
+    client.print("X-Content-Type-Options: nosniff\r\n");
+    client.print("Connection: close\r\n\r\n");
+    if (body != nullptr) client.print(body);
+    client.flush();
+    client.stop();
+}
+
+static void begin_stream(WiFiClient &client) {
+    close_stream();
+    g_client = client;
+    g_client.setNoDelay(true);
+    g_start_ms = millis();
+    g_sent = 0;
+    g_dropped = 0;
+    g_filtered = 0;
+    ring_reset();
+
+    g_client.print("HTTP/1.1 200 OK\r\n");
+    g_client.print("Content-Type: text/plain; charset=utf-8\r\n");
+    g_client.print("Cache-Control: no-store\r\n");
+    g_client.print("Access-Control-Allow-Origin: *\r\n");
+    g_client.print("X-Content-Type-Options: nosniff\r\n");
+    g_client.print("Connection: close\r\n\r\n");
+    g_active = true;
+    Serial.printf("[HTTP-CAN] Stream started on :%u/stream filter_ids=%u\n",
+                  HTTP_CAN_STREAM_PORT, g_filter_count);
+}
+
+static bool parse_request_path(WiFiClient &client, char *path, size_t path_len) {
+    if (path_len == 0) return false;
+    path[0] = '\0';
+
+    client.setTimeout(20);
+    String request_line = client.readStringUntil('\n');
+    request_line.trim();
+    if (!request_line.startsWith("GET ")) return false;
+
+    int path_start = 4;
+    int path_end = request_line.indexOf(' ', path_start);
+    if (path_end <= path_start) return false;
+
+    size_t len = (size_t)(path_end - path_start);
+    if (len >= path_len) return false;
+    memcpy(path, request_line.c_str() + path_start, len);
+    path[len] = '\0';
+
+    uint32_t deadline = millis() + 20u;
+    while (client.connected() && millis() < deadline) {
+        if (!client.available()) break;
+        String header = client.readStringUntil('\n');
+        if (header == "\r" || header.length() == 0) break;
+    }
+    return true;
+}
+
+static void accept_client() {
+    WiFiClient incoming = g_server.available();
+    if (!incoming) return;
+
+    if (!g_enabled) {
+        send_response(incoming, 409, "Conflict", "HTTP CAN log disabled in Active mode\n");
+        return;
+    }
+
+    char path[256];
+    if (!parse_request_path(incoming, path, sizeof(path))) {
+        send_response(incoming, 400, "Bad Request", "Bad Request\n");
+        return;
+    }
+
+    uint8_t old_filter_count = g_filter_count;
+    uint32_t old_filter_ids[HTTP_CAN_STREAM_MAX_FILTER_IDS];
+    memcpy(old_filter_ids, g_filter_ids, sizeof(old_filter_ids));
+
+    if (!configure_filter_from_path(path)) {
+        g_filter_count = old_filter_count;
+        memcpy(g_filter_ids, old_filter_ids, sizeof(g_filter_ids));
+        send_response(incoming, 400, "Bad Request", "Invalid ids filter\n");
+        return;
+    }
+
+    if (strcmp(path, "/stream") != 0 && strcmp(path, "/canlog/stream") != 0) {
+        g_filter_count = old_filter_count;
+        memcpy(g_filter_ids, old_filter_ids, sizeof(g_filter_ids));
+        send_response(incoming, 404, "Not Found", "Not Found\n");
+        return;
+    }
+
+    begin_stream(incoming);
+}
+
+static bool write_all(const char *line, size_t len) {
+    if (!g_active || !g_client.connected()) return false;
+    size_t written = g_client.write((const uint8_t *)line, len);
+    return written == len;
+}
+
+static bool write_frame(const StreamFrame &item) {
+    uint32_t sec = item.elapsed_ms / 1000u;
+    uint32_t usec = (item.elapsed_ms % 1000u) * 1000u;
+    uint8_t dlc = item.frame.dlc;
+    if (dlc > 8) dlc = 8;
+
+    char line[72];
+    int pos;
+    if (item.frame.id <= 0x7FFu) {
+        pos = snprintf(line, sizeof(line), "(%lu.%06lu) can0 %03lX#",
+                       (unsigned long)sec,
+                       (unsigned long)usec,
+                       (unsigned long)item.frame.id);
+    } else {
+        pos = snprintf(line, sizeof(line), "(%lu.%06lu) can0 %08lX#",
+                       (unsigned long)sec,
+                       (unsigned long)usec,
+                       (unsigned long)item.frame.id);
+    }
+    if (pos < 0 || pos >= (int)sizeof(line)) return false;
+
+    for (uint8_t i = 0; i < dlc; i++) {
+        int wrote = snprintf(line + pos, sizeof(line) - (size_t)pos,
+                             "%02X", item.frame.data[i]);
+        if (wrote != 2) return false;
+        pos += wrote;
+    }
+    if (pos >= (int)sizeof(line) - 2) return false;
+    line[pos++] = '\r';
+    line[pos++] = '\n';
+
+    return write_all(line, (size_t)pos);
+}
+
+static void flush_stream() {
+    if (!g_active) return;
+    if (!g_client.connected()) {
+        close_stream();
+        return;
+    }
+
+    uint16_t budget = HTTP_CAN_STREAM_FLUSH_BUDGET;
+    while (budget > 0) {
+        if (ring_empty()) return;
+        if (!write_frame(g_ring[g_tail])) return;
+        g_tail = ring_next(g_tail);
+        g_sent++;
+        budget--;
+    }
+}
+
+void http_can_stream_init() {
+    if (g_started) return;
+    g_server.begin();
+    g_server.setNoDelay(true);
+    g_started = true;
+    Serial.printf("[HTTP-CAN] Stream endpoint: http://192.168.4.1:%u/stream\n",
+                  HTTP_CAN_STREAM_PORT);
+}
+
+void http_can_stream_update() {
+    if (!g_started) return;
+    if (!g_enabled) {
+        close_stream();
+        accept_client();
+        return;
+    }
+    accept_client();
+    flush_stream();
+}
+
+void http_can_stream_record(const CanFrame &frame) {
+    if (!g_enabled || !g_active || !g_client.connected()) return;
+    if (!filter_matches(frame.id)) {
+        g_filtered++;
+        return;
+    }
+
+    if (ring_full()) {
+        g_dropped++;
+        g_tail = ring_next(g_tail);
+    }
+
+    StreamFrame &slot = g_ring[g_head];
+    slot.elapsed_ms = millis() - g_start_ms;
+    slot.frame.id = frame.id;
+    slot.frame.dlc = frame.dlc > 8 ? 8 : frame.dlc;
+    memcpy(slot.frame.data, frame.data, slot.frame.dlc);
+    g_head = ring_next(g_head);
+}
+
+void http_can_stream_set_enabled(bool enabled) {
+    if (g_enabled == enabled) return;
+    g_enabled = enabled;
+    if (!g_enabled) {
+        close_stream();
+        Serial.println("[HTTP-CAN] Stream disabled in Active mode");
+    } else {
+        Serial.println("[HTTP-CAN] Stream enabled in Listen-Only mode");
+    }
+}
+
+bool http_can_stream_active() {
+    return g_enabled && g_active && g_client.connected();
+}
+
+uint32_t http_can_stream_frames_sent() {
+    return g_sent;
+}
+
+uint32_t http_can_stream_frames_dropped() {
+    return g_dropped;
+}
+
+uint32_t http_can_stream_frames_filtered() {
+    return g_filtered;
+}
+
+uint16_t http_can_stream_buffered_frames() {
+    return ring_count();
+}

--- a/esp32/.firmware/http_can_stream.h
+++ b/esp32/.firmware/http_can_stream.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Arduino.h>
+#include "fsd_handler.h"
+
+/**
+ * HTTP CAN stream logger.
+ *
+ * Serves a single plain HTTP stream on port 82 at /stream. The dashboard reads
+ * this stream with fetch(), stores the bytes in the browser, and saves them as
+ * a candump-compatible text file when the user stops collection.
+ */
+
+void     http_can_stream_init();
+void     http_can_stream_update();
+void     http_can_stream_record(const CanFrame &frame);
+void     http_can_stream_set_enabled(bool enabled);
+bool     http_can_stream_active();
+uint32_t http_can_stream_frames_sent();
+uint32_t http_can_stream_frames_dropped();
+uint32_t http_can_stream_frames_filtered();
+uint16_t http_can_stream_buffered_frames();

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -25,6 +25,7 @@
 #include "wifi_manager.h"
 #include "web_dashboard.h"
 #include "can_dump.h"
+#include "http_can_stream.h"
 #include "prefs.h"
 #if defined(BOARD_TTGO_DISPLAY)
 #include "display.h"
@@ -112,6 +113,7 @@ static void dispatch_clicks(int n) {
         saved = g_state;
         state_exit();
         g_can->setListenOnly(!active);
+        http_can_stream_set_enabled(!active);
         Serial.println(active ? "[BTN] → Active mode" : "[BTN] → Listen-Only mode");
         can_dump_log(active ? "MODE switched to Active — TX enabled" : "MODE switched to Listen-Only — TX disabled");
         prefs_save(&saved);
@@ -252,6 +254,9 @@ static void process_frame(const CanFrame &frame) {
     state_exit();
 
     can_dump_record(frame);
+    if (state_snapshot().op_mode == OpMode_ListenOnly) {
+        http_can_stream_record(frame);
+    }
 #if defined(BOARD_LILYGO)
     g_last_can_rx_ms = millis();
     g_sleep_warned   = false;
@@ -570,6 +575,7 @@ void setup() {
     // ── WiFi AP + Web dashboard (non-fatal if WiFi fails) ─────────────────────
     if (wifi_ap_init(&g_state)) {
         web_dashboard_init(&g_state, g_can, &g_state_mux);
+        http_can_stream_set_enabled(state_snapshot().op_mode == OpMode_ListenOnly);
     }
 }
 

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -11,6 +11,7 @@
 
 #include "web_dashboard.h"
 #include "can_dump.h"
+#include "http_can_stream.h"
 #include "prefs.h"
 #include <WebServer.h>
 #include <WebSocketsServer.h>
@@ -216,6 +217,12 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   color:var(--text);border-radius:8px;padding:11px;font-size:1em}
 .auth-actions{display:flex;gap:10px;margin-top:16px}
 .auth-actions button{flex:1;margin:0}
+.log-info{font-size:.74em;color:var(--text2);line-height:1.45;margin-top:8px}
+.log-actions{display:flex;gap:10px;margin-top:12px}
+.log-actions button{flex:1;margin:0}
+.log-filter{width:210px;max-width:60%;background:var(--card2);border:1px solid var(--border);
+  color:var(--text);border-radius:6px;padding:6px 8px;font-size:.8em;text-align:right}
+.log-filter::placeholder{color:var(--text3)}
 </style>
 </head>
 <body>
@@ -322,6 +329,35 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <div class="sb"><div class="sv" id="txCnt">0</div><div class="sl">TX Frames</div></div>
     <div class="sb"><div class="sv" id="crcErr">0</div><div class="sl">TX Errors</div></div>
     <div class="sb"><div class="sv" id="fps">0.0</div><div class="sl">Frames/s</div></div>
+  </div>
+</div>
+
+<!-- HTTP CAN Log -->
+<div class="card">
+  <div class="card-head"><div class="icon ic-d">L</div><h2>HTTP CAN Log</h2></div>
+  <div class="row">
+    <span class="lbl">Stream</span>
+    <span class="pill off" id="httpLogSt"><span class="pd"></span>Idle</span>
+  </div>
+  <div class="row">
+    <span class="lbl">Filter IDs</span>
+    <input id="httpLogFilter" class="log-filter" type="text" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="0x370, 0x3FD">
+  </div>
+  <div class="row">
+    <span class="lbl">Buffered</span>
+    <span id="httpLogBuf" style="font-size:.8em;color:var(--text2)">0 frames</span>
+  </div>
+  <div class="row">
+    <span class="lbl">Dropped</span>
+    <span id="httpLogDrop" style="font-size:.8em;color:var(--text2)">0 frames</span>
+  </div>
+  <div class="row">
+    <span class="lbl">Filtered</span>
+    <span id="httpLogFiltered" style="font-size:.8em;color:var(--text2)">0 frames</span>
+  </div>
+  <div id="httpLogInfo" class="log-info">Ready to collect a candump file in this browser.</div>
+  <div class="log-actions">
+    <button id="btnHttpLog" type="button" class="btn-main btn-blue" onclick="toggleHttpLog()">STREAM LOG AND SAVE</button>
   </div>
 </div>
 
@@ -473,6 +509,9 @@ R"rawliteral(</div>
 
 <script>
 var ws,rt,busy=0,wifiOnce=false,authHeader='',authAction=null,restartAnchor=null;
+var httpLogAbort=null,httpLogReader=null,httpLogParts=[],httpLogBytes=0,httpLogStarted=0,httpLogRunning=false;
+var httpLogName='',httpLogReady=false,httpLogSaveUrl='';
+var httpLogAllowed=true;
 var HW=['Unknown','Legacy','HW3','HW4'];
 var CIRC=326.73;
 
@@ -554,6 +593,27 @@ function upd(d){
   if(document.getElementById('txCnt')) document.getElementById('txCnt').textContent=(d.tx_count||0).toLocaleString();
   if(document.getElementById('crcErr')) document.getElementById('crcErr').textContent=d.crc_errors||0;
   if(document.getElementById('fps')) document.getElementById('fps').textContent=(d.fps||0.0).toFixed(1);
+  httpLogAllowed=d.op_mode!==1;
+  if(!httpLogAllowed&&httpLogRunning){
+    stopHttpLog('HTTP CAN log stopped because device entered Active mode.');
+  }
+  if(!httpLogRunning)setHttpLogUi(false);
+  if(!httpLogRunning){
+    if(httpLogReady){
+      pill('httpLogSt',true,'Ready');
+    }else{
+      pill('httpLogSt', d.http_can_stream && d.http_can_stream.active,
+        httpLogAllowed?((d.http_can_stream && d.http_can_stream.active)?'Streaming':'Idle'):'Disabled');
+    }
+  }
+  if(!httpLogRunning&&!httpLogReady&&document.getElementById('httpLogInfo')&&!httpLogAllowed)
+    logInfo('HTTP CAN log is available only in Listen-Only mode.','var(--yellow)');
+  if(document.getElementById('httpLogBuf'))
+    document.getElementById('httpLogBuf').textContent=((d.http_can_stream&&d.http_can_stream.buffered)||0)+' frames';
+  if(document.getElementById('httpLogDrop'))
+    document.getElementById('httpLogDrop').textContent=((d.http_can_stream&&d.http_can_stream.dropped)||0)+' frames';
+  if(document.getElementById('httpLogFiltered'))
+    document.getElementById('httpLogFiltered').textContent=((d.http_can_stream&&d.http_can_stream.filtered)||0)+' frames';
 
   // Battery
   if(d.bms && d.bms.seen){
@@ -740,6 +800,191 @@ function cmd(c,v){
 }
 function toggleMode(){ cmd('mode',null); }
 
+function logInfo(text,color){
+  var e=document.getElementById('httpLogInfo');
+  if(!e)return;
+  e.textContent=text;
+  e.style.color=color||'var(--text2)';
+}
+
+function setHttpLogUi(running){
+  var btn=document.getElementById('btnHttpLog');
+  if(btn){
+    btn.disabled=!httpLogAllowed&&!httpLogReady;
+    btn.style.opacity=btn.disabled?'.45':'1';
+    if(running){
+      btn.textContent='STOP COLLECTING';
+      btn.className='btn-main btn-stop';
+    }else if(httpLogReady){
+      btn.textContent='SAVE LOG FILE';
+      btn.className='btn-main btn-blue';
+    }else if(!httpLogAllowed){
+      btn.textContent='LISTEN-ONLY REQUIRED';
+      btn.className='btn-main btn-blue';
+    }else{
+      btn.textContent='STREAM LOG AND SAVE';
+      btn.className='btn-main btn-blue';
+    }
+  }
+  var filterEl=document.getElementById('httpLogFilter');
+  if(filterEl)filterEl.disabled=running;
+  pill('httpLogSt',running||httpLogReady,running?'Collecting':(httpLogReady?'Ready':'Idle'));
+}
+
+function formatBytes(n){
+  if(n<1024)return n+' B';
+  if(n<1048576)return (n/1024).toFixed(1)+' KB';
+  return (n/1048576).toFixed(1)+' MB';
+}
+
+function logFileName(){
+  var d=new Date();
+  function p(n){return n<10?'0'+n:''+n;}
+  return 'tesla_can_'+d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+'_'
+    +p(d.getHours())+p(d.getMinutes())+p(d.getSeconds())+'.dump';
+}
+
+function clearHttpLogBlob(){
+  if(httpLogSaveUrl)URL.revokeObjectURL(httpLogSaveUrl);
+  httpLogSaveUrl='';
+  httpLogName='';
+  httpLogReady=false;
+}
+
+function prepareHttpLogFile(){
+  clearHttpLogBlob();
+  if(httpLogBytes===0){
+    logInfo('No CAN frames collected. Nothing saved.','var(--yellow)');
+    httpLogParts=[];
+    setHttpLogUi(false);
+    return;
+  }
+  httpLogName=logFileName();
+  httpLogReady=true;
+  setHttpLogUi(false);
+  logInfo('Log ready in phone memory: '+httpLogName+' ('+formatBytes(httpLogBytes)+'). Tap SAVE LOG FILE.','var(--accent)');
+}
+
+function savePreparedHttpLog(){
+  if(!httpLogReady||httpLogBytes===0)return;
+  var blob=new Blob(httpLogParts,{type:'text/plain;charset=utf-8'});
+  if(blob.size===0){
+    logInfo('No CAN frames collected. Nothing saved.','var(--yellow)');
+    return;
+  }
+  if(window.File&&navigator.canShare&&navigator.share){
+    var file=new File([blob],httpLogName,{type:'text/plain'});
+    if(navigator.canShare({files:[file]})){
+      navigator.share({files:[file],title:httpLogName}).then(function(){
+        logInfo('Save/share requested for '+httpLogName+'.','var(--accent)');
+      }).catch(function(err){
+        logInfo('Share cancelled or failed: '+(err&&err.message?err.message:'unknown')+'. Trying download link...','var(--yellow)');
+        downloadHttpLogBlob(blob);
+      });
+      return;
+    }
+  }
+  downloadHttpLogBlob(blob);
+}
+
+function downloadHttpLogBlob(blob){
+  if(httpLogSaveUrl)URL.revokeObjectURL(httpLogSaveUrl);
+  httpLogSaveUrl=URL.createObjectURL(blob);
+  var a=document.createElement('a');
+  a.href=httpLogSaveUrl;
+  a.download=httpLogName;
+  a.rel='noopener';
+  a.textContent=httpLogName;
+  a.style.position='fixed';
+  a.style.left='0';
+  a.style.bottom='0';
+  a.style.opacity='0.01';
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(function(){a.remove();},1000);
+  logInfo('Save requested for '+httpLogName+'. If no file appears, tap SAVE LOG FILE again or use another browser.','var(--accent)');
+}
+
+function stopHttpLog(reason){
+  if(!httpLogRunning)return;
+  httpLogRunning=false;
+  if(httpLogReader)httpLogReader.cancel().catch(function(){});
+  if(httpLogAbort)httpLogAbort.abort();
+  httpLogReader=null;
+  httpLogAbort=null;
+  prepareHttpLogFile();
+  if(reason){
+    if(httpLogReady){
+      logInfo(reason+' Log ready in phone memory: '+httpLogName+' ('+formatBytes(httpLogBytes)+'). Tap SAVE LOG FILE.','var(--yellow)');
+    }else{
+      logInfo(reason,'var(--yellow)');
+    }
+  }
+}
+
+function startHttpLog(){
+  if(httpLogRunning)return;
+  if(!httpLogAllowed){
+    logInfo('Switch to Listen-Only mode before starting HTTP CAN log.','var(--yellow)');
+    setHttpLogUi(false);
+    return;
+  }
+  if(!window.ReadableStream){
+    alert('This browser does not support HTTP stream collection.');
+    return;
+  }
+  httpLogParts=[];
+  httpLogBytes=0;
+  clearHttpLogBlob();
+  httpLogStarted=Date.now();
+  httpLogRunning=true;
+  httpLogAbort=new AbortController();
+  setHttpLogUi(true);
+  logInfo('Connecting to HTTP stream...');
+
+  var streamUrl='http://'+location.hostname+':82/stream';
+  var filterEl=document.getElementById('httpLogFilter');
+  var filter=(filterEl&&filterEl.value)?filterEl.value.trim():'';
+  if(filter)streamUrl+='?ids='+encodeURIComponent(filter);
+
+  fetch(streamUrl,{cache:'no-store',signal:httpLogAbort.signal})
+    .then(function(r){
+      if(!r.ok)throw new Error('HTTP '+r.status);
+      if(!r.body)throw new Error('Readable stream unavailable');
+      logInfo('Collecting 0 B...');
+      var reader=r.body.getReader();
+      httpLogReader=reader;
+      function pump(){
+        return reader.read().then(function(result){
+          if(result.done)return;
+          if(result.value&&result.value.length){
+            httpLogParts.push(result.value);
+            httpLogBytes+=result.value.length;
+            var secs=Math.max(1,Math.round((Date.now()-httpLogStarted)/1000));
+            logInfo('Collecting '+formatBytes(httpLogBytes)+' for '+secs+'s...');
+          }
+          return pump();
+        });
+      }
+      return pump();
+    })
+    .catch(function(err){
+      if(!httpLogRunning)return;
+      httpLogRunning=false;
+      httpLogReader=null;
+      httpLogAbort=null;
+      setHttpLogUi(false);
+      logInfo('Stream stopped: '+(err&&err.message?err.message:'connection closed'),'var(--yellow)');
+      if(httpLogBytes>0)prepareHttpLogFile();
+    });
+}
+
+function toggleHttpLog(){
+  if(httpLogRunning)stopHttpLog();
+  else if(httpLogReady)savePreparedHttpLog();
+  else startHttpLog();
+}
+
 function conn(){
   ws=new WebSocket('ws://'+location.hostname+':81/');
   ws.onopen=function(){
@@ -852,6 +1097,12 @@ static String build_json() {
     j += "\"wifi_pass\":\"***\",";
     j += "\"wifi_hidden\":";  j += state.wifi_hidden                  ? "true" : "false"; j += ',';
     j += "\"wifi_clients\":";  j += (int)WiFi.softAPgetStationNum();   j += ',';
+    j += "\"http_can_stream\":{";
+    j += "\"active\":";       j += http_can_stream_active()           ? "true" : "false"; j += ',';
+    j += "\"sent\":";         j += http_can_stream_frames_sent();      j += ',';
+    j += "\"dropped\":";      j += http_can_stream_frames_dropped();   j += ',';
+    j += "\"filtered\":";     j += http_can_stream_frames_filtered();  j += ',';
+    j += "\"buffered\":";     j += http_can_stream_buffered_frames();  j += "},";
     j += "\"ota_partition\":"; j += ota_part;
     j += '}';
     return j;
@@ -892,6 +1143,7 @@ static void ws_event(uint8_t num, WStype_t type,
         saved = *g_state;
         state_exit();
         if (g_can) g_can->setListenOnly(!active);
+        http_can_stream_set_enabled(!active);
         Serial.println(active ? "[Web] → Active mode" : "[Web] → Listen-Only mode");
         prefs_save(&saved);
     } else if (strstr(buf, "\"nag\"")) {
@@ -1286,6 +1538,7 @@ void web_dashboard_init(FSDState *state, CanDriver *can, portMUX_TYPE *state_mux
     g_http.on("/restart",    HTTP_GET,  handle_restart);
     g_http.on("/update",     HTTP_POST, handle_ota_done, handle_ota_upload);
     g_http.begin();
+    http_can_stream_init();
 
     g_ws.begin();
     g_ws.onEvent(ws_event);
@@ -1298,6 +1551,7 @@ void web_dashboard_update() {
 
     g_http.handleClient();
     g_ws.loop();
+    http_can_stream_update();
 
     // FPS calculation + 1 Hz WebSocket broadcast
     uint32_t now = millis();

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -53,6 +53,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - **Battery SOC Ring** — animated circular progress bar with color coding (green >60%, yellow >30%, red ≤30%)
 - **BMS Live Data UI hooks** — fields exist in UI/API, but BMS section is currently not working reliably on tested vehicle setup
 - **CAN Bus Stats** — RX frame count, TX modified count, CRC errors, frames/second
+- **HTTP CAN Log Stream** — phone-friendly candump collection via dashboard button; device streams CAN frames over HTTP on port 82 and the browser saves the collected `.dump` file on Stop
 - **Web Controls** — toggle buttons for:
   - Activate/Stop FSD (Listen-Only ↔ Active mode switch)
   - NAG Killer on/off
@@ -272,7 +273,9 @@ pio device monitor -b 115200
 1. Connect phone to WiFi: **Tesla-FSD** (password: **12345678**)
 2. Open browser: **http://192.168.4.1**
 3. Monitor and control everything from the web UI
-4. REST API available at `http://192.168.4.1/api/status`
+4. Tap **STREAM LOG AND SAVE** to collect a CAN log on the phone; tap **STOP COLLECTING**, then **SAVE LOG FILE** to save it as a candump `.dump` file
+5. REST API available at `http://192.168.4.1/api/status`
+6. Raw CAN stream endpoint: `http://192.168.4.1:82/stream`
 
 ---
 
@@ -309,6 +312,7 @@ esp32/
 ├── .firmware/
 │   ├── main.cpp            — Init, button handling, main loop
 │   ├── fsd_handler.cpp/h   — CAN protocol logic (ported from hypery11)
+│   ├── http_can_stream.cpp/h — HTTP candump-compatible CAN stream
 │   ├── can_driver.cpp/h    — CAN driver abstraction (TWAI / MCP2515)
 │   ├── wifi_manager.cpp/h  — WiFi AP setup
 │   ├── web_dashboard.cpp/h — HTTP server + WebSocket + embedded UI


### PR DESCRIPTION
Adds a phone-friendly HTTP CAN log stream for ESP32. In Listen-Only mode, the device streams candump-compatible CAN frames on port 82, and the dashboard can collect, filter, stop, and save the log as a .dump file from the browser.
