### PR TITLE
fix(flipper): HW3 0x399 DAS_status parser + Suppress Chime HW gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 | `0x082` | `UI_tripPlanning` | TX | Battery preconditioning trigger |
 | `0x398` | `GTW_carConfig` | RX | HW version detection |
 | `0x318` | `GTW_carState` | RX | OTA detection (auto-suspend TX) |
-| `0x39B` | `DAS_status` | RX | ESP32 HW4 DAS status source; AP state (for AP-First), nag level, lane change, blind spot |
+| `0x399` | `DAS_status` (HW3/Legacy) / `ISA_speedLimit` (HW4) | RX/TX | HW-dispatched: pre-Highland HW3 reads as DAS_status (AP state + hands-on); HW4 keeps the chime-suppression write path |
+| `0x39B` | `DAS_status` | RX | HW4 + Highland HW3 — AP state (for AP-First), nag level, lane change, blind spot |
 | `0x132` | `BMS_hvBusStatus` | RX | Pack voltage / current |
 | `0x292` | `BMS_socStatus` | RX | State of charge |
 | `0x312` | `BMS_thermalStatus` | RX | Battery temperature |

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -387,10 +387,29 @@ void fsd_build_steering_tune_frame(CANFRAME* frame, uint8_t mode) {
     frame->buffer[0] = (mode & 0x07) << 2;
 }
 
-// --- DAS_status (0x39B) parser: AP state, blind spot, FCW, speed limit ---
-// opendbc tesla_model3_party.dbc — all little-endian
+// --- DAS_status parser: AP state, blind spot, FCW, speed limit ---
+//
+// HW-dependent CAN ID + byte layout:
+//   Pre-Highland HW3 / Legacy: 0x399 (legacy CAN map per opendbc/tesla_can.dbc)
+//   Highland HW3 / HW4:        0x39B (party CAN map per opendbc/tesla_model3_party.dbc)
+//
+// HW3 layout (0x399, legacy):
+//   byte 0 low nibble = DAS_autopilotState   (2=available, 3=engaged)
+//   byte 5 bits[5:2]  = DAS_handsOnState     (matches HW4 position)
+//
+// HW4 layout (0x39B, party): full multi-signal parser below.
+//
+// v2.14 silently broke pre-Highland HW3 users by reading 0x39B only.
+// Caller dispatches by hw_version in scenes/fsd_running.c.
 
-void fsd_handle_das_status(FSDState* state, const CANFRAME* frame) {
+void fsd_handle_das_status_hw3(FSDState* state, const CANFRAME* frame) {
+    if(frame->data_lenght < 6) return;
+    state->das_ap_state = frame->buffer[0] & 0x0Fu;
+    state->das_hands_on_state = (frame->buffer[5] >> 2) & 0x0Fu;
+    state->das_seen = true;
+}
+
+void fsd_handle_das_status_hw4(FSDState* state, const CANFRAME* frame) {
     if(frame->data_lenght < 7) return;
     // DAS_autopilotState: bit12|4 → byte1 bits[7:4]
     // 0=UNAVAIL 1=AVAIL 2=ACTIVE_NOMINAL 3=ACTIVE_MIN_DRIVER ...
@@ -734,7 +753,7 @@ void fsd_handle_das_steering(FSDState* state, const CANFRAME* frame) {
 // Improved from ev-open-can-tools PR #5 (zdenekbouresh):
 //
 // 1. DAS-aware gating: only echo when DAS_autopilotHandsOnState (from
-//    0x39B, already parsed in fsd_handle_das_status) indicates the car
+//    0x39B/0x399, already parsed in fsd_handle_das_status_hw3/hw4) indicates the car
 //    is actually demanding hands-on. States 0 (NOT_REQD) and 8
 //    (SUSPENDED) mean DAS is satisfied — no echo needed. This reduces
 //    spurious bus traffic from ~25 frames/sec to near-zero during normal
@@ -774,7 +793,8 @@ bool fsd_handle_nag_killer(FSDState* state, const CANFRAME* frame, CANFRAME* out
     if(hands_on == 1) return false;
 
     // DAS-aware gating: skip echo when DAS is satisfied or AP suspended.
-    // das_hands_on_state is parsed from 0x39B in fsd_handle_das_status().
+    // das_hands_on_state is parsed from 0x39B (HW4) or 0x399 (HW3) in
+    // fsd_handle_das_status_hw4 / fsd_handle_das_status_hw3.
     // 0 = NOT_REQD (satisfied), 8 = SUSPENDED (AP paused).
     // 0xFF = no DAS frame seen yet — echo conservatively as fallback.
     uint8_t das = state->das_hands_on_state;

--- a/fsd_logic/fsd_handler.h
+++ b/fsd_logic/fsd_handler.h
@@ -25,7 +25,8 @@
 #define CAN_ID_DI_SPEED       0x257  // 599  - DI_speed (vehicle speed, checksummed)
 #define CAN_ID_ESP_STATUS     0x145  // 325  - ESP_status (brake, stability)
 #define CAN_ID_GTW_EPAS_CTRL  0x101  // 257  - GTW_epasControl (steering tune WRITE, Chassis CAN)
-#define CAN_ID_DAS_STATUS     0x39B  // 923  - DAS_status (AP state, nag, lane change, blind spot)
+#define CAN_ID_DAS_STATUS     0x39B  // 923  - DAS_status (HW4 + Highland HW3; AP state, nag, lane change, blind spot)
+#define CAN_ID_DAS_STATUS_HW3 0x399  // 921  - DAS_status (pre-Highland HW3 / Legacy, same ID as HW4 ISA chime — HW-dependent meaning)
 #define CAN_ID_DAS_STATUS2    0x389  // 905  - DAS_status2 (ACC report, driver interaction)
 #define CAN_ID_DAS_SETTINGS   0x293  // 659  - DAS_settings (autosteer enable, steering weight, etc.)
 #define CAN_ID_DAS_AP_CONFIG  0x331  // 817  - DAS autopilot config (tier restore target, ~1 Hz)
@@ -285,7 +286,11 @@ void fsd_build_steering_tune_frame(CANFRAME* frame, uint8_t mode);
 /** Parse DAS_status (0x39B) — AP hands-on state, lane change, blind spot,
  *  FCW, vision speed limit. All Party CAN, read-only.
  *  Source: opendbc tesla_model3_party.dbc. */
-void fsd_handle_das_status(FSDState* state, const CANFRAME* frame);
+/** HW4 / Highland HW3 DAS_status parser (0x39B, party CAN layout). */
+void fsd_handle_das_status_hw4(FSDState* state, const CANFRAME* frame);
+/** Pre-Highland HW3 / Legacy DAS_status parser (0x399, legacy CAN layout).
+ *  Same frame ID as HW4 ISA_SPEED — caller dispatches by HW version. */
+void fsd_handle_das_status_hw3(FSDState* state, const CANFRAME* frame);
 
 /** Parse DAS_status2 (0x389) — ACC report, activation failure.
  *  Source: opendbc tesla_model3_party.dbc. */

--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -281,7 +281,7 @@ static int32_t fsd_running_worker(void* context) {
                     fsd_handle_esp_status(&state, &frame);
                 }
                 else if(frame.canId == CAN_ID_DAS_STATUS) {
-                    fsd_handle_das_status(&state, &frame);
+                    fsd_handle_das_status_hw4(&state, &frame);
                 }
                 else if(frame.canId == CAN_ID_DAS_STATUS2) {
                     fsd_handle_das_status2(&state, &frame);
@@ -362,9 +362,17 @@ static int32_t fsd_running_worker(void* context) {
                     if(fsd_handle_legacy_autopilot(&state, &frame) && tx_allowed) {
                         send_can_frame(mcp, &frame);
                     }
-                } else if(frame.canId == CAN_ID_ISA_SPEED && state.suppress_speed_chime) {
-                    if(fsd_handle_isa_speed_chime(&frame) && tx_allowed) {
-                        send_can_frame(mcp, &frame);
+                } else if(frame.canId == CAN_ID_ISA_SPEED) {
+                    // 0x399 is HW-dependent: HW4 = ISA chime, HW3/Legacy = DAS_status.
+                    // Suppress Chime is HW4-only because writing the HW4 ISA bits
+                    // on HW3 would corrupt the DAS_status payload.
+                    if(state.hw_version == TeslaHW_HW4) {
+                        if(state.suppress_speed_chime &&
+                           fsd_handle_isa_speed_chime(&frame) && tx_allowed) {
+                            send_can_frame(mcp, &frame);
+                        }
+                    } else {
+                        fsd_handle_das_status_hw3(&state, &frame);
                     }
                 } else if(frame.canId == CAN_ID_FOLLOW_DIST) {
                     fsd_handle_follow_distance(&state, &frame);


### PR DESCRIPTION
## Summary

Mirror of @vrs11's ESP32 fix ([PR #92](https://github.com/hypery11/flipper-tesla-fsd/pull/92), already merged) on the Flipper side. v2.14 silently broke pre-Highland HW3 (Intel Atom, MCU2 generation) users on the Flipper port in two ways:

1. **AP-First mode and DAS-aware nag gating** both read `das_ap_state` from `0x39B`, which never arrives on pre-Highland HW3 buses. AP-First's gate stayed false forever; nag killer fell back to the conservative-echo path with no DAS gating.

2. **Suppress Chime** was unconditionally writing `0x399` byte 1 bit 5 + recomputing the HW4 ISA-format checksum. On HW3 cars `0x399` carries DAS_status — byte 1 has hands-on data, byte 7 has a different checksum format — so the chime path was actively corrupting DAS_status frames on enable. (Default is OFF, so this only hits HW3 users who enabled Suppress Chime explicitly, but the failure mode is silent and bad.)

## Changes

- **Split `fsd_handle_das_status` into HW3 and HW4 variants:**
  - `fsd_handle_das_status_hw3(state, frame)` — legacy 0x399 layout: byte 0 low nibble = `DAS_autopilotState`, byte 5 bits[5:2] = `DAS_handsOnState`
  - `fsd_handle_das_status_hw4(state, frame)` — existing 0x39B parser body, renamed
- **Scene-loop dispatch:**
  - `0x39B` → always HW4 parser (Highland HW3 + HW4 both use this)
  - `0x399` → HW-dispatch: HW4 keeps the existing chime-suppression write path; HW3/Legacy reads as DAS_status (read-only)
- **`Suppress Chime` is gated on `hw_version == TeslaHW_HW4`** so the corruption bug above cannot be triggered from the user toggle, even if a HW3 user mis-configures.
- **New `CAN_ID_DAS_STATUS_HW3 = 0x399`** in `fsd_handler.h` for clarity. Same ID as `CAN_ID_ISA_SPEED`; the HW-dependent meaning is documented inline.
- Internal nag killer / AP-First comments updated to reference both source IDs.

## Files

| File | Δ |
|---|---|
| `fsd_logic/fsd_handler.c` | +25/-5 — new HW3 parser + comment updates |
| `fsd_logic/fsd_handler.h` | +7/-2 — new CAN ID + function decls |
| `scenes/fsd_running.c` | +12/-4 — HW-aware dispatch on `0x399` and `0x39B` |
| `README.md` | +2/-1 — CAN IDs table reflects HW-dependent 0x399 meaning |

## Why this is separate from PR #92

PR #92 was scoped to the ESP32 port only — symbolic constants refactor + ESP32 dispatch logic. The Flipper has its own `fsd_logic/fsd_handler.c` that shares the protocol logic but not the file structure. This PR carries the same architectural decision over.

## Test plan

- [x] Build: clean against ufbt SDK API 87.1 ✅
- [ ] HW4 car: behavior unchanged (Suppress Chime still works, AP-First gates on 0x39B as before)
- [ ] Pre-Highland HW3 car: AP-First now triggers correctly (das_ap_state populated from 0x399)
- [ ] Pre-Highland HW3 car with Suppress Chime ON: no longer corrupts DAS_status (toggle is now no-op on non-HW4)
- [ ] Highland HW3 car: behavior unchanged (still reads from 0x39B per party CAN map)

## Credit

Architectural primary contributor: @vrs11 (PR #92 ESP32 fix, where the HW3 0x399 vs HW4 0x39B split was first identified and implemented based on real-car testing on M3 2020 HW3 EU).