### PR TITLE
fix/rtc-log-filename

### DIFF
--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -195,9 +195,12 @@ static int32_t fsd_running_worker(void* context) {
         storage_common_mkdir(app->storage, "/ext/apps_data/tesla_mod");
         storage_common_mkdir(app->storage, "/ext/apps_data/tesla_mod/captures");
         char cap_path[80];
+        DateTime dt;
+        furi_hal_rtc_get_datetime(&dt);
         snprintf(cap_path, sizeof(cap_path),
-            "/ext/apps_data/tesla_mod/captures/cap_%lu.log",
-            (unsigned long)furi_get_tick());
+            "/ext/apps_data/tesla_mod/captures/cap_%04u%02u%02u_%02u%02u%02u.log",
+            dt.year, dt.month, dt.day,
+            dt.hour, dt.minute, dt.second);
         cap_file = storage_file_alloc(app->storage);
         if(!storage_file_open(cap_file, cap_path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
             storage_file_free(cap_file);


### PR DESCRIPTION
## Problem
Log filenames were generated using `furi_get_tick()` (milliseconds since Flipper boot), producing names like `cap_2847361.log`. This made it impossible to correlate log files to real-world timestamps without doing manual math from boot time.

## Fix
Replace the tick-based filename with the RTC wall-clock datetime using `furi_hal_rtc_get_datetime()`, producing human-readable filenames like `cap_20260607_164033.log`.

## Changes
- `scenes/fsd_running.c`: Replace `furi_get_tick()` snprintf with `DateTime dt;` / `furi_hal_rtc_get_datetime(&dt)` and datetime-formatted path string.

## Notes
- Requires Flipper RTC to be set (it is battery-backed and synced via mobile app)
- Uses `DateTime` type (not `FuriHalRtcDateTime` which does not exist in the SDK)