### PR TITLE
feat: opt-in Right-Hand Drive override (0x3F8 bit41), #66

### DIFF
--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -48,6 +48,7 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->emergency_vehicle_detect = false;
     state->summon_unlock        = false;    // opt-in Summon EU Unlock, default OFF
     state->continue_on_green    = false;    // opt-in Continue on Green, default OFF
+    state->assist_rhd_override  = false;    // opt-in RHD driving-side override, default OFF
     state->fsd_unlock           = false;
     state->force_fsd            = false;
     state->china_mode           = false;
@@ -187,6 +188,22 @@ void fsd_handle_follow_distance(FSDState *state, const CanFrame *frame) {
             default: break;
         }
     }
+}
+
+// ── Driver-assist override (UI_driverAssistControl 0x3F8) ────────────────────
+// Opt-in Right-Hand-Drive: set UI_drivingSide = RHD (bit41=1, bit40=0). #66.
+// Source: ev-open-can-tools RHD.json (frame 1016, bit41=1).
+
+bool fsd_handle_driver_assist_override(FSDState *state, CanFrame *frame) {
+    if (frame->dlc < 8) return false;
+    bool modified = false;
+    // bit40-41: UI_drivingSide = 2 (RHD)
+    if (state->assist_rhd_override) {
+        set_bit(frame, 40, false);
+        set_bit(frame, 41, true);
+        modified = true;
+    }
+    return modified;
 }
 
 // ── HW3/HW4 autopilot control (DAS_autopilotControl 0x3FD) ───────────────────

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -105,6 +105,10 @@ void fsd_handle_gtw_car_state(FSDState *state, const CanFrame *frame);
 /** Parse DAS_followDistance (0x3F8) — updates speed_profile from stalk. */
 void fsd_handle_follow_distance(FSDState *state, const CanFrame *frame);
 
+/** Modify UI_driverAssistControl (0x3F8) — opt-in RHD driving-side override (#66).
+ *  Returns true if frame was modified and should be re-sent. */
+bool fsd_handle_driver_assist_override(FSDState *state, CanFrame *frame);
+
 /** Modify DAS_autopilotControl (0x3FD) for HW3/HW4.
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame);

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -1359,11 +1359,15 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
         return;
     }
 
-    // Follow distance → speed_profile (0x3F8), no TX
+    // Follow distance → speed_profile (0x3F8). Parse is read-only; the RHD
+    // driving-side override (#66) may modify a copy and re-TX when enabled.
     if (frame.id == CAN_ID_FOLLOW_DIST) {
+        CanFrame f = frame;
         state_enter();
         fsd_handle_follow_distance(&g_state, &frame);
+        bool modified = fsd_handle_driver_assist_override(&g_state, &f);
         state_exit();
+        if (modified && tx) send_on_bus(bus, f);
         return;
     }
 

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -31,6 +31,7 @@ void prefs_load(FSDState *state) {
     state->emergency_vehicle_detect = g_prefs.getBool("emrg",   false);
     state->summon_unlock            = g_prefs.getBool("summon", false);
     state->continue_on_green        = g_prefs.getBool("cog",    false);
+    state->assist_rhd_override       = g_prefs.getBool("rhd",    false);
     state->bms_output               = g_prefs.getBool("bms",    false);
     state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
     state->blackbox_enabled         = g_prefs.getBool("bbx",    BLACKBOX_DEFAULT_ENABLED);
@@ -64,10 +65,10 @@ void prefs_load(FSDState *state) {
     state->cfg_steer_hi      = g_prefs.getUChar("cshi",   1);
     state->cfg_steer_lo      = g_prefs.getUChar("cslo",   0);
 
-    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
-                  state->continue_on_green,
+                  state->continue_on_green, state->assist_rhd_override,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
@@ -102,6 +103,7 @@ void prefs_save(const FSDState *state) {
     g_prefs.putBool("emrg",   state->emergency_vehicle_detect);
     g_prefs.putBool("summon", state->summon_unlock);
     g_prefs.putBool("cog",    state->continue_on_green);
+    g_prefs.putBool("rhd",    state->assist_rhd_override);
     g_prefs.putBool("bms",    state->bms_output);
     g_prefs.putBool("14x",    state->firmware_14x_warning);
     g_prefs.putBool("bbx",    state->blackbox_enabled);
@@ -134,10 +136,10 @@ void prefs_save(const FSDState *state) {
     g_prefs.putUChar("cshi",  state->cfg_steer_hi);
     g_prefs.putUChar("cslo",  state->cfg_steer_lo);
 
-    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
-                  state->continue_on_green,
+                  state->continue_on_green, state->assist_rhd_override,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -503,6 +503,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">Continue on Green<br><small style="color:var(--muted)">pairs with TLSSC</small></span>
     <label class="sw"><input type="checkbox" id="swCog" onchange="cmd('continue_on_green',this.checked)"><span class="sl2"></span></label>
   </div>
+  <div class="row">
+    <span class="lbl">Right-Hand Drive (RHD)<br><small style="color:var(--red)">RHD markets only — do NOT enable while driving on the right.</small></span>
+    <label class="sw"><input type="checkbox" id="swRhd" onchange="cmd('assist_rhd_override',this.checked)"><span class="sl2"></span></label>
+  </div>
   <div class="row" style="display:block">
     <div id="pmSuggest" style="display:none;margin:0 0 8px;padding:8px 10px;border:1px solid var(--accent);border-radius:6px;background:var(--card2)">
       <div style="font-size:12px;color:var(--text)">Looks like variant <b id="pmName">?</b> &mdash; the standard parser can't read AP-state on this bus.</div>
@@ -966,6 +970,7 @@ function upd(d){
   if(document.getElementById('swTlssc')) document.getElementById('swTlssc').checked=d.tlssc_restore;
   if(document.getElementById('swSummon')) document.getElementById('swSummon').checked=d.summon_unlock;
   if(document.getElementById('swCog')) document.getElementById('swCog').checked=d.continue_on_green;
+  if(document.getElementById('swRhd')) document.getElementById('swRhd').checked=d.assist_rhd_override;
   if(document.getElementById('swDisp')) document.getElementById('swDisp').checked=!!d.display_enabled;
   if(document.activeElement.id!=='dispBr' && document.getElementById('dispBr'))
     document.getElementById('dispBr').value=d.display_brightness||50;
@@ -1553,6 +1558,7 @@ static String build_json() {
     j += "\"tlssc_restore\":"; j += state.tlssc_restore                ? "true" : "false"; j += ',';
     j += "\"summon_unlock\":"; j += state.summon_unlock                ? "true" : "false"; j += ',';
     j += "\"continue_on_green\":"; j += state.continue_on_green         ? "true" : "false"; j += ',';
+    j += "\"assist_rhd_override\":"; j += state.assist_rhd_override      ? "true" : "false"; j += ',';
     j += "\"firmware_14x_warning\":"; j += state.firmware_14x_warning  ? "true" : "false"; j += ',';
 #if defined(BOARD_TTGO_DISPLAY)
     j += "\"display_enabled\":"; j += state.display_enabled             ? "true" : "false"; j += ',';
@@ -2007,6 +2013,18 @@ static void ws_event(uint8_t num, WStype_t type,
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] Continue on Green: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"assist_rhd_override\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->assist_rhd_override = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] RHD Override: %s\n", enabled ? "ON" : "OFF");
             prefs_save(&saved);
         }
     } else if (strstr(buf, "\"dump\"")) {

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -19,6 +19,7 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->enhanced_autopilot = false;
     state->summon_unlock = false;   // opt-in Summon EU Unlock, default OFF
     state->continue_on_green = false; // opt-in Continue on Green, default OFF
+    state->assist_rhd_override = false; // opt-in RHD driving-side override, default OFF
     state->speed_profile_locked = false;
     state->hw4_offset = 0;
 }
@@ -702,6 +703,12 @@ bool fsd_handle_driver_assist_override(FSDState* state, CANFRAME* frame) {
     if(state->assist_lhd_override) {
         fsd_set_bit(frame, 40, true);
         fsd_set_bit(frame, 41, false);
+        modified = true;
+    }
+    // bit40-41: UI_drivingSide = 2 (RHD) — mutually exclusive with LHD above
+    if(state->assist_rhd_override) {
+        fsd_set_bit(frame, 40, false);
+        fsd_set_bit(frame, 41, true);
         modified = true;
     }
     // bit43: UI_enableTripTelemetry = 0 (disable trip data collection)

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -235,6 +235,7 @@ typedef struct FSDState {
     bool assist_hands_off;       // bit14: UI-level hands-on disable
     bool assist_dev_mode;        // bit5: UI_dasDeveloper flag
     bool assist_lhd_override;    // bit40-41: force left-hand drive
+    bool assist_rhd_override;    // bit41 UI_drivingSide = RHD; opt-in, default OFF; mutually exclusive with LHD override
 
     // --- 0x3FD mux1 extras ---
     bool assist_show_lane_graph; // bit45: lane visualization on non-FSD tier

--- a/test/test_fsd_core.c
+++ b/test/test_fsd_core.c
@@ -1585,6 +1585,29 @@ static void test_driver_assist(void) {
     CHECK(fsd_handle_driver_assist_override(&s, &f) == false, "assist no flags -> noop");
 }
 
+// ── 0x3F8 RHD driving-side override (#66) ─────────────────────────────────────
+static void test_rhd_override(void) {
+    FSDState s;
+    CANFRAME f;
+
+    // RHD on: bit41 set, bit40 clear
+    memset(&s, 0, sizeof(s));
+    zero(&f);
+    f.data_lenght = 8;
+    s.assist_rhd_override = true;
+    CHECK(fsd_handle_driver_assist_override(&s, &f), "rhd modifies");
+    CHECK((f.buffer[5] & 0x02) != 0, "rhd bit41 set");
+    CHECK((f.buffer[5] & 0x01) == 0, "rhd bit40 clear");
+
+    // RHD off: bit41 not set, no modification
+    memset(&s, 0, sizeof(s));
+    zero(&f);
+    f.data_lenght = 8;
+    s.assist_rhd_override = false;
+    CHECK(fsd_handle_driver_assist_override(&s, &f) == false, "rhd off -> noop");
+    CHECK((f.buffer[5] & 0x02) == 0, "rhd off bit41 clear");
+}
+
 // ── 0x7FF GTW Config Replay: learn -> arm -> replay ───────────────────────────
 static void test_gtw_shield(void) {
     FSDState s;
@@ -2025,6 +2048,7 @@ int main(void) {
     test_das_status_hw4_no_fallback();
     test_gtw_tier();
     test_driver_assist();
+    test_rhd_override();
     test_gtw_shield();
     test_scroll_press();
     test_misc_parsers();


### PR DESCRIPTION
Adds an opt-in **Right-Hand Drive (RHD)** override (default OFF), addressing #66. On `0x3F8` (UI_driverAssistControl) it sets `UI_drivingSide` to RHD (bit 41 = 1, bit 40 = 0), mirroring the existing LHD override. Source: ev-open-can-tools `RHD.json`.

### Changes
- `fsd_state.h`: new `assist_rhd_override` (default OFF).
- Flipper `fsd_handle_driver_assist_override`: RHD block after the existing LHD block.
- ESP32: new `fsd_handle_driver_assist_override` + routing on the existing `0x3F8` receive path — the follow-distance parse stays read-only; the override modifies a copy and re-TXs only when enabled and TX is allowed, matching the TLSSC send pattern.
- `prefs.cpp`: NVS persistence (`rhd`).
- `web_dashboard.cpp`: "Right-Hand Drive (RHD)" toggle with a warning ("RHD markets only — do NOT enable while driving on the right").
- `test_fsd_core.c`: `test_rhd_override`. **480 host tests pass; ESP32 builds clean (esp32-lilygo).**

### Notes
- Mutually exclusive with the LHD override (enforced in the UI; in the handler RHD wins if both are set).
- Flipper on-device toggle not added — ESP32 dashboard only, consistent with the other recent toggles; the handler logic is present but dormant on Flipper until a settings entry is wired. Follow-up.
- **Not car-validated** — off by default, with a safety warning in the UI.
