### PR TITLE
feat: adjustable Track Mode (0x313 balance/stability/cooling)

### DIFF
--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -23,6 +23,7 @@
 #define CAN_ID_DAS_STATUS_HW3 0x399u  // 921  - DAS_status on Legacy/HW3 AP/DAS
 #define CAN_ID_ISA_SPEED      0x399u  // 921  - ISA speed limit on HW4 only
 #define CAN_ID_DAS_STATUS_HW4 0x39Bu  // 923  - DAS_status on HW4 AP/DAS
+#define CAN_ID_TRACK_MODE_SET 0x313u  // 787  - UI_trackModeSettings: track mode request (checksummed)
 // Vehicle/body bus reachability probes (#128) — RX presence only, never actuated.
 #define CAN_ID_UI_VEHICLE_CTRL 0x273u // 627  - UI_vehicleControl: mirror fold/lock/wiper/horn/seat heat
 #define CAN_ID_VCLEFT_DOOR     0x102u // 258  - VCLEFT_doorStatus: mirror state/tilt read-back

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -50,6 +50,11 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->apmv3_branch         = 0xFF;      // opt-in AP branch/tier selector, default OFF (0xFF sentinel)
     state->continue_on_green    = false;    // opt-in Continue on Green, default OFF
     state->assist_rhd_override  = false;    // opt-in RHD driving-side override, default OFF
+    state->track_mode_inject    = false;    // Track Mode inject master opt-in, default OFF
+    state->track_rotation_pct   = 50;       // neutral handling balance
+    state->track_stability_pct  = 100;      // full stability = safest default
+    state->track_post_cooling   = false;
+    state->track_cmp_overclock  = false;
     state->fsd_unlock           = false;
     state->force_fsd            = false;
     state->china_mode           = false;
@@ -231,6 +236,36 @@ bool fsd_handle_driver_assist_override(FSDState *state, CanFrame *frame) {
         modified = true;
     }
     return modified;
+}
+
+// ── Track Mode inject (UI_trackModeSettings 0x313) ───────────────────────────
+// Adjustable Track Mode via the car's own 0x313 broadcast: request ON + handling
+// balance / stability assist / cooling, then recompute the additive checksum.
+// The byte6 counter is left untouched (we modify the car's own frame in place).
+// Master opt-in only; not gated on trim or the read-back 0x118 state, because the
+// enable request works on non-Performance trims too.
+// Source: joshwardell/model3dbc UI_trackModeSettings (frame 787).
+//   byte0 bits1:0 = UI_trackModeRequest (0 IDLE / 1 ON / 2 OFF)
+//   byte1 = UI_trackRotationTendency, factor 0.5 (raw = pct*2, 0..200)
+//   byte2 = UI_trackStabilityAssist,  factor 0.5 (raw = pct*2, 0..200)
+//   byte3 bit0 = UI_trackPostCooling (bit24), bit1 = UI_trackCmpOverclock (bit25)
+//   byte7 = UI_trackModeSettingsChecksum = additive checksum over bytes 0..6
+static uint8_t track_pct_to_raw(uint8_t pct) {
+    if (pct > 100) pct = 100;   // clamp 0..100
+    return (uint8_t)(pct * 2);  // factor 0.5 -> raw 0..200
+}
+
+bool fsd_handle_track_mode_inject(FSDState *state, CanFrame *frame) {
+    if (!state->track_mode_inject) return false;
+    if (frame->dlc < 8) return false;
+
+    frame->data[0] = (uint8_t)((frame->data[0] & 0xFC) | 0x01);      // UI_trackModeRequest = ON
+    frame->data[1] = track_pct_to_raw(state->track_rotation_pct);    // UI_trackRotationTendency
+    frame->data[2] = track_pct_to_raw(state->track_stability_pct);   // UI_trackStabilityAssist
+    set_bit(frame, 24, state->track_post_cooling);                   // UI_trackPostCooling (byte3 bit0)
+    set_bit(frame, 25, state->track_cmp_overclock);                  // UI_trackCmpOverclock (byte3 bit1)
+    frame->data[7] = tesla_additive_checksum(CAN_ID_TRACK_MODE_SET, frame->data, 7);
+    return true;
 }
 
 // ── HW3/HW4 autopilot control (DAS_autopilotControl 0x3FD) ───────────────────

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -51,8 +51,8 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->continue_on_green    = false;    // opt-in Continue on Green, default OFF
     state->assist_rhd_override  = false;    // opt-in RHD driving-side override, default OFF
     state->track_mode_inject    = false;    // Track Mode inject master opt-in, default OFF
-    state->track_rotation_pct   = 50;       // neutral handling balance
-    state->track_stability_pct  = 100;      // full stability = safest default
+    state->track_rotation_pct   = 100;      // full rotation = rear-biased / RWD-like
+    state->track_stability_pct  = 30;       // 30% keeps a safety margin but lets it move
     state->track_post_cooling   = false;
     state->track_cmp_overclock  = false;
     state->fsd_unlock           = false;

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -109,6 +109,12 @@ void fsd_handle_follow_distance(FSDState *state, const CanFrame *frame);
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_driver_assist_override(FSDState *state, CanFrame *frame);
 
+/** Modify UI_trackModeSettings (0x313) — adjustable Track Mode inject. Sets the
+ *  request ON plus handling balance / stability / cooling and recomputes the
+ *  additive checksum. Master opt-in (state->track_mode_inject). The byte6 counter
+ *  is left untouched. Returns true if the frame was modified and should be re-sent. */
+bool fsd_handle_track_mode_inject(FSDState *state, CanFrame *frame);
+
 /** Modify DAS_autopilotControl (0x3FD) for HW3/HW4.
  *  Returns true if frame was modified and should be re-sent. */
 bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame);

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -1381,6 +1381,17 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
         return;
     }
 
+    // Track Mode inject (0x313) — adjustable balance/stability/cooling on the
+    // car's own UI_trackModeSettings broadcast (master opt-in inside the handler).
+    if (frame.id == CAN_ID_TRACK_MODE_SET) {
+        CanFrame f = frame;
+        state_enter();
+        bool modified = fsd_handle_track_mode_inject(&g_state, &f);
+        state_exit();
+        if (modified && tx) send_on_bus(bus, f);
+        return;
+    }
+
     // HW3/HW4 autopilot control (0x3FD) — main FSD activation frame
     if (frame.id == CAN_ID_AP_CONTROL) {
         CanFrame f = frame;

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -37,6 +37,11 @@ void prefs_load(FSDState *state) {
     state->bms_output               = g_prefs.getBool("bms",    false);
     state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
     state->blackbox_enabled         = g_prefs.getBool("bbx",    BLACKBOX_DEFAULT_ENABLED);
+    state->track_mode_inject        = g_prefs.getBool("tmInj",  false);
+    state->track_rotation_pct       = g_prefs.getUChar("tmRot", 50);
+    state->track_stability_pct      = g_prefs.getUChar("tmStab",100);
+    state->track_post_cooling       = g_prefs.getBool("tmPC",   false);
+    state->track_cmp_overclock      = g_prefs.getBool("tmCO",   false);
 #if defined(BOARD_TTGO_DISPLAY)
     state->display_enabled          = g_prefs.getBool("disp",   true);
     state->display_brightness       = g_prefs.getUChar("disp_br", 50);
@@ -67,11 +72,13 @@ void prefs_load(FSDState *state) {
     state->cfg_steer_hi      = g_prefs.getUChar("cshi",   1);
     state->cfg_steer_lo      = g_prefs.getUChar("cslo",   0);
 
-    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d APMv3=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Loaded: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d APMv3=%d TrkMode=%d/%u/%u/%d/%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
                   state->continue_on_green, state->assist_rhd_override, state->assist_telemetry_off,
-                  state->apmv3_branch, state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
+                  state->apmv3_branch, state->track_mode_inject, state->track_rotation_pct,
+                  state->track_stability_pct, state->track_post_cooling, state->track_cmp_overclock,
+                  state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
 }
@@ -111,6 +118,11 @@ void prefs_save(const FSDState *state) {
     g_prefs.putBool("bms",    state->bms_output);
     g_prefs.putBool("14x",    state->firmware_14x_warning);
     g_prefs.putBool("bbx",    state->blackbox_enabled);
+    g_prefs.putBool("tmInj",  state->track_mode_inject);
+    g_prefs.putUChar("tmRot", state->track_rotation_pct);
+    g_prefs.putUChar("tmStab",state->track_stability_pct);
+    g_prefs.putBool("tmPC",   state->track_post_cooling);
+    g_prefs.putBool("tmCO",   state->track_cmp_overclock);
 #if defined(BOARD_TTGO_DISPLAY)
     g_prefs.putBool("disp",   state->display_enabled);
     g_prefs.putUChar("disp_br", state->display_brightness);
@@ -140,11 +152,13 @@ void prefs_save(const FSDState *state) {
     g_prefs.putUChar("cshi",  state->cfg_steer_hi);
     g_prefs.putUChar("cslo",  state->cfg_steer_lo);
 
-    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d APMv3=%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
+    Serial.printf("[NVS] Saved: FSDUnlock=%d NAG=%d ContinuousAP=%d IgnoreOTA=%d China=%d Chime=%d Summon=%d COG=%d RHD=%d TelOff=%d APMv3=%d TrkMode=%d/%u/%u/%d/%d Sleep=%u AP=\"%s\" STA=\"%s\" HIDDEN=%d\n",
                   state->fsd_unlock, state->nag_killer, state->continuous_ap, state->ignore_ota,
                   state->china_mode, state->suppress_speed_chime, state->summon_unlock,
                   state->continue_on_green, state->assist_rhd_override, state->assist_telemetry_off,
-                  state->apmv3_branch, state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
+                  state->apmv3_branch, state->track_mode_inject, state->track_rotation_pct,
+                  state->track_stability_pct, state->track_post_cooling, state->track_cmp_overclock,
+                  state->sleep_idle_ms, state->wifi_ssid, state->wifi_sta_ssid,
                   state->wifi_hidden);
     g_prefs.end();
 }

--- a/esp32/.firmware/prefs.cpp
+++ b/esp32/.firmware/prefs.cpp
@@ -38,8 +38,8 @@ void prefs_load(FSDState *state) {
     state->firmware_14x_warning     = g_prefs.getBool("14x",    true);
     state->blackbox_enabled         = g_prefs.getBool("bbx",    BLACKBOX_DEFAULT_ENABLED);
     state->track_mode_inject        = g_prefs.getBool("tmInj",  false);
-    state->track_rotation_pct       = g_prefs.getUChar("tmRot", 50);
-    state->track_stability_pct      = g_prefs.getUChar("tmStab",100);
+    state->track_rotation_pct       = g_prefs.getUChar("tmRot", 100);
+    state->track_stability_pct      = g_prefs.getUChar("tmStab", 30);
     state->track_post_cooling       = g_prefs.getBool("tmPC",   false);
     state->track_cmp_overclock      = g_prefs.getBool("tmCO",   false);
 #if defined(BOARD_TTGO_DISPLAY)

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -525,15 +525,15 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
   </div>
   <div class="row" style="display:block">
     <div style="display:flex;align-items:center;justify-content:space-between">
-      <span class="lbl">Track Mode (experimental)<br><small style="color:var(--muted)">Experimental &mdash; Vehicle-bus / Track-capable cars; not car-validated. Stability 100% = stock.</small></span>
+      <span class="lbl">Track Mode (experimental)<br><small style="color:var(--muted)">Experimental &mdash; Vehicle-bus; not car-validated. Defaults to rear-biased (rotation 100) + 30% stability &mdash; fun with a safety margin. Raise stability for stock feel.</small></span>
       <label class="sw"><input type="checkbox" id="swTrkMode" onchange="cmd('track_mode_inject',this.checked)"><span class="sl2"></span></label>
     </div>
     <div style="margin-top:8px">
-      <label style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted)"><span>Handling Balance <small>(stable &rarr; rotation)</small></span><span id="trkRotV">50</span></label>
+      <label style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted)"><span>Handling Balance <small>(stable &rarr; rotation)</small></span><span id="trkRotV">100</span></label>
       <input type="range" id="trkRot" min="0" max="100" style="width:100%" oninput="document.getElementById('trkRotV').textContent=this.value" onchange="cmd('track_rotation_pct',parseInt(this.value,10))">
     </div>
     <div style="margin-top:6px">
-      <label style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted)"><span>Stability Assist</span><span id="trkStabV">100</span></label>
+      <label style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted)"><span>Stability Assist</span><span id="trkStabV">30</span></label>
       <input type="range" id="trkStab" min="0" max="100" style="width:100%" oninput="document.getElementById('trkStabV').textContent=this.value" onchange="cmd('track_stability_pct',parseInt(this.value,10))">
     </div>
     <div class="row" style="padding:6px 0 0">

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -524,6 +524,28 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     </select>
   </div>
   <div class="row" style="display:block">
+    <div style="display:flex;align-items:center;justify-content:space-between">
+      <span class="lbl">Track Mode (experimental)<br><small style="color:var(--muted)">Experimental &mdash; Vehicle-bus / Track-capable cars; not car-validated. Stability 100% = stock.</small></span>
+      <label class="sw"><input type="checkbox" id="swTrkMode" onchange="cmd('track_mode_inject',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div style="margin-top:8px">
+      <label style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted)"><span>Handling Balance <small>(stable &rarr; rotation)</small></span><span id="trkRotV">50</span></label>
+      <input type="range" id="trkRot" min="0" max="100" style="width:100%" oninput="document.getElementById('trkRotV').textContent=this.value" onchange="cmd('track_rotation_pct',parseInt(this.value,10))">
+    </div>
+    <div style="margin-top:6px">
+      <label style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted)"><span>Stability Assist</span><span id="trkStabV">100</span></label>
+      <input type="range" id="trkStab" min="0" max="100" style="width:100%" oninput="document.getElementById('trkStabV').textContent=this.value" onchange="cmd('track_stability_pct',parseInt(this.value,10))">
+    </div>
+    <div class="row" style="padding:6px 0 0">
+      <span class="lbl">Post-drive Cooling</span>
+      <label class="sw"><input type="checkbox" id="swTrkPC" onchange="cmd('track_post_cooling',this.checked)"><span class="sl2"></span></label>
+    </div>
+    <div class="row" style="padding:0">
+      <span class="lbl">Compressor Overclock<br><small style="color:var(--muted)">max cooling</small></span>
+      <label class="sw"><input type="checkbox" id="swTrkCO" onchange="cmd('track_cmp_overclock',this.checked)"><span class="sl2"></span></label>
+    </div>
+  </div>
+  <div class="row" style="display:block">
     <div id="pmSuggest" style="display:none;margin:0 0 8px;padding:8px 10px;border:1px solid var(--accent);border-radius:6px;background:var(--card2)">
       <div style="font-size:12px;color:var(--text)">Looks like variant <b id="pmName">?</b> &mdash; the standard parser can't read AP-state on this bus.</div>
       <button type="button" id="pmApply" onclick="pmApply()" style="margin-top:6px;background:var(--accent);color:#000;border:0;padding:6px 12px;border-radius:4px;cursor:pointer">Apply this profile</button>
@@ -990,6 +1012,11 @@ function upd(d){
   if(document.getElementById('swTelOff')) document.getElementById('swTelOff').checked=d.assist_telemetry_off;
   var apmv3Sel=document.getElementById('selApmv3');
   if(apmv3Sel && d.apmv3_branch!==undefined && document.activeElement!==apmv3Sel) apmv3Sel.value=String(d.apmv3_branch);
+  if(document.getElementById('swTrkMode')) document.getElementById('swTrkMode').checked=d.track_mode_inject;
+  if(document.getElementById('trkRot')&&document.activeElement.id!=='trkRot'&&d.track_rotation_pct!==undefined){document.getElementById('trkRot').value=d.track_rotation_pct;var _tr=document.getElementById('trkRotV');if(_tr)_tr.textContent=d.track_rotation_pct;}
+  if(document.getElementById('trkStab')&&document.activeElement.id!=='trkStab'&&d.track_stability_pct!==undefined){document.getElementById('trkStab').value=d.track_stability_pct;var _ts=document.getElementById('trkStabV');if(_ts)_ts.textContent=d.track_stability_pct;}
+  if(document.getElementById('swTrkPC')) document.getElementById('swTrkPC').checked=d.track_post_cooling;
+  if(document.getElementById('swTrkCO')) document.getElementById('swTrkCO').checked=d.track_cmp_overclock;
   if(document.getElementById('swDisp')) document.getElementById('swDisp').checked=!!d.display_enabled;
   if(document.activeElement.id!=='dispBr' && document.getElementById('dispBr'))
     document.getElementById('dispBr').value=d.display_brightness||50;
@@ -1580,6 +1607,11 @@ static String build_json() {
     j += "\"assist_rhd_override\":"; j += state.assist_rhd_override      ? "true" : "false"; j += ',';
     j += "\"assist_telemetry_off\":"; j += state.assist_telemetry_off    ? "true" : "false"; j += ',';
     j += "\"apmv3_branch\":";  j += (int)state.apmv3_branch;             j += ',';
+    j += "\"track_mode_inject\":"; j += state.track_mode_inject         ? "true" : "false"; j += ',';
+    j += "\"track_rotation_pct\":";  j += (int)state.track_rotation_pct;   j += ',';
+    j += "\"track_stability_pct\":"; j += (int)state.track_stability_pct;  j += ',';
+    j += "\"track_post_cooling\":"; j += state.track_post_cooling        ? "true" : "false"; j += ',';
+    j += "\"track_cmp_overclock\":"; j += state.track_cmp_overclock       ? "true" : "false"; j += ',';
     j += "\"firmware_14x_warning\":"; j += state.firmware_14x_warning  ? "true" : "false"; j += ',';
 #if defined(BOARD_TTGO_DISPLAY)
     j += "\"display_enabled\":"; j += state.display_enabled             ? "true" : "false"; j += ',';
@@ -2074,6 +2106,68 @@ static void ws_event(uint8_t num, WStype_t type,
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] AP Branch/Tier: %d\n", want);
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"track_mode_inject\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->track_mode_inject = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Track Mode inject: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"track_rotation_pct\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            uint8_t val = (uint8_t)atoi(vptr);
+            if (val > 100) val = 100;
+            FSDState saved;
+            state_enter();
+            g_state->track_rotation_pct = val;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Track Handling Balance: %u\n", val);
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"track_stability_pct\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            uint8_t val = (uint8_t)atoi(vptr);
+            if (val > 100) val = 100;
+            FSDState saved;
+            state_enter();
+            g_state->track_stability_pct = val;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Track Stability Assist: %u\n", val);
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"track_post_cooling\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->track_post_cooling = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Track Post-drive Cooling: %s\n", enabled ? "ON" : "OFF");
+            prefs_save(&saved);
+        }
+    } else if (strstr(buf, "\"track_cmp_overclock\"")) {
+        if (vptr) {
+            while (*vptr == ' ' || *vptr == ':') vptr++;
+            bool enabled = (strncmp(vptr, "true", 4) == 0);
+            FSDState saved;
+            state_enter();
+            g_state->track_cmp_overclock = enabled;
+            saved = *g_state;
+            state_exit();
+            Serial.printf("[Web] Track Compressor Overclock: %s\n", enabled ? "ON" : "OFF");
             prefs_save(&saved);
         }
     } else if (strstr(buf, "\"dump\"")) {

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -24,8 +24,8 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->speed_profile_locked = false;
     state->hw4_offset = 0;
     state->track_mode_inject   = false; // Track Mode inject master opt-in, default OFF
-    state->track_rotation_pct  = 50;    // neutral handling balance
-    state->track_stability_pct = 100;   // full stability = safest default
+    state->track_rotation_pct  = 100;   // full rotation = rear-biased / RWD-like
+    state->track_stability_pct = 30;    // 30% keeps a safety margin but lets it move
     state->track_post_cooling  = false;
     state->track_cmp_overclock = false;
 }

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -23,6 +23,11 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->assist_rhd_override = false; // opt-in RHD driving-side override, default OFF
     state->speed_profile_locked = false;
     state->hw4_offset = 0;
+    state->track_mode_inject   = false; // Track Mode inject master opt-in, default OFF
+    state->track_rotation_pct  = 50;    // neutral handling balance
+    state->track_stability_pct = 100;   // full stability = safest default
+    state->track_post_cooling  = false;
+    state->track_cmp_overclock = false;
 }
 
 void fsd_handle_gtw_car_state(FSDState* state, const CANFRAME* frame) {
@@ -796,18 +801,34 @@ bool fsd_handle_tlssc_restore(FSDState* state, CANFRAME* frame) {
     return true;
 }
 
-// --- Track Mode inject (0x313 / 787) ---
-// Source: ev-open-can-tools HW3Handler frame.id == 787
-// byte[0] bits 1:0 = 0x01 (kTrackModeRequestOn)
-// checksum in byte[7] = computeVehicleChecksum
+// --- Track Mode inject (0x313 / 787 UI_trackModeSettings) ---
+// Adjustable Track Mode via the car's own broadcast: set the request ON and write
+// handling balance / stability assist / cooling, then recompute the additive
+// checksum. We modify the car's existing 0x313 in place so the byte6 counter
+// stays valid — DO NOT touch byte6.
+// Source: joshwardell/model3dbc UI_trackModeSettings (frame 787).
+//   byte0 bits1:0 = UI_trackModeRequest (0 IDLE / 1 ON / 2 OFF)
+//   byte1 = UI_trackRotationTendency, factor 0.5 (raw = pct*2, range 0..200)
+//   byte2 = UI_trackStabilityAssist,  factor 0.5 (raw = pct*2, range 0..200)
+//   byte3 bit0 = UI_trackPostCooling, bit1 = UI_trackCmpOverclock (max cooling)
+//   byte7 = UI_trackModeSettingsChecksum = additive checksum over bytes 0..6
+// Master opt-in only; not gated on trim or the read-back 0x118 state, because the
+// enable request works on non-Performance trims too.
+static uint8_t track_pct_to_raw(uint8_t pct) {
+    if(pct > 100) pct = 100;  // clamp 0..100 (no <algorithm> in C)
+    return (uint8_t)(pct * 2); // factor 0.5 -> raw 0..200
+}
 
 bool fsd_handle_track_mode_inject(FSDState* state, CANFRAME* frame) {
+    if(!state->track_mode_inject) return false;
     if(frame->data_lenght < 8) return false;
-    if(state->op_mode != OpMode_Service) return false;
-    if(state->track_mode_state == 0) return false; // require explicit user toggle
-    // set track mode request ON
-    frame->buffer[0] = (frame->buffer[0] & 0xFC) | 0x01;
-    // recalculate Tesla vehicle checksum
+
+    frame->buffer[0] = (frame->buffer[0] & 0xFC) | 0x01;              // request ON
+    frame->buffer[1] = track_pct_to_raw(state->track_rotation_pct);   // handling balance
+    frame->buffer[2] = track_pct_to_raw(state->track_stability_pct);  // stability assist
+    frame->buffer[3] = (frame->buffer[3] & ~0x03)                     // cooling bits only
+                     | (state->track_post_cooling  ? 0x01 : 0)
+                     | (state->track_cmp_overclock ? 0x02 : 0);
     frame->buffer[7] = tesla_additive_checksum(CAN_ID_TRACK_MODE_SET, frame->buffer, 7);
     return true;
 }

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -68,6 +68,19 @@ typedef struct FSDState {
 
     // --- extras: read-only vehicle state (parsed from bus) ---
     uint8_t track_mode_state;    // 0=unavail 1=avail 2=on (from 0x118)
+
+    // --- Track Mode inject (0x313 UI_trackModeSettings, opt-in adjustable) ---
+    // Modify the car's own 0x313 broadcast: request ON + handling balance,
+    // stability assist and cooling, then recompute the additive checksum. The
+    // byte6 counter is left untouched (we edit the car's frame in place). Master
+    // opt-in only — not gated on trim or the read-back track_mode_state, because
+    // the enable request works on non-Performance trims too.
+    bool track_mode_inject;      // master opt-in, default OFF
+    uint8_t track_rotation_pct;  // Handling Balance 0-100 (low=understeer/stable, high=oversteer/rotation); default 50
+    uint8_t track_stability_pct; // Stability Assist 0-100; default 100 (full stability = safest)
+    bool track_post_cooling;     // UI_trackPostCooling, default false
+    bool track_cmp_overclock;    // UI_trackCmpOverclock (max cooling), default false
+
     uint8_t traction_ctrl_mode;  // 0..7 (from 0x118)
     uint8_t rear_defrost_state;  // 0=sna 1=on 2=off (from 0x343)
     float vehicle_speed_kph;     // from 0x257 DI_vehicleSpeed (12-bit, 0.08 factor, -40 offset)

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -76,8 +76,8 @@ typedef struct FSDState {
     // opt-in only — not gated on trim or the read-back track_mode_state, because
     // the enable request works on non-Performance trims too.
     bool track_mode_inject;      // master opt-in, default OFF
-    uint8_t track_rotation_pct;  // Handling Balance 0-100 (low=understeer/stable, high=oversteer/rotation); default 50
-    uint8_t track_stability_pct; // Stability Assist 0-100; default 100 (full stability = safest)
+    uint8_t track_rotation_pct;  // Handling Balance 0-100 (low=understeer/stable, high=oversteer/rotation); default 100 (rear-biased / RWD-like)
+    uint8_t track_stability_pct; // Stability Assist 0-100; default 30 (safety margin + fun)
     bool track_post_cooling;     // UI_trackPostCooling, default false
     bool track_cmp_overclock;    // UI_trackCmpOverclock (max cooling), default false
 

--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -379,7 +379,8 @@ static int32_t fsd_running_worker(void* context) {
                     }
                 }
 
-                // Track Mode inject (Service mode only, 0x313)
+                // Track Mode inject (0x313) — adjustable balance/stability/cooling,
+                // gated by the master opt-in inside the handler
                 if(frame.canId == CAN_ID_TRACK_MODE_SET) {
                     if(fsd_handle_track_mode_inject(&state, &frame) && tx_allowed) {
                         send_can_frame(mcp, &frame);

--- a/test/test_fsd_core.c
+++ b/test/test_fsd_core.c
@@ -388,8 +388,7 @@ static void test_tlssc_restore(void) {
 static void test_track_mode_crc(void) {
     FSDState s;
     memset(&s, 0, sizeof(s));
-    s.op_mode = OpMode_Service; // gated behind Service mode
-    s.track_mode_state = 2;     // user toggled
+    s.track_mode_inject = true;  // master opt-in
     CANFRAME f;
     zero(&f);
     f.data_lenght = 8;
@@ -406,12 +405,50 @@ static void test_track_mode_crc(void) {
     CHECK(f.buffer[7] == (uint8_t)(sum & 0xFF), "track-mode checksum got 0x%02X exp 0x%02X",
           f.buffer[7], (uint8_t)(sum & 0xFF));
 
-    // Service-mode gate: not in Service -> no-op
-    s.op_mode = OpMode_Active;
+    // Master-toggle gate: inject off -> no-op
+    s.track_mode_inject = false;
     CANFRAME g;
     zero(&g);
     g.data_lenght = 8;
-    CHECK(fsd_handle_track_mode_inject(&s, &g) == false, "track-mode gated outside Service");
+    CHECK(fsd_handle_track_mode_inject(&s, &g) == false, "track-mode gated when inject off");
+}
+
+// ── 0x313 adjustable balance / stability / cooling ────────────────────────────
+static void test_track_mode_adjust(void) {
+    FSDState s;
+    memset(&s, 0, sizeof(s));
+    s.track_mode_inject   = true;
+    s.track_rotation_pct  = 40;    // -> raw 80
+    s.track_stability_pct = 80;    // -> raw 160
+    s.track_post_cooling  = true;  // byte3 bit0 set
+    s.track_cmp_overclock = false; // byte3 bit1 clear
+
+    CANFRAME f;
+    zero(&f);
+    f.data_lenght = 8;
+    f.buffer[3] = 0xF0;  // upper nibble must survive the bit0/bit1 write
+
+    CHECK(fsd_handle_track_mode_inject(&s, &f), "track-adjust reports modified");
+    CHECK((f.buffer[0] & 0x03) == 0x01, "track-adjust request ON");
+    CHECK(f.buffer[1] == 80, "track-adjust rotation raw got %u exp 80", f.buffer[1]);
+    CHECK(f.buffer[2] == 160, "track-adjust stability raw got %u exp 160", f.buffer[2]);
+    CHECK((f.buffer[3] & 0x01) == 0x01, "track-adjust post-cooling bit set");
+    CHECK((f.buffer[3] & 0x02) == 0x00, "track-adjust overclock bit clear");
+    CHECK((f.buffer[3] & 0xF0) == 0xF0, "track-adjust preserves byte3 upper bits");
+    CHECK(f.buffer[7] == tesla_additive_checksum(0x313, f.buffer, 7),
+          "track-adjust checksum got 0x%02X", f.buffer[7]);
+
+    // inject off -> false, frame unchanged
+    FSDState s2;
+    memset(&s2, 0, sizeof(s2));
+    s2.track_mode_inject = false;
+    CANFRAME g;
+    zero(&g);
+    g.data_lenght = 8;
+    g.buffer[0] = 0xAA;
+    g.buffer[1] = 0xBB;
+    CHECK(fsd_handle_track_mode_inject(&s2, &g) == false, "track-adjust off -> no-op");
+    CHECK(g.buffer[0] == 0xAA && g.buffer[1] == 0xBB, "track-adjust off leaves frame unchanged");
 }
 
 // ── 0x249 SCCM_leftStalk builders + CRC ───────────────────────────────────────
@@ -2140,6 +2177,7 @@ int main(void) {
     test_di_speed();
     test_tlssc_restore();
     test_track_mode_crc();
+    test_track_mode_adjust();
     test_sccm_crc();
     test_nag_killer();
     test_nag_killer_faithful();


### PR DESCRIPTION
Turns the dormant Track Mode injection (`0x313 UI_trackModeSettings`) into a real, adjustable, opt-in feature. It previously only set the request ON and gated on the wrong things (Service mode + the read-back `0x118` state); now it exposes the actual Track Mode adjustments and is wired on both platforms.

⚠️ Opt-in, default OFF, **not car-validated.** Vehicle-bus frame.

### Adjustments (written into the car's own 0x313, checksum recomputed, counter preserved)
- **Handling Balance** — `UI_trackRotationTendency` (byte1, 0–100%)
- **Stability Assist** — `UI_trackStabilityAssist` (byte2, 0–100%, default 100 = stock)
- **Post-drive Cooling** — `UI_trackPostCooling` (byte3 bit0)
- **Compressor Overclock** / max cooling — `UI_trackCmpOverclock` (byte3 bit1)
- Track Mode request set ON. The enable works on **non-Performance** trims too, so it's deliberately not gated on trim or the read-back state.

### Changes
- `fsd_state.h`: 5 new fields (master toggle + 2 sliders + 2 cooling flags), safe defaults.
- Flipper `fsd_handle_track_mode_inject` rewritten — gate on the new toggle, byte1/2/3 writes, `tesla_additive_checksum` in byte7, byte6 counter left untouched. Routing was already present in `scenes/fsd_running.c` (matches the 0x331/0x3F8 TX pattern).
- ESP32: mirrored handler + 0x313 routing in `main.cpp` (copy-modify-resend, same as the 0x3F8/RHD path); `CAN_ID_TRACK_MODE_SET` added to config.
- `prefs.cpp` NVS persistence; `web_dashboard.cpp` "Track Mode (experimental)" group (toggle + two 0–100 sliders + two cooling checkboxes) with a not-validated hint.
- `test_fsd_core.c`: `test_track_mode_adjust` (raw ×2 conversion, byte3 RMW preserves upper bits, checksum oracle, off→no-op). **510 host tests pass; ESP32 (esp32-lilygo) builds clean.**

Checksum is the shared, unit-tested `tesla_additive_checksum` — verified this session against real `0x118` captures (142/154 frames), so the byte7 math is sound.

### On-car unknown (reviewer note)
This modifies the car's own 0x313 broadcast in place (which is why the counter stays valid). It relies on the car actually broadcasting `UI_trackModeSettings` on the tapped Vehicle bus — whether it's emitted continuously when Track Mode is *off* is unverified; if it's only sent once engaged, there'd be nothing to modify. Needs on-car validation before it's a reliable enable path.
