### PR TITLE
feat(esp32): add LilyGO T-2CAN dual bus support

### DIFF
--- a/esp32/.firmware/can_driver.cpp
+++ b/esp32/.firmware/can_driver.cpp
@@ -2,8 +2,9 @@
  * can_driver.cpp
  *
  * CAN driver abstraction: compile-time selection between
- *   CAN_DRIVER_TWAI   — ESP32 built-in TWAI peripheral (M5Stack ATOM Lite + ATOMIC CAN Base)
- *   CAN_DRIVER_MCP2515 — SPI-attached MCP2515 (generic ESP32 boards)
+ *   CAN_DRIVER_TWAI        — ESP32 built-in TWAI peripheral
+ *   CAN_DRIVER_MCP2515     — SPI-attached MCP2515
+ *   CAN_DRIVER_T2CAN_DUAL  — LilyGO T-2CAN: TWAI can0 + MCP2515 can1
  *
  * Both drivers implement the CanDriver interface from can_driver.h.
  */
@@ -14,19 +15,22 @@
 #include <string.h>
 
 // ── TWAI driver ───────────────────────────────────────────────────────────────
-#if defined(CAN_DRIVER_TWAI)
+#if defined(CAN_DRIVER_TWAI) || defined(CAN_DRIVER_T2CAN_DUAL)
 
 #include "driver/twai.h"
 
 class TwaiDriver : public CanDriver {
+    const char *label_;
+    int      tx_pin_;
+    int      rx_pin_;
     bool     listen_only_ = false;
     bool     installed_   = false;
     uint32_t tx_count_    = 0;
 
     bool install_and_start(bool listen_only) {
         twai_general_config_t g = TWAI_GENERAL_CONFIG_DEFAULT(
-            (gpio_num_t)PIN_CAN_TX,
-            (gpio_num_t)PIN_CAN_RX,
+            (gpio_num_t)tx_pin_,
+            (gpio_num_t)rx_pin_,
             listen_only ? TWAI_MODE_LISTEN_ONLY : TWAI_MODE_NORMAL);
         // Queue depths: 10 RX, 5 TX — sufficient for polling loop
         g.rx_queue_len = 10;
@@ -53,8 +57,15 @@ class TwaiDriver : public CanDriver {
     }
 
 public:
+    TwaiDriver(const char *label, int tx_pin, int rx_pin)
+        : label_(label), tx_pin_(tx_pin), rx_pin_(rx_pin) {}
+
     bool begin(bool listen_only) override {
-        return install_and_start(listen_only);
+        bool ok = install_and_start(listen_only);
+        Serial.printf("[CAN] %s TWAI %s @ 500 kbps (TX=%d RX=%d)\n",
+                      label_, ok ? (listen_only ? "Listen-Only" : "Normal") : "FAILED",
+                      tx_pin_, rx_pin_);
+        return ok;
     }
 
     bool send(const CanFrame &frame) override {
@@ -91,19 +102,27 @@ public:
     void setListenOnly(bool enable) override {
         if (listen_only_ == enable) return;
         stop_and_uninstall();
-        install_and_start(enable);
+        if (!install_and_start(enable)) {
+            Serial.printf("[CAN] %s TWAI mode switch FAILED\n", label_);
+        }
     }
 };
-
-CanDriver *can_driver_create() {
-    return new TwaiDriver();
-}
+#endif
 
 // ── MCP2515 driver ────────────────────────────────────────────────────────────
-#elif defined(CAN_DRIVER_MCP2515)
+#if defined(CAN_DRIVER_MCP2515) || defined(CAN_DRIVER_T2CAN_DUAL)
 
 #include <SPI.h>
 #include <mcp2515.h>   // autowp/autowp-mcp2515
+
+static const char *mcp_clock_name(CAN_CLOCK clock) {
+    switch (clock) {
+        case MCP_20MHZ: return "20 MHz";
+        case MCP_16MHZ: return "16 MHz";
+        case MCP_8MHZ:  return "8 MHz";
+        default:        return "?";
+    }
+}
 
 class Mcp2515Driver : public CanDriver {
 #if defined(BOARD_TTGO_DISPLAY)
@@ -111,6 +130,12 @@ class Mcp2515Driver : public CanDriver {
     bool     spi_begun_    = false;
 #endif
     MCP2515  mcp_;
+    const char *label_;
+    int      cs_pin_;
+    int      sck_pin_;
+    int      miso_pin_;
+    int      mosi_pin_;
+    int      rst_pin_;
     bool     listen_only_  = false;
     bool     installed_    = false;
     bool     chip_detected_ = false;
@@ -119,23 +144,46 @@ class Mcp2515Driver : public CanDriver {
 
 public:
 #if defined(BOARD_TTGO_DISPLAY)
-    Mcp2515Driver() : spi_(HSPI), mcp_(PIN_MCP_CS, 10000000, &spi_) {}
+    Mcp2515Driver(const char *label, int cs_pin, int sck_pin, int miso_pin, int mosi_pin, int rst_pin)
+        : spi_(HSPI),
+          mcp_(cs_pin, 10000000, &spi_),
+          label_(label),
+          cs_pin_(cs_pin),
+          sck_pin_(sck_pin),
+          miso_pin_(miso_pin),
+          mosi_pin_(mosi_pin),
+          rst_pin_(rst_pin) {}
 #else
-    Mcp2515Driver() : mcp_(PIN_MCP_CS) {}
+    Mcp2515Driver(const char *label, int cs_pin, int sck_pin, int miso_pin, int mosi_pin, int rst_pin)
+        : mcp_(cs_pin),
+          label_(label),
+          cs_pin_(cs_pin),
+          sck_pin_(sck_pin),
+          miso_pin_(miso_pin),
+          mosi_pin_(mosi_pin),
+          rst_pin_(rst_pin) {}
 #endif
 
     bool begin(bool listen_only) override {
+        if (rst_pin_ >= 0) {
+            pinMode((uint8_t)rst_pin_, OUTPUT);
+            digitalWrite((uint8_t)rst_pin_, LOW);
+            delay(2);
+            digitalWrite((uint8_t)rst_pin_, HIGH);
+            delay(10);
+        }
+
 #if defined(BOARD_TTGO_DISPLAY)
         // Keep MCP2515 on HSPI so TFT_eSPI can own the T-Display LCD SPI bus.
         if (!spi_begun_) {
-            spi_.begin(PIN_MCP_SCK, PIN_MCP_MISO, PIN_MCP_MOSI, PIN_MCP_CS);
+            spi_.begin(sck_pin_, miso_pin_, mosi_pin_, cs_pin_);
             spi_.setFrequency(8000000);
             spi_begun_ = true;
         }
 #else
         static bool s_spi_begun = false;
         if (!s_spi_begun) {
-            SPI.begin(PIN_MCP_SCK, PIN_MCP_MISO, PIN_MCP_MOSI, PIN_MCP_CS);
+            SPI.begin(sck_pin_, miso_pin_, mosi_pin_, cs_pin_);
             SPI.setFrequency(8000000);
             s_spi_begun = true;
         }
@@ -151,10 +199,11 @@ public:
         if (mcp_.setBitrate(CAN_500KBPS, MCP_CRYSTAL_MHZ) != MCP2515::ERROR_OK) {
             chip_detected_ = false;
             installed_     = false;
-            Serial.printf("[CAN] MCP2515 NOT detected on SPI "
-                          "(CS=%d SCK=%d MISO=%d MOSI=%d) — "
+            Serial.printf("[CAN] %s MCP2515 NOT detected on SPI "
+                          "(CS=%d SCK=%d MISO=%d MOSI=%d CLK=%s) — "
                           "check wiring, 5V power, and crystal\n",
-                          PIN_MCP_CS, PIN_MCP_SCK, PIN_MCP_MISO, PIN_MCP_MOSI);
+                          label_, cs_pin_, sck_pin_, miso_pin_, mosi_pin_,
+                          mcp_clock_name(MCP_CRYSTAL_MHZ));
             return false;
         }
 
@@ -170,11 +219,13 @@ public:
         listen_only_ = listen_only;
         installed_ = (err == MCP2515::ERROR_OK);
         if (installed_) {
-            Serial.printf("[CAN] MCP2515 detected on SPI — %s mode @ 500 kbps\n",
-                          listen_only ? "Listen-Only" : "Normal");
+            Serial.printf("[CAN] %s MCP2515 detected on SPI — %s mode @ 500 kbps, clock=%s\n",
+                          label_,
+                          listen_only ? "Listen-Only" : "Normal",
+                          mcp_clock_name(MCP_CRYSTAL_MHZ));
         } else {
-            Serial.printf("[CAN] MCP2515 detected but mode change FAILED (err=%d)\n",
-                          (int)err);
+            Serial.printf("[CAN] %s MCP2515 detected but mode change FAILED (err=%d)\n",
+                          label_, (int)err);
         }
         return installed_;
     }
@@ -199,7 +250,7 @@ public:
         if (!installed_) return false;
         struct can_frame f;
         if (mcp_.readMessage(&f) != MCP2515::ERROR_OK) return false;
-        frame.id  = f.can_id;
+        frame.id  = f.can_id & CAN_EFF_MASK;
         frame.dlc = f.can_dlc;
         memcpy(frame.data, f.data, f.can_dlc);
         return true;
@@ -213,18 +264,43 @@ public:
 
     void setListenOnly(bool enable) override {
         if (!installed_ || listen_only_ == enable) return;
-        listen_only_ = enable;
-        if (enable)
-            mcp_.setListenOnlyMode();
-        else
-            mcp_.setNormalMode();
+        MCP2515::ERROR err = enable ? mcp_.setListenOnlyMode() : mcp_.setNormalMode();
+        if (err == MCP2515::ERROR_OK) {
+            listen_only_ = enable;
+        } else {
+            Serial.printf("[CAN] %s MCP2515 mode switch FAILED (err=%d)\n",
+                          label_, (int)err);
+        }
     }
 };
+#endif
 
 CanDriver *can_driver_create() {
-    return new Mcp2515Driver();
+#if defined(CAN_DRIVER_TWAI)
+    return new TwaiDriver("can0", PIN_CAN_TX, PIN_CAN_RX);
+#elif defined(CAN_DRIVER_MCP2515)
+    return new Mcp2515Driver("can0", PIN_MCP_CS, PIN_MCP_SCK, PIN_MCP_MISO,
+                             PIN_MCP_MOSI, PIN_MCP_RST);
+#elif defined(CAN_DRIVER_T2CAN_DUAL)
+    return can_driver_create(CAN_BUS_PRIMARY);
+#else
+    return nullptr;
+#endif
 }
 
+CanDriver *can_driver_create(CanBusId bus) {
+#if defined(CAN_DRIVER_T2CAN_DUAL)
+    if (bus == CAN_BUS_SECONDARY) {
+        return new Mcp2515Driver("can1", PIN_MCP_CS, PIN_MCP_SCK, PIN_MCP_MISO,
+                                 PIN_MCP_MOSI, PIN_MCP_RST);
+    }
+    return new TwaiDriver("can0", PIN_CAN_TX, PIN_CAN_RX);
 #else
-#error "Define CAN_DRIVER_TWAI or CAN_DRIVER_MCP2515 in platformio.ini build_flags"
+    (void)bus;
+    return can_driver_create();
+#endif
+}
+
+#if !defined(CAN_DRIVER_TWAI) && !defined(CAN_DRIVER_MCP2515) && !defined(CAN_DRIVER_T2CAN_DUAL)
+#error "Define CAN_DRIVER_TWAI, CAN_DRIVER_MCP2515, or CAN_DRIVER_T2CAN_DUAL in platformio.ini build_flags"
 #endif

--- a/esp32/.firmware/can_driver.h
+++ b/esp32/.firmware/can_driver.h
@@ -1,6 +1,17 @@
 #pragma once
 
+#include <stdint.h>
 #include "fsd_handler.h"  // for CanFrame
+
+enum CanBusId : uint8_t {
+    CAN_BUS_PRIMARY = 0,    // can0
+    CAN_BUS_SECONDARY = 1,  // can1
+    CAN_BUS_COUNT = 2,
+};
+
+static inline const char *can_bus_name(CanBusId bus) {
+    return bus == CAN_BUS_SECONDARY ? "can1" : "can0";
+}
 
 // ── Abstract CAN driver ───────────────────────────────────────────────────────
 // Implemented by TwaiDriver (CAN_DRIVER_TWAI) and Mcp2515Driver (CAN_DRIVER_MCP2515).
@@ -41,3 +52,7 @@ public:
 /** Factory function — returns the driver selected at compile time.
  *  Caller owns the returned pointer. */
 CanDriver *can_driver_create();
+
+/** Factory function for boards with two active CAN controllers.
+ *  Caller owns the returned pointer. */
+CanDriver *can_driver_create(CanBusId bus);

--- a/esp32/.firmware/can_dump.cpp
+++ b/esp32/.firmware/can_dump.cpp
@@ -159,7 +159,7 @@ void can_dump_stop() {
                   (unsigned long)elapsed_s, (unsigned long)g_entries);
 }
 
-void can_dump_record(const CanFrame &frame) {
+void can_dump_record(CanBusId bus, const CanFrame &frame) {
     if (!g_active || !g_file) return;
 
     uint32_t elapsed_ms = millis() - g_start_ms;
@@ -168,8 +168,9 @@ void can_dump_record(const CanFrame &frame) {
 
     // candump ASCII log: (sec.usec) can0 ID#DATA\n
     char line[48];
-    int pos = snprintf(line, sizeof(line), "(%lu.%06lu) can0 %03X#",
-                       (unsigned long)sec, (unsigned long)usec, frame.id);
+    int pos = snprintf(line, sizeof(line), "(%lu.%06lu) %s %03X#",
+                       (unsigned long)sec, (unsigned long)usec,
+                       can_bus_name(bus), frame.id);
     for (int i = 0; i < frame.dlc && i < 8; i++) {
         pos += snprintf(line + pos, sizeof(line) - pos, "%02X", frame.data[i]);
     }
@@ -305,7 +306,7 @@ String sd_format_card() {
 void   can_dump_init()                    {}
 bool   can_dump_start()                   { return false; }
 void   can_dump_stop()                    {}
-void   can_dump_record(const CanFrame &)  {}
+void   can_dump_record(CanBusId, const CanFrame &) {}
 void   can_dump_tick(uint32_t)            {}
 bool   can_dump_active()                  { return false; }
 void   can_dump_log(const char *, ...)    {}

--- a/esp32/.firmware/can_dump.h
+++ b/esp32/.firmware/can_dump.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Arduino.h>
 #include "fsd_handler.h"
+#include "can_driver.h"
 
 /**
  * can_dump.h — SD-card CAN bus logger (Lilygo T-CAN485)
@@ -21,7 +22,7 @@
 void   can_dump_init();
 bool   can_dump_start();
 void   can_dump_stop();
-void   can_dump_record(const CanFrame &frame);
+void   can_dump_record(CanBusId bus, const CanFrame &frame);
 void   can_dump_tick(uint32_t now_ms);
 bool   can_dump_active();
 String sd_format_card();

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -18,7 +18,22 @@
 #define CAN_ID_DAS_STATUS_HW4 0x39Bu  // 923  - DAS_status on HW4 AP/DAS
 
 // ── GPIO ──────────────────────────────────────────────────────────────────────
-#if defined(BOARD_LILYGO)
+#if defined(BOARD_LILYGO_T2CAN)
+  #define PIN_CAN_TX         7
+  #define PIN_CAN_RX         6
+  #define PIN_LED            -1
+  #define PIN_BUTTON         0    // BOOT button, active-LOW, internal pull-up
+  #define PIN_MCP_CS         10
+  #define PIN_MCP_SCK        12
+  #define PIN_MCP_MOSI       11
+  #define PIN_MCP_MISO       13
+  #define PIN_MCP_RST        9
+  #define PIN_MCP_INT        8
+  #ifndef MCP_CRYSTAL_MHZ
+  #define MCP_CRYSTAL_MHZ    MCP_16MHZ
+  #endif
+  #define PRECONDITION_TX_BUS_INDEX 0
+#elif defined(BOARD_LILYGO)
   #define PIN_CAN_TX         27
   #define PIN_CAN_RX         26
   #define PIN_CAN_SPEED_MODE 23   // SN65HVD230 Rs — must be LOW for TX+RX
@@ -68,9 +83,21 @@
 #ifndef PIN_MCP_MOSI
 #define PIN_MCP_MOSI 23
 #endif
+#ifndef PIN_MCP_RST
+#define PIN_MCP_RST  -1
+#endif
+#ifndef PIN_MCP_INT
+#define PIN_MCP_INT  -1
+#endif
+#ifndef PRECONDITION_TX_BUS_INDEX
+#define PRECONDITION_TX_BUS_INDEX 0
+#endif
 
-// MCP2515 oscillator: common Chinese modules use 8 MHz
+// MCP2515 oscillator. Generic breakout modules often use 8 MHz; LilyGO
+// T-2CAN's onboard MCP2515 uses a 16 MHz crystal.
+#ifndef MCP_CRYSTAL_MHZ
 #define MCP_CRYSTAL_MHZ  MCP_8MHZ   // from autowp-mcp2515 CAN_CLOCK enum
+#endif
 
 // ── Timing ────────────────────────────────────────────────────────────────────
 #define WIRING_WARN_MS        5000u   // Red LED / serial warning if no CAN after this

--- a/esp32/.firmware/http_can_stream.cpp
+++ b/esp32/.firmware/http_can_stream.cpp
@@ -11,6 +11,7 @@
 
 struct StreamFrame {
     uint32_t elapsed_ms;
+    CanBusId bus;
     CanFrame frame;
 };
 
@@ -281,14 +282,16 @@ static bool write_frame(const StreamFrame &item) {
     char line[72];
     int pos;
     if (item.frame.id <= 0x7FFu) {
-        pos = snprintf(line, sizeof(line), "(%lu.%06lu) can0 %03lX#",
+        pos = snprintf(line, sizeof(line), "(%lu.%06lu) %s %03lX#",
                        (unsigned long)sec,
                        (unsigned long)usec,
+                       can_bus_name(item.bus),
                        (unsigned long)item.frame.id);
     } else {
-        pos = snprintf(line, sizeof(line), "(%lu.%06lu) can0 %08lX#",
+        pos = snprintf(line, sizeof(line), "(%lu.%06lu) %s %08lX#",
                        (unsigned long)sec,
                        (unsigned long)usec,
+                       can_bus_name(item.bus),
                        (unsigned long)item.frame.id);
     }
     if (pos < 0 || pos >= (int)sizeof(line)) return false;
@@ -343,7 +346,7 @@ void http_can_stream_update() {
     flush_stream();
 }
 
-void http_can_stream_record(const CanFrame &frame) {
+void http_can_stream_record(CanBusId bus, const CanFrame &frame) {
     if (!g_enabled || !g_active || !g_client.connected()) return;
     if (!filter_matches(frame.id)) {
         g_filtered++;
@@ -357,6 +360,7 @@ void http_can_stream_record(const CanFrame &frame) {
 
     StreamFrame &slot = g_ring[g_head];
     slot.elapsed_ms = millis() - g_start_ms;
+    slot.bus = bus;
     slot.frame.id = frame.id;
     slot.frame.dlc = frame.dlc > 8 ? 8 : frame.dlc;
     memcpy(slot.frame.data, frame.data, slot.frame.dlc);

--- a/esp32/.firmware/http_can_stream.h
+++ b/esp32/.firmware/http_can_stream.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include "fsd_handler.h"
+#include "can_driver.h"
 
 /**
  * HTTP CAN stream logger.
@@ -13,7 +14,7 @@
 
 void     http_can_stream_init();
 void     http_can_stream_update();
-void     http_can_stream_record(const CanFrame &frame);
+void     http_can_stream_record(CanBusId bus, const CanFrame &frame);
 void     http_can_stream_set_enabled(bool enabled);
 bool     http_can_stream_active();
 uint32_t http_can_stream_frames_sent();

--- a/esp32/.firmware/led.cpp
+++ b/esp32/.firmware/led.cpp
@@ -2,7 +2,7 @@
 #include "config.h"
 #include <Arduino.h>
 
-#if !defined(BOARD_TTGO_DISPLAY)
+#if !defined(BOARD_TTGO_DISPLAY) && (PIN_LED >= 0)
 #include <Adafruit_NeoPixel.h>
 
 // Smart LED for M5Stack, Lilygo T-CAN485, etc.
@@ -15,6 +15,8 @@ void led_init() {
         pinMode(PIN_LED, OUTPUT);
         digitalWrite(PIN_LED, HIGH); // Off (active-LOW)
     }
+#elif PIN_LED < 0
+    return;
 #else
     g_strip.begin();
     g_strip.setBrightness(25);  // keep dim — the ATOM LED is very bright
@@ -33,6 +35,9 @@ void led_set(LedColor color) {
     } else {
         digitalWrite(PIN_LED, LOW);  // On
     }
+#elif PIN_LED < 0
+    (void)color;
+    return;
 #else
     uint32_t c;
     if (color == LED_SLEEP) {

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -33,12 +33,26 @@
 #endif
 
 // ── Globals ───────────────────────────────────────────────────────────────────
-static CanDriver *g_can   = nullptr;
-static bool       g_can_ok = false;       // true once g_can->begin() succeeds
-static uint32_t   g_can_last_retry_ms = 0; // for periodic re-init when init fails
+#if defined(CAN_DRIVER_T2CAN_DUAL)
+#define CAN_ACTIVE_BUS_COUNT 2u
+#else
+#define CAN_ACTIVE_BUS_COUNT 1u
+#endif
+
+static CanDriver *g_can[CAN_ACTIVE_BUS_COUNT] = {};
+static bool       g_can_ok[CAN_ACTIVE_BUS_COUNT] = {};       // true once begin() succeeds
+static uint32_t   g_can_last_retry_ms[CAN_ACTIVE_BUS_COUNT] = {}; // periodic re-init
 #define CAN_REINIT_INTERVAL_MS  30000u
 static FSDState   g_state = {};
 static portMUX_TYPE g_state_mux = portMUX_INITIALIZER_UNLOCKED;
+
+static CanBusId bus_id_from_index(uint8_t index) {
+    return index == 1 ? CAN_BUS_SECONDARY : CAN_BUS_PRIMARY;
+}
+
+static uint8_t bus_index(CanBusId bus) {
+    return bus == CAN_BUS_SECONDARY ? 1u : 0u;
+}
 
 static void state_enter() {
     portENTER_CRITICAL(&g_state_mux);
@@ -74,6 +88,46 @@ static bool frame_looks_like_hw3_das_status(const CanFrame &frame) {
 
     return ap_state <= SIG_DAS_HW3_AP_ACTIVE_STATE &&
            hands_on <= SIG_DAS_HANDS_ON_SUSPENDED;
+}
+
+static void can_set_all_listen_only(bool listen_only) {
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        if (g_can[i]) g_can[i]->setListenOnly(listen_only);
+    }
+}
+
+static bool can_any_ok() {
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        if (g_can_ok[i]) return true;
+    }
+    return false;
+}
+
+static uint32_t can_total_error_count() {
+    uint32_t total = 0;
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        if (g_can[i]) total += g_can[i]->errorCount();
+    }
+    return total;
+}
+
+static uint32_t can_total_tx_count() {
+    uint32_t total = 0;
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        if (g_can[i]) total += g_can[i]->txCount();
+    }
+    return total;
+}
+
+static CanDriver *can_for_bus(CanBusId bus) {
+    uint8_t index = bus_index(bus);
+    if (index >= CAN_ACTIVE_BUS_COUNT) return nullptr;
+    return g_can[index];
+}
+
+static bool send_on_bus(CanBusId bus, const CanFrame &frame) {
+    CanDriver *driver = can_for_bus(bus);
+    return driver ? driver->send(frame) : false;
 }
 
 static void apply_detected_hw(TeslaHWVersion hw, const char *reason) {
@@ -133,7 +187,7 @@ static void dispatch_clicks(int n) {
         }
         saved = g_state;
         state_exit();
-        g_can->setListenOnly(!active);
+        can_set_all_listen_only(!active);
         http_can_stream_set_enabled(!active);
         Serial.println(active ? "[BTN] → Active mode" : "[BTN] → Listen-Only mode");
         can_dump_log(active ? "MODE switched to Active — TX enabled" : "MODE switched to Listen-Only — TX disabled");
@@ -263,7 +317,7 @@ static void update_led() {
 }
 
 // ── CAN frame dispatcher ──────────────────────────────────────────────────────
-static void process_frame(const CanFrame &frame) {
+static void process_frame(CanBusId bus, const CanFrame &frame) {
     state_enter();
     g_state.rx_count++;
     if (frame.id == CAN_ID_GTW_CAR_STATE)  g_state.seen_gtw_car_state++;
@@ -274,9 +328,9 @@ static void process_frame(const CanFrame &frame) {
     if (frame.id == CAN_ID_BMS_THERMAL)    g_state.seen_bms_thermal++;
     state_exit();
 
-    can_dump_record(frame);
+    can_dump_record(bus, frame);
     if (state_snapshot().op_mode == OpMode_ListenOnly) {
-        http_can_stream_record(frame);
+        http_can_stream_record(bus, frame);
     }
 #if defined(BOARD_LILYGO)
     g_last_can_rx_ms = millis();
@@ -356,7 +410,7 @@ static void process_frame(const CanFrame &frame) {
             uint8_t cnt_out = echo.data[6] & 0x0F;
             can_dump_log("NAG 0x370 hands_off lvl=%u cnt=%u->%u %s",
                          lvl, cnt_in, cnt_out, tx ? "TX echo" : "listen-only no-TX");
-            if (tx) g_can->send(echo);
+            if (tx) send_on_bus(bus, echo);
         }
         return;
     }
@@ -375,7 +429,7 @@ static void process_frame(const CanFrame &frame) {
         state_enter();
         bool modified = fsd_handle_legacy_autopilot(&g_state, &f);
         state_exit();
-        if (modified && tx) g_can->send(f);
+        if (modified && tx) send_on_bus(bus, f);
         return;
     }
 
@@ -416,7 +470,7 @@ static void process_frame(const CanFrame &frame) {
         s.suppress_speed_chime) {
         CanFrame f = frame;
         if (fsd_handle_isa_speed_chime(&f) && tx)
-            g_can->send(f);
+            send_on_bus(bus, f);
         return;
     }
 
@@ -434,7 +488,7 @@ static void process_frame(const CanFrame &frame) {
         state_enter();
         bool modified = fsd_handle_tlssc_restore(&g_state, &f);
         state_exit();
-        if (modified && tx) g_can->send(f);
+        if (modified && tx) send_on_bus(bus, f);
         return;
     }
 
@@ -444,7 +498,7 @@ static void process_frame(const CanFrame &frame) {
         state_enter();
         bool modified = fsd_handle_autopilot_frame(&g_state, &f);
         state_exit();
-        if (modified && tx) g_can->send(f);
+        if (modified && tx) send_on_bus(bus, f);
         return;
     }
 }
@@ -506,7 +560,9 @@ void setup() {
         }
     }
 
-#if defined(CAN_DRIVER_TWAI)
+#if defined(CAN_DRIVER_T2CAN_DUAL)
+    Serial.println("[CAN] Driver: LilyGO T-2CAN dual CAN (TWAI can0 + MCP2515 can1)");
+#elif defined(CAN_DRIVER_TWAI)
   #if defined(BOARD_WAVESHARE_S3)
     Serial.println("[CAN] Driver: ESP32-S3 TWAI (Waveshare ESP32-S3-RS485-CAN)");
   #elif defined(BOARD_LILYGO)
@@ -529,7 +585,10 @@ void setup() {
     digitalWrite(PIN_CAN_SPEED_MODE, LOW);
 #endif
 
-#if defined(CAN_DRIVER_TWAI)
+#if defined(CAN_DRIVER_T2CAN_DUAL)
+    Serial.printf("[CFG] pins: LED=%d BUTTON=%d CAN0_TX=%d CAN0_RX=%d MCP_CS=%d MCP_SCK=%d\n",
+                  PIN_LED, PIN_BUTTON, PIN_CAN_TX, PIN_CAN_RX, PIN_MCP_CS, PIN_MCP_SCK);
+#elif defined(CAN_DRIVER_TWAI)
     Serial.printf("[CFG] pins: LED=%d BUTTON=%d CAN_TX=%d CAN_RX=%d\n",
                   PIN_LED, PIN_BUTTON, PIN_CAN_TX, PIN_CAN_RX);
 #else
@@ -590,12 +649,19 @@ void setup() {
     }
 #endif
 
-    g_can = can_driver_create();
-    g_can_ok = g_can->begin(true);
-    g_can_last_retry_ms = millis();
-    if (!g_can_ok) {
-        Serial.println("[ERR] CAN driver init FAILED — check wiring");
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        CanBusId bus = bus_id_from_index(i);
+        g_can[i] = can_driver_create(bus);
+        g_can_ok[i] = g_can[i] && g_can[i]->begin(true);
+        g_can_last_retry_ms[i] = millis();
+    }
+    if (!can_any_ok()) {
+        Serial.println("[ERR] All CAN driver init failed — check wiring");
 #if defined(BOARD_TTGO_DISPLAY)
+        Serial.printf("[ERR] Continuing in NO-CAN mode (will retry every %lu ms)\n",
+                      (unsigned long)CAN_REINIT_INTERVAL_MS);
+        led_set(LED_RED);
+#elif defined(CAN_DRIVER_T2CAN_DUAL)
         Serial.printf("[ERR] Continuing in NO-CAN mode (will retry every %lu ms)\n",
                       (unsigned long)CAN_REINIT_INTERVAL_MS);
         led_set(LED_RED);
@@ -608,7 +674,7 @@ void setup() {
 #endif
     } else {
         if (state_snapshot().op_mode == OpMode_Active) {
-            g_can->setListenOnly(false);
+            can_set_all_listen_only(false);
             Serial.println("[CAN] 500 kbps — Active (restored from NVS)");
         } else {
             Serial.println("[CAN] 500 kbps — Listen-Only");
@@ -621,7 +687,7 @@ void setup() {
 
     // ── WiFi AP + Web dashboard (non-fatal if WiFi fails) ─────────────────────
     if (wifi_ap_init(&g_state)) {
-        web_dashboard_init(&g_state, g_can, &g_state_mux);
+        web_dashboard_init(&g_state, g_can, CAN_ACTIVE_BUS_COUNT, &g_state_mux);
         http_can_stream_set_enabled(state_snapshot().op_mode == OpMode_ListenOnly);
     }
 }
@@ -638,17 +704,21 @@ void loop() {
     button_tick();
 
     // Drain all available CAN frames in one shot
-    CanFrame frame;
-    while (g_can->receive(frame)) {
-        process_frame(frame);
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        if (!g_can_ok[i] || !g_can[i]) continue;
+        CanBusId bus = bus_id_from_index(i);
+        CanFrame frame;
+        while (g_can[i]->receive(frame)) {
+            process_frame(bus, frame);
+        }
     }
 
     // ── Periodic error counter refresh (~every 250 ms) ────────────────────────
     static uint32_t last_err_ms = 0;
     if ((now - last_err_ms) >= 250u) {
         state_enter();
-        g_state.crc_err_count = g_can->errorCount();
-        g_state.tx_count      = g_can->txCount();
+        g_state.crc_err_count = can_total_error_count();
+        g_state.tx_count      = can_total_tx_count();
         state_exit();
         last_err_ms = now;
     }
@@ -660,7 +730,7 @@ void loop() {
         (now - last_precond_ms) >= PRECOND_INTERVAL_MS) {
         CanFrame pf;
         fsd_build_precondition_frame(&pf);
-        g_can->send(pf);
+        send_on_bus(bus_id_from_index(PRECONDITION_TX_BUS_INDEX), pf);
         last_precond_ms = now;
     }
 
@@ -705,16 +775,20 @@ void loop() {
         last_status_ms = now;
     }
 
-    // ── Periodic re-init when CAN driver failed at boot ──────────────────────
-    if (!g_can_ok && g_can &&
-        (now - g_can_last_retry_ms) >= CAN_REINIT_INTERVAL_MS) {
-        g_can_last_retry_ms = now;
-        Serial.println("[CAN] Retrying driver init…");
-        bool listen_only = (state_snapshot().op_mode != OpMode_Active);
-        g_can_ok = g_can->begin(listen_only);
-        if (g_can_ok) {
-            Serial.printf("[CAN] Re-init SUCCESS — %s mode\n",
-                          listen_only ? "Listen-Only" : "Active");
+    // ── Periodic re-init when a CAN driver failed at boot ────────────────────
+    for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
+        if (!g_can_ok[i] && g_can[i] &&
+            (now - g_can_last_retry_ms[i]) >= CAN_REINIT_INTERVAL_MS) {
+            g_can_last_retry_ms[i] = now;
+            Serial.printf("[CAN] Retrying %s driver init...\n",
+                          can_bus_name(bus_id_from_index(i)));
+            bool listen_only = (state_snapshot().op_mode != OpMode_Active);
+            g_can_ok[i] = g_can[i]->begin(listen_only);
+            if (g_can_ok[i]) {
+                Serial.printf("[CAN] %s re-init SUCCESS — %s mode\n",
+                              can_bus_name(bus_id_from_index(i)),
+                              listen_only ? "Listen-Only" : "Active");
+            }
         }
     }
 
@@ -722,17 +796,12 @@ void loop() {
     static uint32_t last_warn_ms = 0;
     s = state_snapshot();
     if (now > WIRING_WARN_MS && (now - last_warn_ms) >= 5000u) {
-        if (!g_can_ok) {
+        if (!can_any_ok()) {
             // Driver init failed — distinguish chip-not-detected from other.
             // Skip the "no CAN traffic" warn entirely (it's never going to
             // arrive without a working driver).
-            if (g_can && !g_can->hardwarePresent()) {
-                Serial.println("[WARN] MCP2515 not detected on SPI — "
-                               "no CAN traffic possible until chip responds");
-            } else {
-                Serial.println("[WARN] CAN driver not initialised — "
-                               "no CAN traffic possible");
-            }
+            Serial.println("[WARN] CAN drivers not initialised — "
+                           "no CAN traffic possible");
             last_warn_ms = now;
         } else if (s.rx_count == 0) {
             Serial.println("[WARN] No CAN traffic after 5 s — check wiring");

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -23,7 +23,8 @@
 
 // ── Module state ──────────────────────────────────────────────────────────────
 static FSDState  *g_state = nullptr;   // shared with main
-static CanDriver *g_can   = nullptr;   // for setListenOnly()
+static CanDriver **g_can_buses = nullptr; // for setListenOnly()
+static uint8_t g_can_count = 0;
 static portMUX_TYPE *g_state_mux = nullptr;
 
 static WebServer        g_http(80);
@@ -1163,7 +1164,9 @@ static void ws_event(uint8_t num, WStype_t type,
         }
         saved = *g_state;
         state_exit();
-        if (g_can) g_can->setListenOnly(!active);
+        for (uint8_t i = 0; i < g_can_count; i++) {
+            if (g_can_buses[i]) g_can_buses[i]->setListenOnly(!active);
+        }
         http_can_stream_set_enabled(!active);
         Serial.println(active ? "[Web] → Active mode" : "[Web] → Listen-Only mode");
         prefs_save(&saved);
@@ -1555,9 +1558,13 @@ static void handle_ota_done() {
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
-void web_dashboard_init(FSDState *state, CanDriver *can, portMUX_TYPE *state_mux) {
+void web_dashboard_init(FSDState *state,
+                        CanDriver **can_buses,
+                        uint8_t can_count,
+                        portMUX_TYPE *state_mux) {
     g_state       = state;
-    g_can         = can;
+    g_can_buses   = can_buses;
+    g_can_count   = can_count;
     g_state_mux   = state_mux;
     g_start_ms    = millis();
     g_last_fps_ms = millis();

--- a/esp32/.firmware/web_dashboard.h
+++ b/esp32/.firmware/web_dashboard.h
@@ -20,10 +20,14 @@
  * Initialise HTTP and WebSocket servers.
  *
  * @param state      Pointer to the shared FSDState (read + written by command handler)
- * @param can        Pointer to the active CanDriver (used by mode-toggle command)
+ * @param can_buses  CAN drivers to switch between listen-only and active mode
+ * @param can_count  Number of entries in can_buses
  * @param state_mux  Spinlock protecting cross-core access to state
  */
-void web_dashboard_init(FSDState *state, CanDriver *can, portMUX_TYPE *state_mux);
+void web_dashboard_init(FSDState *state,
+                        CanDriver **can_buses,
+                        uint8_t can_count,
+                        portMUX_TYPE *state_mux);
 
 /** Service HTTP requests and WebSocket messages; broadcast state at 1 Hz. */
 void web_dashboard_update();

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -56,6 +56,29 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     Links2004/WebSockets@^2.4.0
 
+[env:lilygo-t2can]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+
+board_build.flash_size = 16MB
+board_build.flash_mode = qio
+board_build.partitions = default_16MB.csv
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+
+build_flags =
+    -D BOARD_LILYGO_T2CAN
+    -D CAN_DRIVER_T2CAN_DUAL
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MODE=1
+
+lib_deps =
+    autowp/autowp-mcp2515@^1.3.0
+    Links2004/WebSockets@^2.4.0
+
 [env:ttgo-tdisplay]
 platform = espressif32
 board = esp32dev


### PR DESCRIPTION
Add a LilyGO T-2CAN PlatformIO target with native TWAI can0 and MCP2515 can1 support. Route RX processing, modified-frame TX, dashboard mode switching, counters, retries, and CAN dumps through bus-aware helpers while preserving existing single-CAN builds.