### PR TITLE
feat: experimental AP branch/tier selector (0x3FD mux1 UI_apmv3Branch)

### DIFF
--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -47,6 +47,7 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->ignore_ota           = false;
     state->emergency_vehicle_detect = false;
     state->summon_unlock        = false;    // opt-in Summon EU Unlock, default OFF
+    state->apmv3_branch         = 0xFF;      // opt-in AP branch/tier selector, default OFF (0xFF sentinel)
     state->continue_on_green    = false;    // opt-in Continue on Green, default OFF
     state->assist_rhd_override  = false;    // opt-in RHD driving-side override, default OFF
     state->fsd_unlock           = false;
@@ -277,7 +278,8 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             modified = true;
         }
         if (mux == CAN_MUX_1 &&
-            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off)) {
+            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off ||
+             state->apmv3_branch <= 5)) {
             if (state->nag_killer) {
                 // Nag suppression via bit 19 (clear = no hands-on-wheel request)
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);
@@ -295,6 +297,12 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             if (state->assist_telemetry_off) {
                 set_bit(frame, 48, false);
                 set_bit(frame, 50, false);
+                modified = true;
+            }
+            // AP branch/tier selector (experimental, non-persistent): UI_apmv3Branch
+            // bits 40-42 = byte5 bits 0-2. 0xFF sentinel = OFF (leave untouched).
+            if (state->apmv3_branch <= 5) {
+                frame->data[5] = (uint8_t)((frame->data[5] & ~0x07) | (state->apmv3_branch & 0x07));
                 modified = true;
             }
         }
@@ -321,7 +329,8 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             modified = true;
         }
         if (mux == CAN_MUX_1 &&
-            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off)) {
+            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off ||
+             state->apmv3_branch <= 5)) {
             if (state->nag_killer) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);      // clear hands-on-wheel nag
                 set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true); // HW4 nag-suppression confirmation bit
@@ -339,6 +348,12 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             if (state->assist_telemetry_off) {
                 set_bit(frame, 48, false);
                 set_bit(frame, 50, false);
+                modified = true;
+            }
+            // AP branch/tier selector (experimental, non-persistent): UI_apmv3Branch
+            // bits 40-42 = byte5 bits 0-2. 0xFF sentinel = OFF (leave untouched).
+            if (state->apmv3_branch <= 5) {
+                frame->data[5] = (uint8_t)((frame->data[5] & ~0x07) | (state->apmv3_branch & 0x07));
                 modified = true;
             }
         }

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -33,6 +33,7 @@ void prefs_load(FSDState *state) {
     state->continue_on_green        = g_prefs.getBool("cog",    false);
     state->assist_rhd_override       = g_prefs.getBool("rhd",    false);
     state->assist_telemetry_off      = g_prefs.getBool("teloff", false);
+    state->apmv3_branch             = g_prefs.getUChar("apmv3", 0xFF);  // AP branch/tier selector, 0xFF = OFF
     state->bms_output               = g_prefs.getBool("bms",    false);
     state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
     state->blackbox_enabled         = g_prefs.getBool("bbx",    BLACKBOX_DEFAULT_ENABLED);
@@ -66,11 +67,11 @@ void prefs_load(FSDState *state) {
     state->cfg_steer_hi      = g_prefs.getUChar("cshi",   1);
     state->cfg_steer_lo      = g_prefs.getUChar("cslo",   0);
 
-    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d APMv3=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
                   state->continue_on_green, state->assist_rhd_override, state->assist_telemetry_off,
-                  state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
+                  state->apmv3_branch, state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
 }
@@ -106,6 +107,7 @@ void prefs_save(const FSDState *state) {
     g_prefs.putBool("cog",    state->continue_on_green);
     g_prefs.putBool("rhd",    state->assist_rhd_override);
     g_prefs.putBool("teloff", state->assist_telemetry_off);
+    g_prefs.putUChar("apmv3", state->apmv3_branch);  // AP branch/tier selector, 0xFF = OFF
     g_prefs.putBool("bms",    state->bms_output);
     g_prefs.putBool("14x",    state->firmware_14x_warning);
     g_prefs.putBool("bbx",    state->blackbox_enabled);
@@ -138,11 +140,11 @@ void prefs_save(const FSDState *state) {
     g_prefs.putUChar("cshi",  state->cfg_steer_hi);
     g_prefs.putUChar("cslo",  state->cfg_steer_lo);
 
-    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d APMv3=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
                   state->continue_on_green, state->assist_rhd_override, state->assist_telemetry_off,
-                  state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
+                  state->apmv3_branch, state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
 }

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -511,6 +511,18 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">Telemetry Off (experimental)<br><small style="color:var(--muted)">Experimental &amp; unverified — clears reachable telemetry flags only (not the Vehicle-bus ECU log-upload). Does NOT guarantee reduced detection.</small></span>
     <label class="sw"><input type="checkbox" id="swTelOff" onchange="cmd('assist_telemetry_off',this.checked)"><span class="sl2"></span></label>
   </div>
+  <div class="row">
+    <span class="lbl">AP Branch/Tier (experimental)<br><small style="color:var(--muted)">Experimental &amp; non-persistent — injects a UI branch/tier hint only, reverts when injection stops; unverified and may be a ban signal. Off by default.</small></span>
+    <select id="selApmv3" onchange="cmd('apmv3_branch',parseInt(this.value,10))">
+      <option value="255">Off</option>
+      <option value="0">Live</option>
+      <option value="1">Stage</option>
+      <option value="2">Dev</option>
+      <option value="3">Stage2</option>
+      <option value="4">EAP</option>
+      <option value="5">Demo</option>
+    </select>
+  </div>
   <div class="row" style="display:block">
     <div id="pmSuggest" style="display:none;margin:0 0 8px;padding:8px 10px;border:1px solid var(--accent);border-radius:6px;background:var(--card2)">
       <div style="font-size:12px;color:var(--text)">Looks like variant <b id="pmName">?</b> &mdash; the standard parser can't read AP-state on this bus.</div>
@@ -976,6 +988,8 @@ function upd(d){
   if(document.getElementById('swCog')) document.getElementById('swCog').checked=d.continue_on_green;
   if(document.getElementById('swRhd')) document.getElementById('swRhd').checked=d.assist_rhd_override;
   if(document.getElementById('swTelOff')) document.getElementById('swTelOff').checked=d.assist_telemetry_off;
+  var apmv3Sel=document.getElementById('selApmv3');
+  if(apmv3Sel && d.apmv3_branch!==undefined && document.activeElement!==apmv3Sel) apmv3Sel.value=String(d.apmv3_branch);
   if(document.getElementById('swDisp')) document.getElementById('swDisp').checked=!!d.display_enabled;
   if(document.activeElement.id!=='dispBr' && document.getElementById('dispBr'))
     document.getElementById('dispBr').value=d.display_brightness||50;
@@ -1565,6 +1579,7 @@ static String build_json() {
     j += "\"continue_on_green\":"; j += state.continue_on_green         ? "true" : "false"; j += ',';
     j += "\"assist_rhd_override\":"; j += state.assist_rhd_override      ? "true" : "false"; j += ',';
     j += "\"assist_telemetry_off\":"; j += state.assist_telemetry_off    ? "true" : "false"; j += ',';
+    j += "\"apmv3_branch\":";  j += (int)state.apmv3_branch;             j += ',';
     j += "\"firmware_14x_warning\":"; j += state.firmware_14x_warning  ? "true" : "false"; j += ',';
 #if defined(BOARD_TTGO_DISPLAY)
     j += "\"display_enabled\":"; j += state.display_enabled             ? "true" : "false"; j += ',';
@@ -2043,6 +2058,22 @@ static void ws_event(uint8_t num, WStype_t type,
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] Telemetry Off: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"apmv3_branch\"")) {
+        // AP branch/tier selector (experimental, non-persistent): 0-5 select a
+        // UI_apmv3Branch value, any other value (255 = Off) stores the 0xFF
+        // sentinel so the handler leaves the frame untouched.
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            int sel = atoi(vptr);
+            uint8_t want = (sel >= 0 && sel <= 5) ? (uint8_t)sel : 0xFF;
+            FSDState saved;
+            state_enter();
+            g_state->apmv3_branch = want;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] AP Branch/Tier: %d\n", want);
             prefs_save(&saved);
         }
     } else if (strstr(buf, "\"dump\"")) {

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -18,6 +18,7 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->das_prev_hands_on_state = 0xFF; // escalation-edge baseline (#100)
     state->enhanced_autopilot = false;
     state->summon_unlock = false;   // opt-in Summon EU Unlock, default OFF
+    state->apmv3_branch = 0xFF;     // opt-in AP branch/tier selector, default OFF (0xFF sentinel)
     state->continue_on_green = false; // opt-in Continue on Green, default OFF
     state->assist_rhd_override = false; // opt-in RHD driving-side override, default OFF
     state->speed_profile_locked = false;
@@ -255,6 +256,11 @@ bool fsd_handle_autopilot_frame(FSDState* state, CANFRAME* frame, uint32_t now_m
             if(state->assist_show_lane_graph) {
                 fsd_set_bit(frame, 45, true);
             }
+            // AP branch/tier selector (experimental, non-persistent): UI_apmv3Branch
+            // bits 40-42 = byte5 bits 0-2. 0xFF sentinel = OFF (leave untouched).
+            if(state->apmv3_branch <= 5) {
+                frame->buffer[5] = (uint8_t)((frame->buffer[5] & ~0x07) | (state->apmv3_branch & 0x07));
+            }
             state->nag_suppressed = true;
             modified = true;
         }
@@ -294,6 +300,11 @@ bool fsd_handle_autopilot_frame(FSDState* state, CANFRAME* frame, uint32_t now_m
             }
             if(state->assist_show_lane_graph) {
                 fsd_set_bit(frame, 45, true);
+            }
+            // AP branch/tier selector (experimental, non-persistent): UI_apmv3Branch
+            // bits 40-42 = byte5 bits 0-2. 0xFF sentinel = OFF (leave untouched).
+            if(state->apmv3_branch <= 5) {
+                frame->buffer[5] = (uint8_t)((frame->buffer[5] & ~0x07) | (state->apmv3_branch & 0x07));
             }
             state->nag_suppressed = true;
             modified = true;

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -191,6 +191,13 @@ typedef struct FSDState {
     // bit19 (EU summon restriction) and sets bit47 (summon enable), on HW3 + HW4.
     // Opt-in, default OFF. // TODO: add Summon EU Unlock to Flipper menu
     bool summon_unlock;
+    // AP branch/tier selector (0x3FD DAS_autopilotControl mux1, UI_apmv3Branch,
+    // bits 40-42 = byte5 bits 0-2). Enum: 0=LIVE 1=STAGE 2=DEV 3=STAGE2 4=EAP
+    // 5=DEMO. Opt-in, default OFF (0xFF sentinel = don't touch). Experimental and
+    // non-persistent: writing this only changes which AP software branch/tier the
+    // UI presents while injection is live; it reverts the instant injection stops.
+    // Real-world effect is unverified.
+    uint8_t apmv3_branch;
     bool speed_profile_locked;   // when true, follow distance won't override profile
     uint8_t hw4_offset;          // HW4 mux=2 speed offset override (0 = no override)
 

--- a/test/test_fsd_core.c
+++ b/test/test_fsd_core.c
@@ -1668,6 +1668,59 @@ static void test_telemetry_off(void) {
     CHECK((f.buffer[6] & 0x04) != 0, "0x3FD bit50 untouched when off");
 }
 
+// ── AP branch/tier selector (0x3FD mux1 UI_apmv3Branch, bits 40-42) ──────────
+// Experimental, opt-in, non-persistent. 0xFF sentinel = OFF (frame untouched);
+// 0-5 write the branch/tier into byte5 bits 0-2.
+static void test_apmv3_branch(void) {
+    FSDState s;
+    CANFRAME f;
+
+    // HW4 mux1: apmv3_branch=4 (EAP) -> byte5 bits0-2 == 4.
+    memset(&s, 0, sizeof(s));
+    s.hw_version = TeslaHW_HW4;
+    s.apmv3_branch = 4;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1; // mux1
+    CHECK(fsd_handle_autopilot_frame(&s, &f, 0), "HW4 mux1 apmv3 modifies");
+    CHECK((f.buffer[5] & 0x07) == 4, "HW4 mux1 apmv3=EAP byte5[0:2]=%u exp 4",
+          f.buffer[5] & 0x07);
+
+    // HW3 mux1: apmv3_branch=4 (EAP) -> byte5 bits0-2 == 4.
+    memset(&s, 0, sizeof(s));
+    s.hw_version = TeslaHW_HW3;
+    s.apmv3_branch = 4;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1; // mux1
+    CHECK(fsd_handle_autopilot_frame(&s, &f, 0), "HW3 mux1 apmv3 modifies");
+    CHECK((f.buffer[5] & 0x07) == 4, "HW3 mux1 apmv3=EAP byte5[0:2]=%u exp 4",
+          f.buffer[5] & 0x07);
+
+    // OFF (0xFF sentinel): byte5 bits0-2 left untouched (preset 0x05 preserved).
+    memset(&s, 0, sizeof(s));
+    s.hw_version = TeslaHW_HW4;
+    s.apmv3_branch = 0xFF;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1; // mux1
+    f.buffer[5] = 0x05; // preset low 3 bits to prove they survive
+    fsd_handle_autopilot_frame(&s, &f, 0);
+    CHECK((f.buffer[5] & 0x07) == 0x05, "HW4 mux1 apmv3 OFF leaves byte5[0:2]=%u exp 5",
+          f.buffer[5] & 0x07);
+
+    memset(&s, 0, sizeof(s));
+    s.hw_version = TeslaHW_HW3;
+    s.apmv3_branch = 0xFF;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[0] = 1; // mux1
+    f.buffer[5] = 0x05;
+    fsd_handle_autopilot_frame(&s, &f, 0);
+    CHECK((f.buffer[5] & 0x07) == 0x05, "HW3 mux1 apmv3 OFF leaves byte5[0:2]=%u exp 5",
+          f.buffer[5] & 0x07);
+}
+
 // ── 0x7FF GTW Config Replay: learn -> arm -> replay ───────────────────────────
 static void test_gtw_shield(void) {
     FSDState s;
@@ -2110,6 +2163,7 @@ int main(void) {
     test_driver_assist();
     test_rhd_override();
     test_telemetry_off();
+    test_apmv3_branch();
     test_gtw_shield();
     test_scroll_press();
     test_misc_parsers();


### PR DESCRIPTION
Adds an **experimental** opt-in AP branch/tier selector (`UI_apmv3Branch`) on `0x3FD` mux 1, bits 40-42 (byte 5 bits 0-2). Values: Off (default) / Live / Stage / Dev / Stage2 / EAP / Demo.

⚠️ **Experimental & non-persistent.** This injects a UI branch/tier hint only — it reverts the moment injection stops, its real-world effect is unverified, and selecting a non-Live branch (e.g. Dev/EAP) could be a ban signal. Off by default; the dashboard hint says exactly that.

Implemented clean-room from the DBC signal definition (start bit 40, length 3) — no third-party code copied.

### Changes
- `fsd_state.h`: `uint8_t apmv3_branch` (`0xFF` sentinel = OFF).
- Flipper + ESP32 `0x3FD` mux1 handlers: write the 3-bit field when a branch is selected; byte-for-byte unchanged when OFF (only byte5 bits 0-2 touched — no overlap with the bit45/46/47 lane/EAP/summon bits).
- `prefs.cpp`: NVS `apmv3`. `web_dashboard.cpp`: dropdown selector with the experimental hint. `test_fsd_core.c`: `test_apmv3_branch`. **500 host tests pass; ESP32 builds clean.**
- **Not car-validated.** Relates to the EAP-tier question in #143 — note this is the injection (non-persistent) path, distinct from a persistent config-coding unlock.
