### PR TITLE
fix(esp32): count only sent modified frames

### DIFF
--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -221,7 +221,6 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
         }
     }
 
-    if (modified) state->frames_modified++;
     return modified;
 }
 
@@ -262,7 +261,6 @@ bool fsd_handle_legacy_autopilot(FSDState *state, CanFrame *frame) {
         modified = true;
     }
 
-    if (modified) state->frames_modified++;
     return modified;
 }
 

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -34,7 +34,7 @@ struct FSDState {
     bool           fsd_enabled;     // true when car's UI has FSD selected (mux0)
     bool           nag_suppressed;  // true after first nag-killer echo sent
 
-    uint32_t       frames_modified; // count of autopilot frames (0x3FD/0x3EE) we patched
+    uint32_t       frames_modified; // count of modified/spoofed frames successfully sent
     uint32_t       tx_count;        // total frames successfully transmitted on the bus
                                     // (autopilot mods + nag echoes + ISA + TLSSC + precond)
 

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -71,6 +71,14 @@ static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
     can_dump_log("HW  auto-detected: %s (%s)", hw_str, reason);
 }
 
+static bool send_modified_frame(const CanFrame &frame) {
+    if (!g_can || !g_can->send(frame)) return false;
+    state_enter();
+    g_state.frames_modified++;
+    state_exit();
+    return true;
+}
+
 // ── Button state machine ──────────────────────────────────────────────────────
 static uint32_t g_btn_down_ms     = 0;
 static uint32_t g_last_release_ms = 0;
@@ -312,7 +320,7 @@ static void process_frame(const CanFrame &frame) {
             uint8_t cnt_out = echo.data[6] & 0x0F;
             can_dump_log("NAG 0x370 hands_off lvl=%u cnt=%u->%u %s",
                          lvl, cnt_in, cnt_out, tx ? "TX echo" : "listen-only no-TX");
-            if (tx) g_can->send(echo);
+            if (tx) send_modified_frame(echo);
         }
         return;
     }
@@ -331,7 +339,7 @@ static void process_frame(const CanFrame &frame) {
         state_enter();
         bool modified = fsd_handle_legacy_autopilot(&g_state, &f);
         state_exit();
-        if (modified && tx) g_can->send(f);
+        if (modified && tx) send_modified_frame(f);
         return;
     }
 
@@ -365,7 +373,7 @@ static void process_frame(const CanFrame &frame) {
         s.suppress_speed_chime) {
         CanFrame f = frame;
         if (fsd_handle_isa_speed_chime(&f) && tx)
-            g_can->send(f);
+            send_modified_frame(f);
         return;
     }
 
@@ -383,7 +391,7 @@ static void process_frame(const CanFrame &frame) {
         state_enter();
         bool modified = fsd_handle_tlssc_restore(&g_state, &f);
         state_exit();
-        if (modified && tx) g_can->send(f);
+        if (modified && tx) send_modified_frame(f);
         return;
     }
 
@@ -393,7 +401,7 @@ static void process_frame(const CanFrame &frame) {
         state_enter();
         bool modified = fsd_handle_autopilot_frame(&g_state, &f);
         state_exit();
-        if (modified && tx) g_can->send(f);
+        if (modified && tx) send_modified_frame(f);
         return;
     }
 }

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -319,8 +319,8 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   <div class="card-head"><div class="icon ic-d">C</div><h2>CAN Bus</h2></div>
   <div class="sg">
     <div class="sb"><div class="sv" id="rxCnt">0</div><div class="sl">RX Frames</div></div>
-    <div class="sb"><div class="sv" id="txCnt">0</div><div class="sl">TX Frames</div></div>
-    <div class="sb"><div class="sv" id="crcErr">0</div><div class="sl">TX Errors</div></div>
+    <div class="sb"><div class="sv" id="txCnt">0</div><div class="sl">TX Modified</div></div>
+    <div class="sb"><div class="sv" id="crcErr">0</div><div class="sl">CAN Errors</div></div>
     <div class="sb"><div class="sv" id="fps">0.0</div><div class="sl">Frames/s</div></div>
   </div>
 </div>

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -52,7 +52,7 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - **FSD Status Panel** — FSD active/waiting, Listen-Only/Active mode, HW version, NAG Killer state
 - **Battery SOC Ring** — animated circular progress bar with color coding (green >60%, yellow >30%, red ≤30%)
 - **BMS Live Data UI hooks** — fields exist in UI/API, but BMS section is currently not working reliably on tested vehicle setup
-- **CAN Bus Stats** — RX frame count, TX modified count, CRC errors, frames/second
+- **CAN Bus Stats** — RX frame count, TX modified count, CAN driver errors, frames/second
 - **Web Controls** — toggle buttons for:
   - Activate/Stop FSD (Listen-Only ↔ Active mode switch)
   - NAG Killer on/off
@@ -85,7 +85,7 @@ Dual CAN driver support (compile-time switch):
 | **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected |
 | **HW Auto-Detect** | `0x398` | Reads GTW_carConfig for HW version |
 | **Listen-Only Mode** | — | Default on boot, passive monitoring only |
-| **Wiring Check** | — | rx_count + CRC error monitoring |
+| **Wiring Check** | — | rx_count + CAN error monitoring |
 | **WiFi Dashboard** | — | Real-time web UI at 192.168.4.1 |
 
 ---
@@ -265,7 +265,7 @@ pio device monitor -b 115200
 | 🔵 Blue | Listen-Only (passive monitoring) |
 | 🟢 Green | Active (FSD enabled, transmitting) |
 | 🟡 Yellow | OTA detected (TX suspended) |
-| 🔴 Red | Error (no CAN signal / CRC errors) |
+| 🔴 Red | Error (no CAN signal / CAN errors) |
 
 ### WiFi Dashboard
 
@@ -280,7 +280,7 @@ pio device monitor -b 115200
 
 - **OTA Protection** — automatically stops all CAN TX when a software update is detected on `0x318`
 - **Listen-Only default** — device will not modify any CAN frames until explicitly switched to Active mode
-- **Wiring diagnostics** — monitors rx_count and CRC error counter; red LED if no CAN traffic
+- **Wiring diagnostics** — monitors rx_count and CAN driver error counter; red LED if no CAN traffic
 - **DLC validation** — checks frame data length before parsing to prevent buffer overflows
 - **Unplug = reset** — remove the device and restart the car to clear any modified state
 - **WiFi isolated** — AP mode only, no internet connection, no data leaves the device


### PR DESCRIPTION
Fixes ESP32 modified-frame accounting so frames_modified increments only after a modified/spoofed CAN frame is successfully transmitted. This makes dashboard TX modified stats reflect actual bus sends instead of attempted frame modifications.
