### PR TITLE
feat: extend Telemetry Off to reachable 0x3F8 + 0x3FD mux1 flags (experimental)

### DIFF
--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -203,6 +203,32 @@ bool fsd_handle_driver_assist_override(FSDState *state, CanFrame *frame) {
         set_bit(frame, 41, true);
         modified = true;
     }
+    // Telemetry Off (experimental) — clear the reachable UI_driverAssistControl
+    // telemetry-enable flags on 0x3F8. Plain bit-clears, no checksum on this frame.
+    //   bit19 UI_enableClipParkedTelemetry
+    //   bit42 UI_enableClipTelemetry
+    //   bit43 UI_enableTripTelemetry
+    //   bit44 UI_enableRoadSegmentTelemetry
+    //   bit55 UI_enableClipStartStopTelemetry
+    // Source: ev-open-can-tools disable-telemetry.json (GPL-3.0).
+    //
+    // DELIBERATELY OUT OF SCOPE (documented so coverage is honest):
+    //   * 0x389 DAS_status2 bits 13/34/35 — clearing them requires recomputing the
+    //     frame counter (byte6 mask 0xF0) + Tesla checksum; deferred to avoid emitting
+    //     invalid frames.
+    //   * 0x3B3 VCSEC and the ~11 *_alertMatrix *_a030_ECULogUploadRequest frames
+    //     (0x340/341/342/360/3BA/3C0/3C8/3CD/3CE/3CF) — on the Vehicle CAN bus, which
+    //     this tool does not reliably tap; injecting them on a Chassis/Party tap does
+    //     nothing. Reaching them needs Vehicle-bus access first.
+    // REACHABLE SUBSET only — does NOT guarantee reduced detection.
+    if (state->assist_telemetry_off) {
+        set_bit(frame, 19, false);
+        set_bit(frame, 42, false);
+        set_bit(frame, 43, false);
+        set_bit(frame, 44, false);
+        set_bit(frame, 55, false);
+        modified = true;
+    }
     return modified;
 }
 
@@ -250,7 +276,8 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
                           SIG_AP_SPEED_PROFILE_SHIFT);
             modified = true;
         }
-        if (mux == CAN_MUX_1 && (state->nag_killer || state->summon_unlock)) {
+        if (mux == CAN_MUX_1 &&
+            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off)) {
             if (state->nag_killer) {
                 // Nag suppression via bit 19 (clear = no hands-on-wheel request)
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);
@@ -260,6 +287,14 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             if (state->summon_unlock) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);       // bit19 EU restriction clear
                 set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true);  // bit47 summon enable
+                modified = true;
+            }
+            // Telemetry Off (experimental): clear reachable DAS_autopilotControl mux1
+            // telemetry flags — bit48 UI_enableCabinCameraTelemetry, bit50
+            // UI_autopilotTelemetryInChina. Plain bit-clears, no checksum.
+            if (state->assist_telemetry_off) {
+                set_bit(frame, 48, false);
+                set_bit(frame, 50, false);
                 modified = true;
             }
         }
@@ -285,7 +320,8 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
                 set_bit(frame, SIG_AP_HW4_EMERGENCY_VEHICLE_BIT, true);
             modified = true;
         }
-        if (mux == CAN_MUX_1 && (state->nag_killer || state->summon_unlock)) {
+        if (mux == CAN_MUX_1 &&
+            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off)) {
             if (state->nag_killer) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);      // clear hands-on-wheel nag
                 set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true); // HW4 nag-suppression confirmation bit
@@ -295,6 +331,14 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             if (state->summon_unlock) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);       // bit19 EU restriction clear
                 set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true);  // bit47 summon enable
+                modified = true;
+            }
+            // Telemetry Off (experimental): clear reachable DAS_autopilotControl mux1
+            // telemetry flags — bit48 UI_enableCabinCameraTelemetry, bit50
+            // UI_autopilotTelemetryInChina. Plain bit-clears, no checksum.
+            if (state->assist_telemetry_off) {
+                set_bit(frame, 48, false);
+                set_bit(frame, 50, false);
                 modified = true;
             }
         }

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -32,6 +32,7 @@ void prefs_load(FSDState *state) {
     state->summon_unlock            = g_prefs.getBool("summon", false);
     state->continue_on_green        = g_prefs.getBool("cog",    false);
     state->assist_rhd_override       = g_prefs.getBool("rhd",    false);
+    state->assist_telemetry_off      = g_prefs.getBool("teloff", false);
     state->bms_output               = g_prefs.getBool("bms",    false);
     state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
     state->blackbox_enabled         = g_prefs.getBool("bbx",    BLACKBOX_DEFAULT_ENABLED);
@@ -65,10 +66,10 @@ void prefs_load(FSDState *state) {
     state->cfg_steer_hi      = g_prefs.getUChar("cshi",   1);
     state->cfg_steer_lo      = g_prefs.getUChar("cslo",   0);
 
-    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
-                  state->continue_on_green, state->assist_rhd_override,
+                  state->continue_on_green, state->assist_rhd_override, state->assist_telemetry_off,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
@@ -104,6 +105,7 @@ void prefs_save(const FSDState *state) {
     g_prefs.putBool("summon", state->summon_unlock);
     g_prefs.putBool("cog",    state->continue_on_green);
     g_prefs.putBool("rhd",    state->assist_rhd_override);
+    g_prefs.putBool("teloff", state->assist_telemetry_off);
     g_prefs.putBool("bms",    state->bms_output);
     g_prefs.putBool("14x",    state->firmware_14x_warning);
     g_prefs.putBool("bbx",    state->blackbox_enabled);
@@ -136,10 +138,10 @@ void prefs_save(const FSDState *state) {
     g_prefs.putUChar("cshi",  state->cfg_steer_hi);
     g_prefs.putUChar("cslo",  state->cfg_steer_lo);
 
-    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
-                  state->continue_on_green, state->assist_rhd_override,
+                  state->continue_on_green, state->assist_rhd_override, state->assist_telemetry_off,
                   state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -507,6 +507,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">Right-Hand Drive (RHD)<br><small style="color:var(--red)">RHD markets only — do NOT enable while driving on the right.</small></span>
     <label class="sw"><input type="checkbox" id="swRhd" onchange="cmd('assist_rhd_override',this.checked)"><span class="sl2"></span></label>
   </div>
+  <div class="row">
+    <span class="lbl">Telemetry Off (experimental)<br><small style="color:var(--muted)">Experimental &amp; unverified — clears reachable telemetry flags only (not the Vehicle-bus ECU log-upload). Does NOT guarantee reduced detection.</small></span>
+    <label class="sw"><input type="checkbox" id="swTelOff" onchange="cmd('assist_telemetry_off',this.checked)"><span class="sl2"></span></label>
+  </div>
   <div class="row" style="display:block">
     <div id="pmSuggest" style="display:none;margin:0 0 8px;padding:8px 10px;border:1px solid var(--accent);border-radius:6px;background:var(--card2)">
       <div style="font-size:12px;color:var(--text)">Looks like variant <b id="pmName">?</b> &mdash; the standard parser can't read AP-state on this bus.</div>
@@ -971,6 +975,7 @@ function upd(d){
   if(document.getElementById('swSummon')) document.getElementById('swSummon').checked=d.summon_unlock;
   if(document.getElementById('swCog')) document.getElementById('swCog').checked=d.continue_on_green;
   if(document.getElementById('swRhd')) document.getElementById('swRhd').checked=d.assist_rhd_override;
+  if(document.getElementById('swTelOff')) document.getElementById('swTelOff').checked=d.assist_telemetry_off;
   if(document.getElementById('swDisp')) document.getElementById('swDisp').checked=!!d.display_enabled;
   if(document.activeElement.id!=='dispBr' && document.getElementById('dispBr'))
     document.getElementById('dispBr').value=d.display_brightness||50;
@@ -1559,6 +1564,7 @@ static String build_json() {
     j += "\"summon_unlock\":"; j += state.summon_unlock                ? "true" : "false"; j += ',';
     j += "\"continue_on_green\":"; j += state.continue_on_green         ? "true" : "false"; j += ',';
     j += "\"assist_rhd_override\":"; j += state.assist_rhd_override      ? "true" : "false"; j += ',';
+    j += "\"assist_telemetry_off\":"; j += state.assist_telemetry_off    ? "true" : "false"; j += ',';
     j += "\"firmware_14x_warning\":"; j += state.firmware_14x_warning  ? "true" : "false"; j += ',';
 #if defined(BOARD_TTGO_DISPLAY)
     j += "\"display_enabled\":"; j += state.display_enabled             ? "true" : "false"; j += ',';
@@ -2025,6 +2031,18 @@ static void ws_event(uint8_t num, WStype_t type,
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] RHD Override: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"assist_telemetry_off\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->assist_telemetry_off = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Telemetry Off: %s\n", enabled ? "ON" : "OFF");
             prefs_save(&saved);
         }
     } else if (strstr(buf, "\"dump\"")) {

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -238,6 +238,14 @@ bool fsd_handle_autopilot_frame(FSDState* state, CANFRAME* frame, uint32_t now_m
         }
         if(mux == 1) {
             fsd_set_bit(frame, 19, false);
+            // Telemetry Off (experimental): clear reachable DAS_autopilotControl
+            // mux1 telemetry flags — bit48 UI_enableCabinCameraTelemetry,
+            // bit50 UI_autopilotTelemetryInChina. Plain bit-clears, no checksum.
+            // Source: ev-open-can-tools disable-telemetry.json (GPL-3.0).
+            if(state->assist_telemetry_off) {
+                fsd_set_bit(frame, 48, false);
+                fsd_set_bit(frame, 50, false);
+            }
             if(state->summon_unlock) {
                 fsd_set_bit(frame, 47, true);   // summon enable (ev-open-can-tools summon-eu-unlock)
             }
@@ -269,6 +277,13 @@ bool fsd_handle_autopilot_frame(FSDState* state, CANFRAME* frame, uint32_t now_m
         }
         if(mux == 1) {
             fsd_set_bit(frame, 19, false);
+            // Telemetry Off (experimental): clear reachable DAS_autopilotControl
+            // mux1 telemetry flags — bit48 UI_enableCabinCameraTelemetry,
+            // bit50 UI_autopilotTelemetryInChina. Plain bit-clears, no checksum.
+            if(state->assist_telemetry_off) {
+                fsd_set_bit(frame, 48, false);
+                fsd_set_bit(frame, 50, false);
+            }
             // HW4 sets bit47 (summon enable) unconditionally here (pre-existing),
             // so the summon_unlock toggle is effectively always-on for HW4 on this
             // build. The toggle's real effect is on the HW3 path above; ESP32 gates
@@ -711,9 +726,31 @@ bool fsd_handle_driver_assist_override(FSDState* state, CANFRAME* frame) {
         fsd_set_bit(frame, 41, true);
         modified = true;
     }
-    // bit43: UI_enableTripTelemetry = 0 (disable trip data collection)
+    // Telemetry Off (experimental) — clear the reachable UI_driverAssistControl
+    // telemetry-enable flags on 0x3F8. Plain bit-clears, no checksum on this frame.
+    //   bit19 UI_enableClipParkedTelemetry
+    //   bit42 UI_enableClipTelemetry
+    //   bit43 UI_enableTripTelemetry
+    //   bit44 UI_enableRoadSegmentTelemetry
+    //   bit55 UI_enableClipStartStopTelemetry
+    // Source: ev-open-can-tools disable-telemetry.json (GPL-3.0).
+    //
+    // DELIBERATELY OUT OF SCOPE (documented so coverage is honest, not silently
+    // truncated):
+    //   * 0x389 DAS_status2 bits 13/34/35 — clearing these requires recomputing the
+    //     frame counter (byte6 mask 0xF0) + Tesla checksum; deferred to avoid emitting
+    //     invalid frames.
+    //   * 0x3B3 VCSEC and the ~11 *_alertMatrix *_a030_ECULogUploadRequest frames
+    //     (0x340/341/342/360/3BA/3C0/3C8/3CD/3CE/3CF) — these live on the Vehicle CAN
+    //     bus, which this tool does not reliably tap; injecting them on a Chassis/Party
+    //     tap does nothing. Reaching them needs Vehicle-bus access first.
+    // This is a REACHABLE SUBSET only and does NOT guarantee reduced detection.
     if(state->assist_telemetry_off) {
+        fsd_set_bit(frame, 19, false);
+        fsd_set_bit(frame, 42, false);
         fsd_set_bit(frame, 43, false);
+        fsd_set_bit(frame, 44, false);
+        fsd_set_bit(frame, 55, false);
         modified = true;
     }
 

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -242,8 +242,14 @@ typedef struct FSDState {
     bool assist_tlssc_bit38;     // bit38 on mux0: explicit TLSSC enable (complementary to 0x331)
     bool continue_on_green;      // bit39 on mux0 (UI_fsdContinueOnGreenWithCIPV): continue through a green light behind a lead car without stalk confirm; opt-in, default OFF, pairs with TLSSC/bit38
 
-    // --- telemetry disable (0x3F8 bit43) ---
-    bool assist_telemetry_off;   // force UI_enableTripTelemetry=0
+    // --- Telemetry Off (experimental, opt-in, default OFF) ---
+    // Clears the telemetry/logging flags this tool can REACH on the buses it taps:
+    //   0x3F8 UI_driverAssistControl bits 19/42/43/44/55 (clip/trip/road-segment)
+    //   0x3FD DAS_autopilotControl mux1 bits 48/50 (cabin-camera / China AP telemetry)
+    // These are plain bit-clears (no checksum). This is a REACHABLE SUBSET only —
+    // it does NOT touch Vehicle-bus ECU log-upload frames and does NOT guarantee
+    // reduced detection. See the omission notes in fsd_handler.c.
+    bool assist_telemetry_off;
 
     // --- energy consumption (0x33A, read-only) ---
     float energy_wh_per_km;

--- a/tesla_fsd_app.h
+++ b/tesla_fsd_app.h
@@ -106,7 +106,7 @@ typedef struct {
     bool assist_lhd_override;    // force left-hand drive
     bool assist_show_lane_graph; // lane visualization
     bool assist_tlssc_bit38;     // explicit TLSSC enable on 0x3FD mux0
-    bool assist_telemetry_off;   // force trip telemetry off (0x3F8 bit43)
+    bool assist_telemetry_off;   // experimental: clear reachable telemetry flags (0x3F8 19/42/43/44/55 + 0x3FD mux1 48/50)
 
     // extras toggles (BETA — need on-vehicle verification per CAN ID)
     bool extra_hazard_lights;

--- a/test/test_fsd_core.c
+++ b/test/test_fsd_core.c
@@ -1608,6 +1608,66 @@ static void test_rhd_override(void) {
     CHECK((f.buffer[5] & 0x02) == 0, "rhd off bit41 clear");
 }
 
+// ── Telemetry Off (experimental): reachable 0x3F8 + 0x3FD mux1 flag clears ─────
+// 0x3F8 UI_driverAssistControl clears bits 19/42/43/44/55; 0x3FD mux1 clears
+// bits 48/50. Plain bit-clears, no checksum. With the toggle off, none move.
+static void test_telemetry_off(void) {
+    FSDState s;
+    CANFRAME f;
+
+    // 0x3F8: with telemetry-off ON, bits 19/42/43/44/55 are cleared.
+    memset(&s, 0, sizeof(s));
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[2] = 0x08;         // bit19 preset
+    f.buffer[5] = 0x04 | 0x08 | 0x10; // bits 42/43/44 preset
+    f.buffer[6] = 0x80;         // bit55 preset
+    s.assist_telemetry_off = true;
+    CHECK(fsd_handle_driver_assist_override(&s, &f), "0x3F8 telemetry-off modifies");
+    CHECK((f.buffer[2] & 0x08) == 0, "0x3F8 bit19 cleared");
+    CHECK((f.buffer[5] & 0x04) == 0, "0x3F8 bit42 cleared");
+    CHECK((f.buffer[5] & 0x08) == 0, "0x3F8 bit43 cleared");
+    CHECK((f.buffer[5] & 0x10) == 0, "0x3F8 bit44 cleared");
+    CHECK((f.buffer[6] & 0x80) == 0, "0x3F8 bit55 cleared");
+
+    // 0x3F8: with telemetry-off OFF, those bits are untouched.
+    memset(&s, 0, sizeof(s));
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[2] = 0x08;
+    f.buffer[5] = 0x04 | 0x08 | 0x10;
+    f.buffer[6] = 0x80;
+    s.assist_telemetry_off = false;
+    fsd_handle_driver_assist_override(&s, &f);
+    CHECK((f.buffer[2] & 0x08) != 0, "0x3F8 bit19 untouched when off");
+    CHECK((f.buffer[5] & 0x1C) == 0x1C, "0x3F8 bits42/43/44 untouched when off");
+    CHECK((f.buffer[6] & 0x80) != 0, "0x3F8 bit55 untouched when off");
+
+    // 0x3FD mux1: with telemetry-off ON, bits 48/50 are cleared.
+    memset(&s, 0, sizeof(s));
+    s.hw_version = TeslaHW_HW3;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1;            // mux1
+    f.buffer[6] = 0x01 | 0x04; // bits 48/50 preset
+    s.assist_telemetry_off = true;
+    CHECK(fsd_handle_autopilot_frame(&s, &f, 0), "0x3FD mux1 telemetry-off modifies");
+    CHECK((f.buffer[6] & 0x01) == 0, "0x3FD bit48 cleared");
+    CHECK((f.buffer[6] & 0x04) == 0, "0x3FD bit50 cleared");
+
+    // 0x3FD mux1: with telemetry-off OFF, bits 48/50 are untouched.
+    memset(&s, 0, sizeof(s));
+    s.hw_version = TeslaHW_HW3;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1;
+    f.buffer[6] = 0x01 | 0x04;
+    s.assist_telemetry_off = false;
+    fsd_handle_autopilot_frame(&s, &f, 0);
+    CHECK((f.buffer[6] & 0x01) != 0, "0x3FD bit48 untouched when off");
+    CHECK((f.buffer[6] & 0x04) != 0, "0x3FD bit50 untouched when off");
+}
+
 // ── 0x7FF GTW Config Replay: learn -> arm -> replay ───────────────────────────
 static void test_gtw_shield(void) {
     FSDState s;
@@ -2049,6 +2109,7 @@ int main(void) {
     test_gtw_tier();
     test_driver_assist();
     test_rhd_override();
+    test_telemetry_off();
     test_gtw_shield();
     test_scroll_press();
     test_misc_parsers();


### PR DESCRIPTION
Extends the existing **Telemetry Off** flag (`assist_telemetry_off`) from a single bit to the full **reachable** set of telemetry-enable flags, and exposes it on the ESP32 dashboard. Source: ev-open-can-tools `disable-telemetry.json` (GPL-3.0).

⚠️ **Experimental & unverified.** It clears only the telemetry flags on frames this tool actually reaches (Chassis/Party). It does **not** cover the Vehicle-bus ECU log-upload family and does **not** guarantee reduced detection or any ban protection — and the UI says exactly that.

### Bits cleared
- **0x3F8**: 19 (ClipParked), 42 (Clip), 43 (Trip), 44 (RoadSegment), 55 (ClipStartStop)
- **0x3FD mux1**: 48 (CabinCamera), 50 (autopilotTelemetryInChina)

### Deliberately out of scope (documented in-code, not silently dropped)
- **0x389** bits 13/34/35 — would require recomputing the counter + checksum; deferred to avoid emitting invalid frames.
- **0x3B3 + ~11 `*_alertMatrix` ECU-log-upload frames** (0x340/341/342/360/3BA/3C0/3C8/3CD/3CE/3CF) — on the Vehicle CAN bus this tool doesn't reliably tap; reaching them needs Vehicle-bus access first.

### Changes
- Flipper + ESP32 `0x3F8` and `0x3FD`-mux1 handlers clear the reachable bits under the flag.
- `prefs.cpp`: NVS `teloff`. `web_dashboard.cpp`: "Telemetry Off (experimental)" toggle with the honesty hint. `test_fsd_core.c`: `test_telemetry_off`. **494 host tests pass; ESP32 builds clean.**
- Stacked on #146; base retargets to `main` once that merges.
- **Not car-validated.**
