### PR TITLE
docs: clean up Feifan references and local ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist/
 .vscode/
 .ufbt/
 .DS_Store
+.idea
+.tmp

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -205,7 +205,7 @@ And these "Vehicle CAN" signals are also writable on bus 6:
 
 **One bus, one connection, reads and writes almost everything.**
 
-This is how the 非凡指揮官 (Feifan Commander, 69K+ sales in China)
+This is how the Feifan Commander (69K+ sales in China)
 achieves its full feature set with just 4 wires:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[English](README.md) | [繁體中文](README_zh-TW.md) | [简体中文](README_zh-CN.md)
+[English](README.md) | [Traditional Chinese](README_zh-TW.md) | [Simplified Chinese](README_zh-CN.md)
 
 # Tesla Mod for Flipper Zero
 

--- a/changelog.md
+++ b/changelog.md
@@ -125,7 +125,7 @@
   - `VCRIGHT_rearDefrostState (0x343)`: rear window defrost.
 - **Extras scene expanded** to 10 toggles: Hazard, Rear Window Heat, Auto Wipers Off, Fold Mirrors, Rear Fog, Steering [ChassisCAN], High Beam Strobe, Turn Left, Turn Right.
 - **New research docs:**
-  - `enhauto-re/FEIFAN_CAN_ANALYSIS.md` — technical analysis of the 非凡指揮官 (Feifan Commander, 69K+ sales in China) CAN injection techniques: continuous AP, stalk simulation, strobe, checksum formulas.
+  - `enhauto-re/FEIFAN_CAN_ANALYSIS.md` — technical analysis of the Feifan Commander (69K+ sales in China) CAN injection techniques: continuous AP, stalk simulation, strobe, checksum formulas.
   - `enhauto-re/COMMANDER_VS_TESLAMOD.md` — three-way feature comparison between enhauto S3XY Commander, Feifan Commander, and Tesla Mod.
 
 ## 2.5 — Tesla Mod

--- a/enhauto-re/FEIFAN_CAN_ANALYSIS.md
+++ b/enhauto-re/FEIFAN_CAN_ANALYSIS.md
@@ -1,4 +1,4 @@
-# 非凡指揮官 CAN Signal Analysis
+# Feifan Commander CAN Signal Analysis
 
 How the Feifan Commander (TSL 6th gen module, ~69K units sold in China)
 likely implements its key features using CAN bus injection via OBD-II.
@@ -177,5 +177,5 @@ Reads from `DAS_status (0x39B)`:
 
 - opendbc/dbc/tesla_model3_party.dbc — Party CAN signal definitions
 - opendbc/dbc/tesla_model3_vehicle.dbc — Vehicle CAN signal definitions
-- Non-public: 非凡指揮官 product feature list (from Bilibili/Taobao)
+- Non-public: Feifan Commander product feature list (from Bilibili/Taobao)
 - Inference: matching features to available CAN signals by elimination


### PR DESCRIPTION
Small docs and hygiene cleanup. Adds .idea and .tmp to .gitignore, changes README language selector labels to English, and standardizes English docs to use “Feifan Commander” wording.
