### PR TITLE
feat: opt-in Summon EU Unlock (0x3FD mux1 bit47) for HW3/HW4

### DIFF
--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -46,6 +46,7 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->suppress_speed_chime = true;
     state->ignore_ota           = false;
     state->emergency_vehicle_detect = false;
+    state->summon_unlock        = false;    // opt-in Summon EU Unlock, default OFF
     state->fsd_unlock           = false;
     state->force_fsd            = false;
     state->china_mode           = false;
@@ -224,11 +225,18 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
                           SIG_AP_SPEED_PROFILE_SHIFT);
             modified = true;
         }
-        if (mux == CAN_MUX_1 && state->nag_killer) {
-            // Nag suppression via bit 19 (clear = no hands-on-wheel request)
-            set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);
-            state->nag_suppressed = true;
-            modified = true;
+        if (mux == CAN_MUX_1 && (state->nag_killer || state->summon_unlock)) {
+            if (state->nag_killer) {
+                // Nag suppression via bit 19 (clear = no hands-on-wheel request)
+                set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);
+                state->nag_suppressed = true;
+                modified = true;
+            }
+            if (state->summon_unlock) {
+                set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);       // bit19 EU restriction clear
+                set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true);  // bit47 summon enable
+                modified = true;
+            }
         }
         if (mux == CAN_MUX_2 && state->fsd_unlock && state->fsd_enabled) {
             // Write speed offset into bits 7:6 of byte 0 and bits 5:0 of byte 1
@@ -252,11 +260,18 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
                 set_bit(frame, SIG_AP_HW4_EMERGENCY_VEHICLE_BIT, true);
             modified = true;
         }
-        if (mux == CAN_MUX_1 && state->nag_killer) {
-            set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);      // clear hands-on-wheel nag
-            set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true); // HW4 nag-suppression confirmation bit
-            state->nag_suppressed = true;
-            modified = true;
+        if (mux == CAN_MUX_1 && (state->nag_killer || state->summon_unlock)) {
+            if (state->nag_killer) {
+                set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);      // clear hands-on-wheel nag
+                set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true); // HW4 nag-suppression confirmation bit
+                state->nag_suppressed = true;
+                modified = true;
+            }
+            if (state->summon_unlock) {
+                set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);       // bit19 EU restriction clear
+                set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true);  // bit47 summon enable
+                modified = true;
+            }
         }
         if (mux == CAN_MUX_2 && state->fsd_unlock) {
             // Write speed profile into bits 6:4 of byte 7

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -29,6 +29,7 @@ void prefs_load(FSDState *state) {
     state->tlssc_restore            = g_prefs.getBool("tlssc",  false);
     state->precondition             = g_prefs.getBool("precond",false);
     state->emergency_vehicle_detect = g_prefs.getBool("emrg",   false);
+    state->summon_unlock            = g_prefs.getBool("summon", false);
     state->bms_output               = g_prefs.getBool("bms",    false);
     state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
     state->blackbox_enabled         = g_prefs.getBool("bbx",    BLACKBOX_DEFAULT_ENABLED);
@@ -62,9 +63,9 @@ void prefs_load(FSDState *state) {
     state->cfg_steer_hi      = g_prefs.getUChar("cshi",   1);
     state->cfg_steer_lo      = g_prefs.getUChar("cslo",   0);
 
-    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
-                  state->china_mode, state->suppress_speed_chime,
+                  state->china_mode, state->suppress_speed_chime, state->summon_unlock,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
@@ -97,6 +98,7 @@ void prefs_save(const FSDState *state) {
     g_prefs.putBool("tlssc",  state->tlssc_restore);
     g_prefs.putBool("precond",state->precondition);
     g_prefs.putBool("emrg",   state->emergency_vehicle_detect);
+    g_prefs.putBool("summon", state->summon_unlock);
     g_prefs.putBool("bms",    state->bms_output);
     g_prefs.putBool("14x",    state->firmware_14x_warning);
     g_prefs.putBool("bbx",    state->blackbox_enabled);
@@ -129,9 +131,9 @@ void prefs_save(const FSDState *state) {
     g_prefs.putUChar("cshi",  state->cfg_steer_hi);
     g_prefs.putUChar("cslo",  state->cfg_steer_lo);
 
-    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
-                  state->china_mode, state->suppress_speed_chime,
+                  state->china_mode, state->suppress_speed_chime, state->summon_unlock,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -495,6 +495,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">TLSSC Restore</span>
     <label class="sw"><input type="checkbox" id="swTlssc" onchange="cmd('tlssc_restore',this.checked)"><span class="sl2"></span></label>
   </div>
+  <div class="row">
+    <span class="lbl">Summon EU Unlock</span>
+    <label class="sw"><input type="checkbox" id="swSummon" onchange="cmd('summon_unlock',this.checked)"><span class="sl2"></span></label>
+  </div>
   <div class="row" style="display:block">
     <div id="pmSuggest" style="display:none;margin:0 0 8px;padding:8px 10px;border:1px solid var(--accent);border-radius:6px;background:var(--card2)">
       <div style="font-size:12px;color:var(--text)">Looks like variant <b id="pmName">?</b> &mdash; the standard parser can't read AP-state on this bus.</div>
@@ -956,6 +960,7 @@ function upd(d){
   if(document.getElementById('swChime')) document.getElementById('swChime').checked=d.suppress_speed_chime;
   if(document.getElementById('rowChime')) document.getElementById('rowChime').style.display=d.isa_speed_enabled?'flex':'none';
   if(document.getElementById('swTlssc')) document.getElementById('swTlssc').checked=d.tlssc_restore;
+  if(document.getElementById('swSummon')) document.getElementById('swSummon').checked=d.summon_unlock;
   if(document.getElementById('swDisp')) document.getElementById('swDisp').checked=!!d.display_enabled;
   if(document.activeElement.id!=='dispBr' && document.getElementById('dispBr'))
     document.getElementById('dispBr').value=d.display_brightness||50;
@@ -1541,6 +1546,7 @@ static String build_json() {
     j += "\"china_mode\":";    j += state.china_mode                   ? "true" : "false"; j += ',';
     j += "\"suppress_speed_chime\":"; j += state.suppress_speed_chime  ? "true" : "false"; j += ',';
     j += "\"tlssc_restore\":"; j += state.tlssc_restore                ? "true" : "false"; j += ',';
+    j += "\"summon_unlock\":"; j += state.summon_unlock                ? "true" : "false"; j += ',';
     j += "\"firmware_14x_warning\":"; j += state.firmware_14x_warning  ? "true" : "false"; j += ',';
 #if defined(BOARD_TTGO_DISPLAY)
     j += "\"display_enabled\":"; j += state.display_enabled             ? "true" : "false"; j += ',';
@@ -1971,6 +1977,18 @@ static void ws_event(uint8_t num, WStype_t type,
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] Suppress Speed Chime: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"summon_unlock\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->summon_unlock = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Summon EU Unlock: %s\n", enabled ? "ON" : "OFF");
             prefs_save(&saved);
         }
     } else if (strstr(buf, "\"dump\"")) {

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -17,6 +17,7 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->das_hands_on_state = 0xFF; // unseen — nag killer echoes conservatively
     state->das_prev_hands_on_state = 0xFF; // escalation-edge baseline (#100)
     state->enhanced_autopilot = false;
+    state->summon_unlock = false;   // opt-in Summon EU Unlock, default OFF
     state->speed_profile_locked = false;
     state->hw4_offset = 0;
 }
@@ -229,6 +230,9 @@ bool fsd_handle_autopilot_frame(FSDState* state, CANFRAME* frame, uint32_t now_m
         }
         if(mux == 1) {
             fsd_set_bit(frame, 19, false);
+            if(state->summon_unlock) {
+                fsd_set_bit(frame, 47, true);   // summon enable (ev-open-can-tools summon-eu-unlock)
+            }
             if(state->enhanced_autopilot) {
                 fsd_set_bit(frame, 46, true);
             }
@@ -257,6 +261,10 @@ bool fsd_handle_autopilot_frame(FSDState* state, CANFRAME* frame, uint32_t now_m
         }
         if(mux == 1) {
             fsd_set_bit(frame, 19, false);
+            // HW4 sets bit47 (summon enable) unconditionally here (pre-existing),
+            // so the summon_unlock toggle is effectively always-on for HW4 on this
+            // build. The toggle's real effect is on the HW3 path above; ESP32 gates
+            // both HW3 and HW4. Reconciling this divergence is a follow-up.
             fsd_set_bit(frame, 47, true);
             if(state->enhanced_autopilot) {
                 fsd_set_bit(frame, 46, true);

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -187,6 +187,10 @@ typedef struct FSDState {
 
     // --- upstream feature flags ---
     bool enhanced_autopilot;     // when true, mux=1 also sets bit46 (EAP/summon)
+    // Summon EU Unlock (ev-open-can-tools summon-eu-unlock): 0x3FD mux1 clears
+    // bit19 (EU summon restriction) and sets bit47 (summon enable), on HW3 + HW4.
+    // Opt-in, default OFF. // TODO: add Summon EU Unlock to Flipper menu
+    bool summon_unlock;
     bool speed_profile_locked;   // when true, follow distance won't override profile
     uint8_t hw4_offset;          // HW4 mux=2 speed offset override (0 = no override)
 

--- a/test/test_fsd_core.c
+++ b/test/test_fsd_core.c
@@ -204,6 +204,64 @@ static void test_autopilot_hw3(void) {
           (f.buffer[6] >> 1) & 0x03);
 }
 
+// ── Summon EU Unlock (0x3FD mux1 bit47) — opt-in, HW3 + HW4 ───────────────────
+// ev-open-can-tools summon-eu-unlock: clear bit19, set bit47 on mux1. This test
+// locks that summon_unlock gates bit47 on HW3 (which never set it before) and
+// that HW3 mux1 with the toggle OFF is byte-for-byte the prior behavior.
+//
+// NOTE on HW4: the Flipper HW4 mux1 path sets bit47 UNCONDITIONALLY (pre-existing
+// behavior, preserved). So on HW4 bit47 is set whether or not summon_unlock is on;
+// the summon toggle adds an explicit guarded path but does not change the emitted
+// HW4 frame. The ESP32 firmware is where the HW4 toggle actually gates bit47 —
+// that divergence is documented for reviewers.
+static void test_summon_unlock(void) {
+    CANFRAME f;
+
+    // ── HW3: bit47 is gated by summon_unlock ──
+    FSDState h3;
+    memset(&h3, 0, sizeof(h3));
+    h3.hw_version = TeslaHW_HW3;
+
+    // summon OFF: mux1 clears bit19, does NOT set bit47 (prior HW3 behavior).
+    h3.summon_unlock = false;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1;            // mux1
+    f.buffer[2] = 0x08;         // pre-set bit19 to prove it is cleared
+    CHECK(fsd_handle_autopilot_frame(&h3, &f, 0), "HW3 mux1 summon-off reports modified");
+    CHECK((f.buffer[2] & 0x08) == 0, "HW3 mux1 summon-off bit19 cleared");
+    CHECK((f.buffer[5] & 0x80) == 0, "HW3 mux1 summon-off bit47 NOT set");
+    CHECK(h3.nag_suppressed, "HW3 mux1 summon-off still sets nag_suppressed");
+
+    // summon ON: mux1 now also sets bit47.
+    h3.summon_unlock = true;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1;
+    CHECK(fsd_handle_autopilot_frame(&h3, &f, 0), "HW3 mux1 summon-on reports modified");
+    CHECK((f.buffer[5] & 0x80) != 0, "HW3 mux1 summon-on bit47 set");
+
+    // ── HW4: bit47 set on mux1 regardless of the toggle (pre-existing behavior) ──
+    FSDState h4;
+    memset(&h4, 0, sizeof(h4));
+    h4.hw_version = TeslaHW_HW4;
+
+    h4.summon_unlock = true;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1;
+    CHECK(fsd_handle_autopilot_frame(&h4, &f, 0), "HW4 mux1 summon-on reports modified");
+    CHECK((f.buffer[5] & 0x80) != 0, "HW4 mux1 summon-on bit47 set");
+
+    // summon OFF: HW4 still sets bit47 unconditionally — frame unchanged from prior.
+    h4.summon_unlock = false;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1;
+    CHECK(fsd_handle_autopilot_frame(&h4, &f, 0), "HW4 mux1 summon-off reports modified");
+    CHECK((f.buffer[5] & 0x80) != 0, "HW4 mux1 summon-off bit47 still set (prior behavior)");
+}
+
 // ── 0x399 ISA speed chime: bit + Tesla additive checksum ──────────────────────
 static void test_isa_checksum(void) {
     CANFRAME f;
@@ -1885,6 +1943,7 @@ int main(void) {
     test_follow_distance();
     test_autopilot_hw4();
     test_autopilot_hw3();
+    test_summon_unlock();
     test_isa_checksum();
     test_di_speed();
     test_tlssc_restore();


### PR DESCRIPTION
Adds an opt-in **Summon EU Unlock** toggle (default OFF) that clears the EU summon restriction bit and sets the summon-enable bit on `0x3FD` (DAS_autopilotControl) mux 1, on both HW3 and HW4.

### Background
The bits are the two documented in the ev-open-can-tools `summon-eu-unlock.json` plugin: `0x3FD` mux 1, clear bit 19 (EU restriction), set bit 47 (summon enable). HW4 already set both as part of the AP-control injection; **HW3 cleared bit 19 but never set bit 47**, so this closes that gap and exposes it as an explicit, persisted, opt-in control. Refs #111, #139.

### Changes
- `fsd_state.h`: new `bool summon_unlock` (default OFF).
- Flipper + ESP32 `0x3FD` handlers: set bit 47 under the flag. ESP32 mux-1 gate widened to `(nag_killer || summon_unlock)`, with the nag bits kept inside `if(nag_killer)` so nag output is byte-for-byte identical when summon is off.
- `prefs.cpp`: NVS persistence (`summon`).
- `web_dashboard.cpp`: "Summon EU Unlock" toggle in Controls.
- `test_fsd_core.c`: `test_summon_unlock` (HW3/HW4 × on/off). **467 host tests pass.**

### Known limitations
- On the Flipper core, HW4 mux-1 sets bit 47 unconditionally (pre-existing, left untouched to avoid regressing nag behaviour), so the toggle only changes the HW3 frame there; ESP32 gates both. Reconciling this divergence is a follow-up.
- Flipper on-device menu item not added yet (ESP32 dashboard only).
- **Not yet validated on a car** — off by default; needs an on-car confirmation before it's recommended.
