### PR TITLE
docs: refresh all docs + translations for the beta.25/26 features

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -283,7 +283,7 @@ And these "Vehicle CAN" signals are also writable on bus 6:
 >
 > A dual-CAN board (e.g. **LILYGO T-2CAN**) gives the full attack surface in
 > one device: Bus 6 for `0x3FD` / `0x370` / `0x3F8` / TLSSC, and Vehicle CAN
-> direct for `0x3C2`. Slated as a v2.16 platformio variant.
+> direct for `0x3C2`. This ships as the `lilygo-t2can` platformio env.
 
 > [!IMPORTANT]
 > **On HW4-modern, `0x370` EPAS3P_sysStatus is the mirror case of `0x3C2`: it is
@@ -401,9 +401,9 @@ Build with `pio run -e esp32-mcp2515`, adjust pin config in
 | **Total** | **~$16-20** |
 
 ATOMIC CAN Base snaps onto the ATOM Lite. Solder X179 CAN-H/CAN-L to
-the screw terminals, 12V to VIN, GND to GND. Build: `pio run -e esp32-twai`.
+the screw terminals, 12V to VIN, GND to GND. Build: `pio run -e m5stack-atom`.
 
-### Setup C — LILYGO T-2CAN dual-CAN (~$33)
+### Setup C — LILYGO T-2CAN dual-CAN (~$27-29)
 
 | Component | Price |
 |-----------|-------|
@@ -411,10 +411,12 @@ the screw terminals, 12V to VIN, GND to GND. Build: `pio run -e esp32-twai`.
 | X179 pigtail cable (4-wire) | ~$3-5 |
 | **Total** | **~$27-29** |
 
-The T-2CAN has **dual isolated MCP2515 controllers**, dual screw
-terminals, 12–24V input, WiFi, BLE, QWIIC, and USB-C. Connect X179
-to CAN1 screw terminal. CAN2 stays free for future use (e.g., OBD-II
-Party CAN for redundancy, or a second X179 bus pair).
+The T-2CAN has **two independent CAN controllers — one native ESP32-S3
+TWAI and one MCP2515 (SPI)** — plus dual screw terminals, 12–24V input,
+WiFi, BLE, QWIIC, and USB-C. The `lilygo-t2can` build drives both (the
+`CAN_DRIVER_T2CAN_DUAL` driver). Connect X179 to one screw terminal; the
+other channel stays free for future use (e.g., OBD-II Party CAN for
+redundancy, or a second X179 bus pair).
 
 This is the recommended board for anyone who wants headroom for
 dual-bus features in a future firmware update.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@
 - **CAN Capture** — record every received frame to the SD card in candump format (`apps_data/tesla_mod/captures/`). Read-only; safe to run on any car. Feeds `tools/tesla_crc_cracker.py`.
 - **Send Test** — load a user-authored `.cantest` text profile from the SD card and replay your own frames. Defaults to dry-run; transmitting is hard-gated to a **parked, stationary** car (fail-closed) and re-checked before every frame. Result is logged for a bug report. Format + workflow: [docs/cantest-format.md](docs/cantest-format.md), example: [examples/example.cantest](examples/example.cantest).
 
+### Extra unlocks (v2.16+, opt-in, default OFF)
+- **Summon EU Unlock** — `0x3FD` mux1: clears bit19 (EU AP restriction) and sets bit47 (summon-enable) to expose Summon on EU-restricted cars
+- **Continue on Green** — `0x3FD` mux0 bit39 `UI_fsdContinueOnGreenWithCIPV` — continue through a green light behind a lead car without a stalk confirmation; pairs with TLSSC
+- **Right-Hand Drive (RHD) override** — `0x3F8` bit41 `UI_drivingSide` = RHD. RHD markets only
+- **AP branch/tier selector** — `0x3FD` mux1 bits 40-42 `UI_apmv3Branch`: Live / Stage / Dev / Stage2 / EAP / Demo. Experimental, non-persistent UI hint — reverts when injection stops
+- **Adjustable Track Mode** — `0x313` `UI_trackModeSettings`: Handling Balance + Stability Assist + post-drive cooling, checksum recomputed. Vehicle bus; defaults to rotation 100 / stability 30%, and works on non-Performance trims too
+
 ### Settings (runtime toggles)
 
 **Stable (car-tested):**
@@ -123,9 +130,9 @@
 | **Lane Graph** | `0x3FD` mux1 bit45 | UI_showLaneGraph — lane visualization on non-FSD tier |
 | **Tier Override** | `0x7FF` mux=2 | Force GTW_autopilot to SELF_DRIVING (more aggressive than GTW Config Replay — actively writes rather than replays) |
 | **Dev Mode** | `0x3F8` bit5 | UI_dasDeveloper flag |
-| **Force LHD** | `0x3F8` bits 40-41 | UI_drivingSide signal override. **Empirically does not change FSD lane-side behavior** (tested on banned RHD HW3 / 2026.2.6 — values 0, 1, 2 all leave FSD on the LHD side; see [#66](https://github.com/hypery11/flipper-tesla-fsd/issues/66)). Likely a UI-only signal. **Slated for removal in v2.15** if no value-3 / DAS_settings counter-evidence surfaces |
+| **Right-Hand Drive (RHD)** | `0x3F8` bit41 | `UI_drivingSide` = RHD (bit41 set, bit40 clear — mutually exclusive with the old LHD probe). RHD markets only. Honest note: the earlier Force-LHD probe was **empirically ineffective** — values 0/1/2 all left FSD on the LHD side on a banned RHD HW3 / 2026.2.6 ([#66](https://github.com/hypery11/flipper-tesla-fsd/issues/66)); RHD now ships as the requested-direction override |
 | **Hands-Off** | `0x3F8` bit14 | UI-level hands-on disable (second nag vector) |
-| **Telemetry Off** | `0x3F8` bit43 | Disable trip telemetry — may itself be a ban signal, use only with SIM pulled |
+| **Telemetry Off** | `0x3F8` bits 19/42/43/44/55 + `0x3FD` mux1 bits 48/50 | Clears the reachable telemetry-enable flags (clip / trip / road-segment on 0x3F8, cabin-camera / China on 0x3FD). Experimental — **reachable flags only, not the Vehicle-bus ECU log-upload, and not a ban guarantee.** Use only with SIM pulled |
 
 **14.x experimental (off by default, please report):**
 
@@ -144,6 +151,7 @@ These target Tesla 2026.14.x / 2026.20 behaviour and are all **off by default**.
 | Setting | Description |
 |---------|-------------|
 | **MCP Crystal** | 16 / 8 / 12 MHz — match your CAN module's crystal frequency. |
+| **Hardware** (ESP32) | Auto-detect / Force HW4 / Force HW3 / Force Legacy. Auto-detect needs `0x398`, which many Model 3/Y never send — pin your car if detection is wrong. NVS-persisted, applied at boot. |
 
 ### HW Support
 
@@ -295,11 +303,12 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 | `0x370` | `EPAS3P_sysStatus` | TX | Nag killer — counter+1 echo with organic torque |
 | `0x399` | `ISA_speedLimit` / `DAS_status` | TX/RX | ESP32 HW-dependent: Legacy/HW3 read DAS status here; HW4 uses ISA speed chime suppression |
 | `0x3FD` | `UI_autopilotControl` | TX | FSD unlock — bit46/60 (HW3/HW4), TLSSC bit38, lane graph bit45 |
-| `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route, hands-off, dev mode, LHD, telemetry (beta) |
+| `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route, hands-off, dev mode, RHD driving-side (bit41), telemetry-off (beta) |
 | `0x3EE` | `UI_autopilotControl` | TX | FSD unlock — Legacy HW1/HW2 |
 | `0x3C2` | `VCLEFT_switchStatus` | TX | ScrollPress AP — right-scroll injection on mux=1 (HW4, Service mode, beta) |
 | `0x7FF` | `GTW_carConfig` | TX | GTW Config Replay + active tier override |
 | `0x082` | `UI_tripPlanning` | TX | Battery preconditioning trigger |
+| `0x313` | `UI_trackModeSettings` | TX | Track Mode — handling balance / stability / cooling (checksum recomputed; Vehicle bus) |
 | `0x398` | `GTW_carConfig` | RX | HW version detection |
 | `0x318` | `GTW_carState` | RX | OTA detection (auto-suspend TX) |
 | `0x399` | `DAS_status` (HW3/Legacy) / `ISA_speedLimit` (HW4) | RX/TX | HW-dispatched: pre-Highland HW3 reads as DAS_status (AP state + hands-on); HW4 keeps the chime-suppression write path |
@@ -309,7 +318,7 @@ Single-bus read-modify-retransmit on Party CAN. No MITM, no second bus tap.
 | `0x312` | `BMS_thermalStatus` | RX | Battery temperature |
 | `0x33A` | `UI_ratedConsumption` | RX | Energy consumption (Wh/km) |
 
-Full list of 37 handlers (14 TX, 23 RX) in [`fsd_logic/fsd_handler.h`](fsd_logic/fsd_handler.h).
+Full list of 42 handlers (18 TX, 24 RX) in [`fsd_logic/fsd_handler.h`](fsd_logic/fsd_handler.h).
 
 ---
 
@@ -353,7 +362,7 @@ For the Flipper: yes, any MCP2515-based module (Electronic Cats, generic boards)
 - [ElectronicCats/flipper-MCP2515-CANBUS](https://github.com/ElectronicCats/flipper-MCP2515-CANBUS) — MCP2515 driver for Flipper
 - Community contributors — the on-car testing, captures, and research this project runs on:
   - **Protocol, nag killer & 2026.14.x work:** @jewelrylin (T-2CAN dual-bus captures, the frame-content preflight test, the X179 Service Mode pinout), @DrStrangeglovebox (the Feifan `0x370` reference capture + HW4 dual-CAN data + safety findings), @ssw0209-sys (the Mode-C steering-torque reference + HW4 14.x testing), @0xAccretion (HW4 Highland China-MIC DAS-layout findings, #116/#117), @dunckencn (China HW3 start-after-AP validation, steer-jerk + bus-off reports), @kristopf007 (HW4 14.x on-car testing)
-  - **Features, captures & PRs:** @JakNo (ScrollPress AP / `0x3C2`), @vrs11 (Continuous AP), @sqladm1n (RTC capture-log PR + bus/wiring investigation), @DmitroPanteliuk (full-rate `0x229` captures), @se7en7777777 (`0x485` / Highland / checksum analysis), @RoyRakete (TLSSC banned-car combo), @mamixsystem (post-SOP10 connector reference)
+  - **Features, captures & PRs:** @JakNo (ScrollPress AP / `0x3C2`), @vrs11 (Continuous AP), @sqladm1n (RTC capture-log PR + bus/wiring investigation), @DmitroPanteliuk (full-rate `0x229` captures), @se7en7777777 (`0x485` / Highland / checksum analysis), @RoyRakete (TLSSC banned-car combo), @mamixsystem (post-SOP10 connector reference), @p0sixturtle (Summon / tier-selector pointers, #139), @dahua910 (RHD request, #66), @HamzaObaidat (theatre-mode `0x118` research, #149), @fboulegue (EU / new-harness Juniper reports, #143/#109/#110), @densen2014 (ESP32 HW-selector suggestion, #110)
   - **Ban research, platform testing, ESP32, bug fixes:** @THER4iN, @MiniCS, @kp43h8, @gauner1986, @dmagyar, @ViPiMP, @marcobellinoroci-source, @danpadure, @bruvv, @Symness, @hkloudou, @nagotti, @patatman, @JordanzhaoD
 - `Starmixcraft/tesla-fsd-can-mod` — original CanFeather FSD research (GitLab repo removed; mirror at [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod))
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > **本翻译可能落后于英文版。** 功能描述、CAN ID 表、硬件接线指南等以 [英文 README](README.md) 为准。如果你发现翻译与英文版不一致，欢迎提交 PR 修正。
 
-# Tesla Mod — Flipper Zero
+# Tesla Mod for Flipper Zero
 
 [![GitHub stars](https://img.shields.io/github/stars/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/network)
@@ -11,16 +11,19 @@
 [![Downloads](https://img.shields.io/github/downloads/hypery11/flipper-tesla-fsd/total?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/releases)
 [![Last commit](https://img.shields.io/github/last-commit/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/commits/main)
 [![Open issues](https://img.shields.io/github/issues/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/issues)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](CONTRIBUTING.md)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square)](LICENSE)
+[![Build](https://img.shields.io/badge/build-ufbt-brightgreen?style=flat-square)](https://github.com/flipperdevices/flipperzero-ufbt)
+[![Flipper target](https://img.shields.io/badge/Flipper%20target-7%20%2F%20API%2087.1-orange?style=flat-square)](https://github.com/flipperdevices/flipperzero-firmware)
+[![Tracked on FSD CAN Mod Hub](https://img.shields.io/badge/tracked%20on-FSD%20CAN%20Mod%20Hub-orange?style=flat-square)](https://fsdcanmod.com/project/hypery11-flipper-zero)
 
-> **Tesla FSD 区域锁绕过 — Flipper Zero 版。** 讓**已經有 FSD 订阅或购买**但所在地区的车机不显示「交通信号灯与停车标志控制」选項的车主，能透過 CAN bus 层面启用 FSD UI 开关。支持 HW3、HW4、Legacy HW1/HW2 Model S/X，FSD v14 可用。另含 Nag 抑制、限速提示音消除、OTA 自动暂停、电池预热触发、BMS 实时仪表板（这些功能**不需要** FSD 訂閱就能使用）。硬件成本：Flipper Zero + Electronic Cats CAN Bus Add-On + OBD-II 線；或做 [ESP32 移植版](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32)，总成本 ~$14 / ¥100。
+> **开源 Tesla CAN bus 工具集，支持 Flipper Zero 与 ESP32。** FSD 区域锁绕过、给 VIN 被封禁车辆的 TLSSC Restore、带拟真扭力变化的 nag killer、GTW Config Replay、BMS 实时仪表板，以及横跨 Model 3、Model Y、Model S、Model X 的 30+ 个 CAN handler。支持 HW3、HW4 与 Legacy HW1/HW2。$200+ 的 S3XY Commander 的免费替代方案 — 搭配 [ESP32 移植版](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32) 总成本最低只要 **$14**。
 
 > [!IMPORTANT]
-> **FSD 相关功能必须有有效的 FSD 套件** — 购买或订阅均可。此工具在 CAN bus 层面启用 FSD 功能，但车辆仍需要来自 Tesla 的合法 FSD 授权。**这不是免费解锁工具。**
->
-> 如果你所在的地区無法訂閱 FSD，上游社群記錄了一個变通方法：在可訂閱 FSD 的地区（如加拿大）创建 Tesla 账号，將車輛轉移到該账号，然后订阅 FSD。详见[上游文档](https://gitlab.com/slxslx/tesla-open-can-mod-slx-repo)。
->
-> Nag 抑制、限速提示音消除、BMS 仪表板、電池預熱等功能**无需 FSD 訂閱**，可独立使用。
+> **FSD 相关功能需要有效的 FSD 套件** — 购买或订阅皆可。此工具在 CAN bus 层面启用 FSD 功能，但车辆仍需要来自 Tesla 的合法 FSD 授权。非 FSD 功能（nag killer、BMS 仪表板、诊断）无需任何订阅即可使用。
+
+> [!CAUTION]
+> **Tesla 已开始实施 VIN 层级封禁**（2026 年 4 月）。受影响的车辆会静默失去 TLSSC 开关 — 没有 OTA、没有警告，且在账号转移与重新订阅后依然存在。**TLSSC Restore** 功能（v2.10+）可通过 0x331 DAS 设置伪造，在被封禁的 Palladium 与 HW4 车上恢复停车标志／交通信号灯控制。完整封禁研究见 [SECURITY.md](SECURITY.md) 与 [issue #18](https://github.com/hypery11/flipper-tesla-fsd/issues/18)。
 
 <p align="center">
   <img src="assets/demo.gif" alt="Tesla FSD 解锁运行中 — 主菜单、HW 检测、BMS 实时仪表板" width="600">
@@ -47,119 +50,98 @@
 
 ## 功能
 
-- 自動检测 HW3/HW4（從 `GTW_carConfig` `0x398` legacy / `0x7FF` Ethernet 讀取），也可手動強制指定 — **注意：** 2020 後 Model 3/Y HW3/HW4 的 `0x398` 在 Ethernet bus 上，CAN bus 可能看不到；遇到检测不到的情況請用 Force HW3 或 Force HW4
-- 通过修改 `UI_autopilotControl`（`0x3FD`）的 bit 來启用 FSD
-- Nag 抑制（消除方向盘握手提醒）
-- 速度档位默认最快，自動從跟车距离拨杆同步
-- Flipper 屏幕实时显示状态
+### 核心 FSD
+- 从 `GTW_carConfig`（`0x398`）自动检测 HW3/HW4；当所接的总线上没有 `0x398` 时，改用 `0x3FD`/`0x399`/`0x3EE` 备用检测
+- **Legacy→HW3 自动升级**（Palladium Model S/X）— 先检测到 `das_hw=0`，之后当 `0x3FD` 出现在总线上时升级
+- 通过修改 `UI_autopilotControl`（`0x3FD` / `0x3EE`）的 bit 来解锁 FSD
+- **Legacy 模式**，支持 HW1/HW2（Model S/X 2016-2019）
+- 速度档位默认最快，并从跟车距离拨杆同步
 
-### 支持硬件
+### TLSSC Restore（v2.10+）
+- 在 **VIN 被封禁** 的车辆上恢复交通信号灯与停车标志控制
+- 对 CAN ID `0x331` 做读取-修改-重发 — 将 `DAS_autopilot` 设为 SELF_DRIVING
+- 已在 Palladium（Model S Plaid 2023）、HW4 Highland（Model 3 Performance 2024）与 Intel HW3（需 AP-first 变通）上确认可用
+- 不会恢复完整 FSD 可视化 — 只恢复 TLSSC（停车标志／交通信号灯）
+- **建议的封禁车组合**：同时启用 **TLSSC Restore** + **TLSSC bit38**（`0x3FD` mux 0 bit 38）— @RoyRakete 在 HW3 / 2026.2.6 上确认可靠（[#18](https://github.com/hypery11/flipper-tesla-fsd/issues/18#issuecomment-4413430516)）。在某些封禁固件上，单独开任一个都不稳定；两者搭配才能重新启用 AP/TACC 接管
 
-| Tesla HW | 修改的 Bits | 速度档位 |
-|----------|------------|----------|
-| HW3 | bit46 | 3 段（0-2） |
-| HW4（FSD V14+） | bit46 + bit60、bit47 | 5 段（0-4） |
+### GTW Config Replay（v2.9+，v2.15 从「Ban Shield」改名）
+- 监看 `GTW_carConfig`（`0x7FF`），当网关发出被修改的 frame 时，实时重播先前学到的健康总线广播
+- 第一次运行时学习全部 8 个 mux frame，之后自动武装
+- **它实际上做什么：** 只在广播层做掩码。武装后，AP ECU 看到的是重播的健康 frame，而不是网关修改过的那个。Tesla 的封禁会写入 GTW NVRAM（重启后仍在）与服务器端标志；本功能不会还原 NVRAM 状态或后端记录，只影响其他总线上的 ECU 实时看到的内容。
+- **它不做什么：** 不能预防封禁、不能解除封禁、也不能改变 Tesla 服务器端的授权记录。在 v2.9-v2.14 部署的 6 周内，没有任何实证确认可预防封禁。诚实说明见 [#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60) 与 [#67](https://github.com/hypery11/flipper-tesla-fsd/issues/67)。v2.14 的名字「Ban Shield」过度承诺了 — v2.15 改名反映代码实际的行为。
 
-HW4 車輛固件版本 **2026.2.3 以前**請使用 HW3 模式。详见[兼容性](#兼容性)。
+### Nag Killer（v2.1+）
+- DAS 感知门控 — 只在 DAS 真的要求手扶方向盘时才回应，DAS 满足时零总线流量
+- 拟真扭力变化 — 在 1.00-2.40 Nm 之间用 xorshift32 PRNG 随机游走，每 5-9 秒有一次到 3.10-3.30 Nm 的握力脉冲
+- **按需握力脉冲（v2.15+）** — 当 `handsOnLevel` 升到提醒需求状态（0 即将 / 3 升级）时，立即发出一次握力脉冲并重置周期排程。补上 v2.14 及更早版本在排程脉冲之间可能出现的 2 秒黄色升级空窗
+- 在 `0x370` 做 EPAS counter+1 回应，并抑制 level 0（提醒即将出现）与 level 3（升级警报）
+- **请接 Party CAN（X179 pin 2/3）给 nag killer。** `0x370` 在 Party CAN — 不在 Vehicle CAN（9/10），而网关转发的 Chassis 副本（13/14）会触发 2026.14.x preflight。已在 HW4 2026.20 上以接 2/3 确认可用（[#100](https://github.com/hypery11/flipper-tesla-fsd/issues/100)）。接错线对的单 CAN 板子没有东西可回应 — 这是「nag killer 在 HW4 上没反应」最常见的原因。用车上的 **Service Mode → CAN Port** 页面确认你这条线束上哪一对是 Party；见 [HARDWARE.md](HARDWARE.md)。
 
----
+### AP-First 模式（v2.14+，给 2026.14.x 固件）
+- Tesla 2026.14.x 新增了 preflight 检查，若 CAN 注入已在进行就挡下 AP/TACC 接管
+- 启用 **AP-First** 后，app 监看 `0x39B` 的 `DAS_autopilotState`，只在 AP 接管后才开始注入 `0x3FD`。在 ESP32 上，DAS 状态来源会依检测到的 HW 版本而定。
+- Nag killer、TLSSC Restore 与 GTW Config Replay 不受影响（它们针对不同的 CAN ID）
 
-## 硬件需求
+### 14.x 固件警告（v2.15+）
+- **默认开启。** 只要启用警告开关，Flipper 运行画面就会把 BMS / flags 那一行换成 `!14.x: TX may stop AP`。ESP32 网页仪表板则在顶端显示可关闭的黄色横幅。
+- 悲观默认：大多数 14.x 固件用户要到自动转向在行驶中脱离时才知道自己受影响。这个警告会在他们启用任何 TX 功能之前先提醒到。
+- 可通过 **On 14.x?** 设置开关（Flipper）或横幅上的 **Dismiss** 按钮（ESP32，存在 NVS）退出。若你确定是 pre-14.x 固件就可关闭。
+- 地区注意：执法强度因市场而异。部分地区（没有 Tesla 直营的市场）似乎执法较不积极。14.x / 2026.20 的实时追踪见 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。
 
-| 组件 | 说明 | 价格 |
-|------|------|------|
-| [Flipper Zero](https://flipper.net/) | 本體 | ~$170 |
-| [Electronic Cats CAN Bus Add-On](https://electroniccats.com/store/flipper-addon-canbus/) | MCP2515 CAN 收發器模組 | ~$30 |
-| OBD-II 線或 T-tap | 接到 Tesla 的 Party CAN bus | ~$10 |
+### 诊断（只读，不需要 FSD）
+- BMS 实时仪表板：电池组电压、电流、SoC、温度范围、**能耗（Wh/km）**
+- 车速、方向盘角度、电机扭力、刹车状态
+- DAS 状态：autopilot 状态、手扶提醒等级、变道状态、盲点警示、FCW、视觉限速
+- GTW autopilot 层级回读（NONE/HIGHWAY/ENHANCED/SELF_DRIVING/BASIC）
+- OTA 检测含防抖 — 固件更新期间自动暂停 TX，除非明确启用 Ignore OTA 覆盖
 
-### 接线
+### CAN Capture + 测试配置文件（v2.16+）
+- **CAN Capture** — 将每个收到的 frame 以 candump 格式录到 SD 卡（`apps_data/tesla_mod/captures/`）。只读；在任何车上运行都安全。可喂给 `tools/tesla_crc_cracker.py`。
+- **Send Test** — 从 SD 卡载入用户自定义的 `.cantest` 文本配置文件并重播你自己的 frame。默认为 dry-run；发送硬性限制在 **停妥、静止** 的车（fail-closed），且每个 frame 前都会重新检查。结果会记录以便回报 bug。格式与流程：[docs/cantest-format.md](docs/cantest-format.md)，示例：[examples/example.cantest](examples/example.cantest)。
 
-<p align="center">
-  <img src="images/wiring_diagram.png" alt="接线圖" width="700">
-</p>
+### 额外解锁（v2.16+，可选，默认关闭）
+- **Summon EU Unlock** — `0x3FD` mux1：清掉 bit19（EU AP 限制）并设 bit47（summon-enable），在受 EU 限制的车上开放召唤（Summon）
+- **Continue on Green** — `0x3FD` mux0 bit39 `UI_fsdContinueOnGreenWithCIPV` — 在有前车的情况下，不用拨杆确认就通过绿灯；搭配 TLSSC 使用
+- **右舵（RHD）覆盖** — `0x3F8` bit41 `UI_drivingSide` = RHD。仅限右舵市场
+- **AP 分支／层级选择器** — `0x3FD` mux1 bits 40-42 `UI_apmv3Branch`：Live / Stage / Dev / Stage2 / EAP / Demo。实验性，非持久化的 UI 提示 — 停止注入后即还原
+- **可调 Track Mode** — `0x313` `UI_trackModeSettings`：操控平衡（Handling Balance）+ 稳定辅助（Stability Assist）+ 收车后冷却，校验和会重算。走 Vehicle 总线；默认为 rotation 100 / stability 30%，非 Performance 车型也可用
 
-> **终端电阻：** Electronic Cats 這塊 Add-On 有兩個版本。v0.1 預設启用 120 Ω 終端，要把板子背面靠近 SN65HVD230 的 `J1 / TERM` solder jumper 切開。v0.2+ 預設已經是斷開状态，不用動。**接車前**先用三用電表量 CAN-H 跟 CAN-L 兩個 pin 之間的電阻：~120 Ω = 好（terminator 關閉），~60 Ω = 要切斷 jumper，無限大 = 也沒問題。完整说明見 [`HARDWARE.md`](HARDWARE.md#termination-resistor--important-detail)。
+### 设置（运行时开关）
 
-替代接点：后座中控台內的 **X179 诊断接头**（20-pin 版 Pin 13/14 = CAN-H/L；26-pin 版 Pin 18/19）。
+**稳定（已上车测试）：**
 
-### 其他支持的硬件
+| 设置 | 说明 |
+|------|------|
+| **Mode** | `Active` / `Listen-Only` / `Service`。Listen-Only 是**首次开机的默认值** — MCP2515 处于硬件 listen-only 模式，物理上无法 TX。 |
+| **Nag Killer** | DAS 感知的 EPAS counter+1 回应，带拟真扭力变化。 |
+| **Force FSD** | 绕过 `isFSDSelectedInUI` 检查。不会绕过 Tesla 服务器端授权 — 只影响本地 CAN frame 流。 |
+| **Ignore OTA** | 即使 `0x318` 报告 Tesla OTA 更新进行中，也允许在 Active 模式下 CAN TX。默认关闭。 |
+| **TLSSC Restore** | 0x331 DAS 设置伪造，在被封禁的车上恢复 TLSSC。会触发 MCU 重启。 |
+| **AP-First (14.x)** | 延后 0x3FD 注入直到 AP 接管。Tesla 固件 2026.14.x 需要此项。 |
+| **GTW Config Replay** | 当网关发出被修改的 frame 时，重播先前学到的健康 `GTW_carConfig`（0x7FF）广播。只在 CAN 广播层做掩码 — 不会还原 NVRAM 或后端封禁标志，也不能预防封禁。v2.15 从「Ban Shield」改名（[#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60)、[#67](https://github.com/hypery11/flipper-tesla-fsd/issues/67)）。 |
+| **Suppress Chime** | 消掉 ISA 限速警告提示音（仅 HW4，`0x399`）。在 ESP32 上只在检测到 HW4 后生效；Legacy/HW3 把 `0x399` 当 DAS 状态用。 |
+| **Emerg. Vehicle** | 启用紧急车辆检测标志（仅 HW4，bit59）。 |
+| **Precondition** | 通过 `0x082` 触发电池预热。 |
 
-不想買 Flipper Zero？PR [#6](https://github.com/hypery11/flipper-tesla-fsd/pull/6) 提供完整 ESP32 移植版，整套硬件成本壓到 **~$14 / ¥100**，內建 WiFi 網頁仪表板。Aliexpress 上 ¥30 的通用 MCP2515 模組也能搭 Flipper Zero 用，自己拉幾條跳線就行。完整对照表见 [`HARDWARE.md`](HARDWARE.md)。
+**Beta（未测试，请回报结果）：**
 
----
+| 设置 | CAN ID | 说明 |
+|------|--------|------|
+| **ScrollPress AP** | `0x3C2` mux=1 | **仅 HW4、仅 Service 模式。** 以基于时间、拟人化的滚轮手势（press ~250ms → scroll-up ~150ms → press ~250ms → scroll-up）在 `swcRightPressed`（bits 12-13）+ `swcRightScrollTicks`（bits 24-29）上接管 AP，于 `DAS_autopilotState` 由 0→1 上升时触发 — 不动 `0x3FD`。已知第一个 2026.14.x 绕过法；由 @JakNo 在 Highland HW4 / 2026.14.2 上发现并台架验证（[#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43)，计时流程 [#82](https://github.com/hypery11/flipper-tesla-fsd/pull/82)）。在 @DmitroPanteliuk 于 Intel HW3 2026.14.6 上报告紧急刹车后，HW3 已于 v2.15 停用 |
+| **Nav FSD Route** | `0x3F8` bits 13/48/49 | 启用基于导航的 FSD routing（EU／受限地区） |
+| **TLSSC bit38** | `0x3FD` mux0 bit38 | 明确启用 TLSSC；与 TLSSC Restore（0x331）搭配为建议的封禁车组合 |
+| **Lane Graph** | `0x3FD` mux1 bit45 | UI_showLaneGraph — 在非 FSD 层级显示车道可视化 |
+| **Tier Override** | `0x7FF` mux=2 | 强制 GTW_autopilot 为 SELF_DRIVING（比 GTW Config Replay 更激进 — 主动写入而非重播） |
+| **Dev Mode** | `0x3F8` bit5 | UI_dasDeveloper 标志 |
+| **右舵（RHD）** | `0x3F8` bit41 | `UI_drivingSide` = RHD（设 bit41、清 bit40 — 与旧的 LHD 探针互斥）。仅限右舵市场。诚实说明：先前的 Force-LHD 探针**实测无效** — 在被封禁的右舵 HW3 / 2026.2.6 上，值 0/1/2 都让 FSD 停在 LHD 侧（[#66](https://github.com/hypery11/flipper-tesla-fsd/issues/66)）；RHD 现在改以「请求的行驶方向」覆盖出货 |
+| **Hands-Off** | `0x3F8` bit14 | UI 层的手扶停用（第二条 nag 向量） |
+| **Telemetry Off** | `0x3F8` bits 19/42/43/44/55 + `0x3FD` mux1 bits 48/50 | 清掉可触及的遥测启用标志（0x3F8 上的 clip / trip / road-segment，0x3FD 上的座舱摄像头 / 中国）。实验性 — **只涵盖可触及的标志，不含 Vehicle 总线 ECU 日志上传，也不保证免于封禁。** 仅在拔掉 SIM 卡时使用 |
 
-## 安装
+**14.x 实验性（默认关闭，请回报）：**
 
-### 方法一：下载编译好的 FAP
+这些针对 Tesla 2026.14.x / 2026.20 行为，**全部默认关闭**。它们是探针，不是已确认的通用修法 — 实时状态见 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。在 ESP32 网页仪表板切换（部分也在 Flipper 设置中）。
 
-1. 到 [Releases](https://github.com/hypery11/flipper-tesla-fsd/releases) 页面
-2. 下载 `tesla_fsd.fap`
-3. 复制到 Flipper 的 SD 卡：`SD Card/apps/GPIO/tesla_fsd.fap`
-
-### 方法二：自行编译
-
-```bash
-# Clone Flipper Zero 固件
-git clone --recursive https://github.com/flipperdevices/flipperzero-firmware.git
-cd flipperzero-firmware
-
-# Clone 本 app 到 applications_user
-git clone https://github.com/hypery11/flipper-tesla-fsd.git applications_user/tesla_fsd
-
-# 编译
-./fbt fap_tesla_fsd
-
-# 烧录到 Flipper
-./fbt launch app=tesla_fsd
-```
-
----
-
-## 使用方式
-
-1. 把 CAN Add-On 插上 Flipper Zero
-2. 用 CAN-H/CAN-L 接到車上 OBD-II 口
-3. 打开 app：`Apps > GPIO > Tesla FSD`
-4. 选 **「Auto Detect & Start」**（或手動选 HW3/HW4）
-5. 等待检测（最多 8 秒）
-6. App 自動開始修改 CAN frame
-
-### 螢幕顯示
-
-```
-  Tesla FSD Active
-  HW: HW4    Profile: 4/4
-  FSD: ON    Nag: OFF
-  Frames modified: 12345
-       [BACK] to stop
-```
-
-### 啟動触发条件
-
-車上 Autopilot 设置中的 **「交通信号灯与停车标志控制」** 打开時，app 才會開始修改 frame。這個标志是 CAN frame 裡的判断依据。
-
----
-
-## 兼容性
-
-| 车型 | HW | 固件 | 模式 | 状态 |
-|------|----|------|------|------|
-| Model 3 / Y（2019-2023） | HW3 | 任何 | Auto | 支持 |
-| Model 3 / Y（2023+） | HW4 | `< 2026.2.3` | Force HW3 | 支持 |
-| Model 3 / Y（2023+） | HW4 | `2026.2.3` ↔ `2026.2.8` | Auto | 支持 |
-| Model 3 / Y（2023+） | HW4 | `2026.2.9.x`（FSD v14） | Auto | 支持 |
-| Model 3 / Y（2023+） | HW4 | `2026.2.10` ↔ `2026.4.x` | Auto | 支持 |
-| Model 3 / Y（2023+） | HW4 | `2026.8.6` | **Force HW3** | HW4 path 在這個版本壞掉，要強制 HW3 |
-| Model 3 Highland（2024+） | HW4 | `2026.2.x` | Auto | 已有运行报告 — 需更多确认 |
-| Model 3 / Y（中規 MIC） | HW3 / HW4 | `2026.2.11` | Auto + Force FSD | 已有运行报告 — 見 issue #1, #4, #7 |
-| Model S / X（2021+） | HW4 | `>= 2026.2.3`（除 2026.8.6） | Auto | 支持 |
-| Model S / X（2016-2019） | HW1 / HW2 | 任何 | Legacy | v2.0 已實作，**待上車驗證** |
-
-### 14.x 实验性开关（默认全部关闭）
-
-针对 Tesla 2026.14.x / 2026.20 行为，**默认全部关闭**。这些是探针，不是已确认的通用修法 — 实时状态见 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。在 ESP32 网页仪表板切换（部分也在 Flipper 设置中）。
-
-| 开关 | 说明 |
+| 设置 | 说明 |
 |------|------|
 | **Abort Guard**（ESP32） | Steer-jerk 缓解（[#108](https://github.com/hypery11/flipper-tesla-fsd/issues/108)）。启动瞬间的方向盘抽动其实是车自己**中止**接管（`DAS_autopilotState` → `8 ABORTING` → `9 ABORTED`）。开启后一检测到 abort 状态就立刻切掉所有 activation 注入，并维持到干净脱离。**已上车验证：** 在宽／直路上消除了抽动（数百次循环 0 次，原本约 1/25–30）。局限：部分窄路会直接跳到 `FAULT (9)`、没有前导信号，挡不住。 |
 | **Soft Engage** | Steer-jerk 缓解（[#108](https://github.com/hypery11/flipper-tesla-fsd/issues/108)）。把启动边缘的注入压住，直到方向盘回到中心 ±5° 内。需要总线上有 `0x129`（方向盘角度）；没有就退化成只有 AP-First。直路抽动已大致被 Abort Guard 取代。 |
@@ -167,97 +149,235 @@ git clone https://github.com/hypery11/flipper-tesla-fsd.git applications_user/te
 | **EPAS-faithful（Mode-C）** | 模拟真实 EPAS 的 demand-state 扭力模型，不去翻 `handsOnLevel`（[#100](https://github.com/hypery11/flipper-tesla-fsd/issues/100)）。用于标准 nag 抑制会触发 preflight 的车。**尚未上车确认。** |
 | **Signal Map**（ESP32 → 高级） | 自定义 nag 抑制读取 AP-state／hands-on／方向盘的位置：`id + byte/shift/mask`（[#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)）。用于 `0x39B`/`0x399` 布局不同的车型变体。有新鲜度门控 — 设错会 fail-closed。DAS id 留 `0` 为自动检测。 |
 
-### 社群测试报告
+**硬件：**
 
-實車报告（用 [Car compatibility report](https://github.com/hypery11/flipper-tesla-fsd/issues/new?template=car_compatibility.yml) issue template 自己报告）：
+| 设置 | 说明 |
+|------|------|
+| **MCP Crystal** | 16 / 8 / 12 MHz — 对应你 CAN 模块的晶振频率。 |
+| **Hardware**（ESP32） | Auto-detect / Force HW4 / Force HW3 / Force Legacy。Auto-detect 需要 `0x398`，但许多 Model 3/Y 从不发送它 — 检测错误时可自己指定车型。存于 NVS，开机时应用。 |
 
-| 报告者 | 車 | HW | 固件 | 地区 | 模式 | 结果 |
-|--------|----|----|------|------|------|------|
-| @vbarrier | Model 3 | HW4 | 2026.4.x | 欧洲 | Auto | 运行 |
-| @kwangseok73-sudo | Model 3 | HW4 | 2026.2.x | 韩国 | Force FSD | 运行 |
-| @andreiboestean | Model 3 | HW4 | 2026.2.9.3（FSD v14） | 欧洲 | Auto | 运行 |
-| Marow | Model Y Juniper | HW4 | 2026.8.6 | 欧洲 | (Force HW3 尚未测试) | 顯示「Region not available」→ 用 Force FSD + Force HW3 |
+### HW 支持
 
-### HW1/HW2 Legacy 支持 — 徵求志願者
+| Tesla HW | 修改的 Bits | 速度档位 |
+|----------|------------|----------|
+| Legacy（HW1/HW2） | bit46 | 3 段（0-2） |
+| HW3 | bit46 | 3 段（0-2） |
+| HW4（FSD V14+） | bit46 + bit60、bit47 | 5 段（0-4） |
 
-舊款 Model S/X（2016-2019）使用 Mobileye 架構，CAN ID 完全不同。Autopilot 控制 frame 在 `0x3EE`（1006）而非 `0x3FD`（1021），bit 排列也不一樣。
+---
 
-邏輯記錄在 [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod) 這個 CanFeather 鏡像（原始 `Starmixcraft/tesla-fsd-can-mod` GitLab 上游已被下架）。但我們需要有 HW1/HW2 車的人幫忙驗證才能上線。
+## 硬件
 
-**如果你有 2016-2019 Model S/X 且有 FSD，想幫忙的話：**
+### Flipper Zero
 
-1. Flipper + CAN Add-On 接上 OBD-II
-2. 打开內建的 CAN sniffer app
-3. 确认 CAN ID `0x3EE`（1006）有出現在 bus 上
-4. 擷取幾個 frame，貼到 [issue #1](https://github.com/hypery11/flipper-tesla-fsd/issues/1)
+| 组件 | 说明 | 价格 |
+|------|------|------|
+| [Flipper Zero](https://flipper.net/) | 多功能工具本体 | ~$170 |
+| [Electronic Cats CAN Bus Add-On](https://electroniccats.com/store/flipper-addon-canbus/) | MCP2515 CAN 收发器（支持 v1.2） | ~$30 |
+| OBD-II 线或 X179 pigtail | 接到 Tesla 的 CAN bus | ~$5-10 |
 
-驗證通過後，Legacy 支持很快就能加上。
+### ESP32（$14 起）
+
+功能完整的 ESP32 移植版，内建 WiFi 网页仪表板、NVS 设置保存、深度睡眠与出厂重置。与 Flipper app 相同的 CAN 逻辑。
+
+ESP32 固件会依检测到的硬件版本对应 AP/DAS 状态来源：
+
+| 检测到的 HW | `0x399` | `0x39B` | ISA 限速提示音 |
+|-------------|---------|---------|----------------|
+| Legacy HW1/HW2 | `DAS_status` | 不使用 | 停用 |
+| HW3 | `DAS_status` | 不使用 | 停用 |
+| HW4 | `ISA_SPEED` | `DAS_status` | 启用 |
+
+| 板子 | 成本 | 编译目标 |
+|------|------|----------|
+| M5Stack ATOM Lite + ATOMIC CAN | ~$14 | `m5stack-atom` |
+| Lilygo T-CAN485 | ~$15 | `esp32-lilygo` |
+| Waveshare ESP32-S3-RS485-CAN | ~$18 | `waveshare-s3-can` |
+| 通用 ESP32 + MCP2515 | ~$6 | `esp32-mcp2515` |
+
+设置见 [`esp32/README.md`](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32)，完整对照＋接线图＋X179 引脚见 [`HARDWARE.md`](HARDWARE.md)。
+
+### 接点
+
+- **OBD-II**（方向盘柱下方）— Party CAN。部分 Model 3/Y 车款在 Drive 挡可能静默。
+- **X179**（副驾驶座脚踢板后方）— 建议使用。Pin 13/14 = Bus 6（混合转发，在所有模式下都保持活动）。20-pin 与 26-pin 引脚见 [`HARDWARE.md`](HARDWARE.md)。
+
+<p align="center">
+  <img src="images/wiring_diagram.png" alt="接线图" width="700">
+</p>
+
+---
+
+## 安装
+
+### 快速开始（不需要编译工具）
+
+第一次接触、不太懂技术？选你的硬件 — 两条路径都不用命令行：
+
+**Flipper Zero**
+1. 打开 [Releases](https://github.com/hypery11/flipper-tesla-fsd/releases)，从最新版本下载 `tesla_mod.fap`。
+2. 接上 Flipper，打开 [qFlipper](https://flipperzero.one/update)（官方桌面 app）。
+3. 把 `tesla_mod.fap` 复制到 SD 卡的 `apps/GPIO/`。
+4. 在 Flipper 上：**Apps → GPIO → Tesla Mod**。
+
+**ESP32** — 直接从浏览器烧录，什么都不用装：
+1. 取得烧录器：打开在线的 **[Web Flasher](https://hypery11.github.io/flipper-tesla-fsd/install/)**，或从最新[版本](https://github.com/hypery11/flipper-tesla-fsd/releases)下载 `tesla-flasher.html` 打开 — 两者都能在桌面版的 **Chrome、Edge 或 Opera** 上运行。
+2. 用 USB 接上板子，在你的板子旁按 **Install**，选择串口。
+3. 完成后，连上板子的 Wi-Fi 网络并打开 `http://192.168.4.1` 来控制它。
+
+板子开机时处于 **Listen-Only 模式**（无法发送），直到你在仪表板启用 Active。接到车上的接线依你的 Tesla 车型／年份而定 — 见 [HARDWARE.md](HARDWARE.md) 或开 issue 询问。
+
+### 方法一：下载编译好的 FAP
+
+1. 到 [Releases](https://github.com/hypery11/flipper-tesla-fsd/releases) 页面
+2. 下载 `tesla_mod.fap`
+3. 复制到 Flipper 的 SD 卡：`SD Card/apps/GPIO/tesla_mod.fap`
+
+### 方法二：自行编译
+
+```bash
+git clone https://github.com/hypery11/flipper-tesla-fsd.git
+cd flipper-tesla-fsd
+ufbt
+# 输出：dist/tesla_mod.fap
+```
+
+### ESP32
+
+> 不想自己编译？从 **[Web Flasher](https://hypery11.github.io/flipper-tesla-fsd/install/)** 烧录预先编译好的镜像 — 一键完成，不需要工具链。
+
+```bash
+git clone https://github.com/hypery11/flipper-tesla-fsd.git
+cd flipper-tesla-fsd/esp32
+pio run -e m5stack-atom    # 或：esp32-lilygo、waveshare-s3-can、esp32-mcp2515
+```
+
+---
+
+## 使用方式
+
+1. 把 CAN Add-On 插上 Flipper Zero（或烧录 ESP32）
+2. 用 CAN-H/CAN-L 通过 OBD-II 或 X179 pin 13/14 接到车辆
+3. 打开 app：`Apps > GPIO > Tesla Mod`
+4. 选 **「Auto Detect & Start」**（或手动 Force HW3/HW4）
+5. 等待检测（最多 8 秒）— Palladium S/X 会自动从 Legacy 升级到 HW3
+6. 当车上启用 TLSSC 开关时，app 就会自动开始修改 frame
+
+---
+
+## 兼容性
+
+### 已确认可用（社区测试）
+
+| 车型 | HW | 固件 | 测试者 | 功能 |
+|------|----|------|--------|------|
+| Model S Plaid 2023（Palladium） | HW3/MCU3 | 2026.2.9.3 | @MiniCS、@nagotti | TLSSC Restore、FSD |
+| Model 3 Highland Perf 2024 | HW4 | 2026.8.6 | @kp43h8 | TLSSC Restore，断线后仍保留 |
+| Model 3 2019-2023 | HW3 | 多种 | @THER4iN 等多人 | FSD、nag killer |
+| Model X Raven 2017（HW3 retrofit） | HW3/MCU2 | 2026.8.3 | @dmagyar | Nag killer、EAP |
+| Model Y 2023（中规 MIC） | HW3 | 2026.2.11 | 社区 | FSD（Force FSD 模式） |
+| Model 3/Y 2023+ | HW4 | < 2026.2.9 | @vbarrier、@kwangseok73-sudo | FSD |
+
+### 已知限制
+
+| 固件 | 问题 | 变通方法 |
+|------|------|----------|
+| 2026.8.6+ | 区域锁 — FSD 神经网络在部分地区拒绝运行 | 拔 SIM 卡，用 Force FSD |
+| 2026.8.6 HW4 | HW4 注入路径在这个特定版本坏掉 | 用 Force HW3 模式 |
+| Intel HW3（被封禁） | 通过 0x331 恢复了 TLSSC 开关，但启用它会让 AP 失效 | 先接管 AP，再通过 0x3FD 注入 TLSSC |
+
+用 [Car compatibility report](https://github.com/hypery11/flipper-tesla-fsd/issues/new?template=car_compatibility.yml) 模板回报你自己的测试结果。
 
 ---
 
 ## 运行原理
 
-在 Party CAN（Bus 0）上做單 bus 的讀取-修改-重發。不需要 MITM，不用接第二條 bus。
+在 Party CAN 上做单总线的读取-修改-重发。不需要 MITM，不用接第二条总线。
 
-1. ECU 在 Bus 0 上發出 `UI_autopilotControl`（`0x3FD`）
-2. Flipper 收到，改掉 FSD 启用 bit
-3. Flipper 重發修改版 — 接收端採用最新的 frame
+1. 网关／ECU 在 CAN bus 上发出一个 frame
+2. Flipper/ESP32 收到，修改目标 bit
+3. 重发 — 接收端采用最新的 frame
 
-### 使用的 CAN ID
+### CAN ID
 
-| CAN ID | 名稱 | 用途 |
-|--------|------|------|
-| `0x398` | `GTW_carConfig` | HW 检测（`GTW_dasHw` byte0 bit6-7） |
-| `0x3F8` | Follow Distance | 速度档位來源（byte5 bit5-7） |
-| `0x3FD` | `UI_autopilotControl` | FSD 解鎖目標（mux 0/1/2） |
+| CAN ID | 名称 | 方向 | 用途 |
+|--------|------|------|------|
+| `0x331` | `DAS_autopilotConfig` | TX | TLSSC Restore — 将层级设为 SELF_DRIVING |
+| `0x370` | `EPAS3P_sysStatus` | TX | Nag killer — counter+1 回应带拟真扭力 |
+| `0x399` | `ISA_speedLimit` / `DAS_status` | TX/RX | ESP32 依 HW 而定：Legacy/HW3 在此读 DAS 状态；HW4 用于 ISA 限速提示音抑制 |
+| `0x3FD` | `UI_autopilotControl` | TX | FSD 解锁 — bit46/60（HW3/HW4）、TLSSC bit38、lane graph bit45 |
+| `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route、hands-off、dev mode、RHD 行驶方向（bit41）、telemetry-off（beta） |
+| `0x3EE` | `UI_autopilotControl` | TX | FSD 解锁 — Legacy HW1/HW2 |
+| `0x3C2` | `VCLEFT_switchStatus` | TX | ScrollPress AP — 于 mux=1 注入右滚轮（HW4、Service 模式、beta） |
+| `0x7FF` | `GTW_carConfig` | TX | GTW Config Replay + 主动层级覆盖 |
+| `0x082` | `UI_tripPlanning` | TX | 电池预热触发 |
+| `0x313` | `UI_trackModeSettings` | TX | Track Mode — 操控平衡／稳定／冷却（校验和重算；Vehicle 总线） |
+| `0x398` | `GTW_carConfig` | RX | HW 版本检测 |
+| `0x318` | `GTW_carState` | RX | OTA 检测（自动暂停 TX） |
+| `0x399` | `DAS_status`（HW3/Legacy）/ `ISA_speedLimit`（HW4） | RX/TX | 依 HW 分派：pre-Highland HW3 读为 DAS_status（AP 状态＋手扶）；HW4 保留提示音抑制写入路径 |
+| `0x39B` | `DAS_status` | RX | HW4 + Highland HW3 — AP 状态（给 AP-First）、nag 等级、变道、盲点 |
+| `0x132` | `BMS_hvBusStatus` | RX | 电池组电压／电流 |
+| `0x292` | `BMS_socStatus` | RX | 充电状态 |
+| `0x312` | `BMS_thermalStatus` | RX | 电池温度 |
+| `0x33A` | `UI_ratedConsumption` | RX | 能耗（Wh/km） |
+
+完整 42 个 handler 清单（18 TX、24 RX）见 [`fsd_logic/fsd_handler.h`](fsd_logic/fsd_handler.h)。
 
 ---
 
-## 常見問題
+## 常见问题
 
-**拔掉之後 FSD 還會維持嗎？**
-不會。這是即時 frame 修改，拔掉就恢復原樣。
+**拔掉之后 FSD 还会维持吗？**
+不会。这是实时 frame 修改，拔掉就恢复原样。
 
-**會不會把車搞壞？**
-只動 UI 設定 frame，不碰煞車、轉向、動力系統。但風險自負。
+**没有 FSD 订阅能用吗？**
+FSD 功能（TLSSC、交通信号灯／停车标志控制）需要来自 Tesla 的 FSD 授权。没有它，AP ECU 就没有载入神经网络权重。非 FSD 功能（nag killer、BMS 仪表板、限速提示音抑制、诊断）在任何支持 AP 的车上都能用。
 
-**一定要 CAN Add-On 嗎？**
-對。Flipper 沒有內建 CAN bus，你需要 Electronic Cats 的板子或任何 MCP2515 模組接在 GPIO 上。
+**VIN 层级封禁怎么办？**
+Tesla 自 2026 年 4 月起在服务器端封禁 VIN。封禁会把 `GTW_autopilot` 层级从 SELF_DRIVING 降到 ENHANCED，并移除 TLSSC 开关。**TLSSC Restore** 功能（0x331）可在 Palladium 与 HW4 上恢复停车标志／交通信号灯控制。完整研究见 [issue #18](https://github.com/hypery11/flipper-tesla-fsd/issues/18)。**GTW Config Replay**（0x7FF，前称「Ban Shield」）可实时重播先前学到的健康设置，但只在 CAN 广播层 — 不会还原底层的 NVRAM 或服务器端状态。
+
+**Flipper Zero vs ESP32 — 该买哪个？**
+ESP32 更便宜（$14 vs $200+），有 WiFi 仪表板、NVS 保存与深度睡眠。Flipper 更便携，且有内建屏幕。两者跑相同的 CAN 逻辑。如果你还没有 Flipper，选 ESP32。
+
+**支持 Model S / Model X 吗？**
+支持。Palladium S/X（2021+）已确认可用 TLSSC Restore。2021 前、做了 HW3 retrofit 的 S/X 通过 Legacy→HW3 自动升级可用。HW1/HW2 Model S/X 走 Legacy 模式（`0x3EE`）。Model S/X 使用不同的 BMS CAN ID — BMS 仪表板可能显示错误数值。
+
+**这会不会把车搞坏（brick）？**
+只动 UI 设置 frame。不会写入刹车、转向或动力系统。App 默认以 Listen-Only 模式开机。完整 TX 面清单见 [SECURITY.md](SECURITY.md)。
+
+**一定要 Flipper CAN Add-On 吗？**
+给 Flipper：是的，任何 MCP2515 模块（Electronic Cats、通用板子）都行。给 ESP32：多数支持的板子有内建 CAN 收发器（M5Stack ATOMIC CAN、Lilygo T-CAN485、Waveshare S3）。
 
 ---
 
 ## 相关项目
 
-| 專案 | 是什麼 | 硬件 |
+| 项目 | 是什么 | 硬件 |
 |------|--------|------|
-| [slxslx/tesla-open-can-mod-slx-repo](https://gitlab.com/slxslx/tesla-open-can-mod-slx-repo) | 原始 Tesla-OPEN-CAN-MOD namespace 改名搬到 ev-open-can-tools（GitLab 仍在、開發移往 GitHub）後的社群 fork。範圍更廣 — 「general CAN mod tool, not just FSD」 | Adafruit RP2040 CAN、Feather M4、ESP32、M5Stack ATOMIC CAN |
-| ESP32 移植 — PR [#6](https://github.com/hypery11/flipper-tesla-fsd/pull/6) by @elonleo | 把本專案 CAN 邏輯完整移植到 ESP32，內建 WiFi 網頁仪表板。~$14 的 Flipper + Add-On 替代方案 | M5Stack ATOM Lite + ATOMIC CAN、Waveshare ESP32-S3-RS485-CAN |
-| [tumik/S3XY-candump](https://github.com/tumik/S3XY-candump) | 用 enhauto S3XY Commander 當 Panda-protocol bridge 透過 WiFi dump 整條 Tesla CAN bus 的 Python 工具 | Commander dongle |
-| [dzid26/ESP32-DualCAN](https://github.com/dzid26/ESP32-DualCAN) | 「Dorky Commander」— 開源硬件版的 enhauto S3XY Commander | ESP32 + dual CAN |
-| [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod) | 原始 `Starmixcraft/tesla-fsd-can-mod` CanFeather 研究的镜像 — 我們移植的源头。原始 GitLab 上游已被下架，這是目前还能看的版本。 | Adafruit Feather M4 CAN |
-| [tuncasoftbildik/tesla-can-mod](https://github.com/tuncasoftbildik/tesla-can-mod) | Arduino 參考實作，含多個非 FSD 功能的 frame template | Arduino + MCP2515 |
+| [ev-open-can-tools](https://github.com/ev-open-can-tools/ev-open-can-tools) | 上游社区项目。开发活动在 GitHub 上（v3.0.x，GPL-3.0）。前身是 GitLab 上的 `Tesla-OPEN-CAN-MOD`；该组已改名为 `ev-open-can-tools`，GitLab repo 现已停摆（0 个开启中的 issue/MR，最后一次 commit 2026-04-25）— 请追踪 GitHub repo。 | RP2040 CAN、Feather M4、ESP32 |
+| [dzid26/ESP32-DualCAN](https://github.com/dzid26/ESP32-DualCAN) | 「Dorky Commander」— S3XY Commander 的开源硬件替代品 | ESP32 + dual CAN |
+| [tuncasoftbildik/tesla-can-mod](https://github.com/tuncasoftbildik/tesla-can-mod) | Arduino 参考实现，附 frame template | Arduino + MCP2515 |
+| [tumik/S3XY-candump](https://github.com/tumik/S3XY-candump) | 通过 S3XY Commander（Panda 协议）的 Python CAN dump 工具 | Commander dongle |
 
 ## 致谢
 
 - [commaai/opendbc](https://github.com/commaai/opendbc) — Tesla CAN 信号数据库
 - [ElectronicCats/flipper-MCP2515-CANBUS](https://github.com/ElectronicCats/flipper-MCP2515-CANBUS) — Flipper 用 MCP2515 驱动
 - 社区贡献者 — 本项目赖以运作的实车测试、抓包与研究：
-  - **协议、nag killer 与 2026.14.x：** @jewelrylin（T-2CAN 双总线抓包、frame-content preflight 测试、X179 Service Mode 针脚图）、@DrStrangeglovebox（非凡 `0x370` 参考抓包 + HW4 双 CAN 数据 + 安全发现）、@ssw0209-sys（Mode-C 转向扭力参考 + HW4 14.x 测试）、@0xAccretion（HW4 Highland 国产车 DAS 布局发现，#116/#117）、@dunckencn（国行 HW3 start-after-AP 验证、steer-jerk 与 bus-off 报告）、@kristopf007（HW4 14.x 实车测试）
-  - **功能、抓包与 PR：** @JakNo（ScrollPress AP / `0x3C2`）、@vrs11（Continuous AP）、@sqladm1n（RTC 抓包日志 PR + 总线/接线排查）、@DmitroPanteliuk（全速率 `0x229` 抓包）、@se7en7777777（`0x485` / Highland / 校验和分析）、@RoyRakete（TLSSC 封禁车组合）、@mamixsystem（post-SOP10 连接器参考）
+  - **协议、nag killer 与 2026.14.x：** @jewelrylin（T-2CAN 双总线抓包、frame-content preflight 测试、X179 Service Mode 针脚图）、@DrStrangeglovebox（`0x370` 参考抓包 + HW4 双 CAN 数据 + 安全发现）、@ssw0209-sys（Mode-C 转向扭力参考 + HW4 14.x 测试）、@0xAccretion（HW4 Highland 中规 MIC DAS 布局发现，#116/#117）、@dunckencn（国行 HW3 start-after-AP 验证、steer-jerk 与 bus-off 报告）、@kristopf007（HW4 14.x 实车测试）
+  - **功能、抓包与 PR：** @JakNo（ScrollPress AP / `0x3C2`）、@vrs11（Continuous AP）、@sqladm1n（RTC 抓包日志 PR + 总线/接线排查）、@DmitroPanteliuk（全速率 `0x229` 抓包）、@se7en7777777（`0x485` / Highland / 校验和分析）、@RoyRakete（TLSSC 封禁车组合）、@mamixsystem（post-SOP10 连接器参考）、@p0sixturtle（Summon / tier-selector 线索，#139）、@dahua910（RHD 需求，#66）、@HamzaObaidat（剧院模式 `0x118` 研究，#149）、@fboulegue（EU / 新线束 Juniper 报告，#143/#109/#110）、@densen2014（ESP32 HW 选择器建议，#110）
   - **封禁研究、平台测试、ESP32、bug 修复：** @THER4iN、@MiniCS、@kp43h8、@gauner1986、@dmagyar、@ViPiMP、@marcobellinoroci-source、@danpadure、@bruvv、@Symness、@hkloudou、@nagotti、@patatman、@JordanzhaoD
-- `Starmixcraft/tesla-fsd-can-mod` — 原始 CanFeather FSD 研究（GitLab 上已被下架，鏡像在 [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod)）
-- mikegapinski/tesla-can-explorer — 從 Tesla 主機 `libQtCarVAPI.so` 萃取的 4 萬個 Tesla CAN 訊號字典
-- talas9/tesla_can_signals — 各车型 wire format 對照
+- `Starmixcraft/tesla-fsd-can-mod` — 原始 CanFeather FSD 研究（GitLab repo 已被移除；镜像在 [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod)）
 
-## 支持这个项目
+## 支持这个研究
 
-如果这个项目帮你省下了改装盒子的钱、让你看懂 Tesla 的 CAN bus，或在封锁后保住了你的 TLSSC，欢迎赞助持续的研究与测试。
+如果这个项目帮你省下了改装盒子的钱、让你看懂 Tesla 的 CAN bus，或在封禁后保住了你的 TLSSC，欢迎赞助持续的研究与测试。
 
 [![Crypto](https://img.shields.io/badge/Crypto-Donate-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white)](https://fsd.fkey.id/) [![PayPal](https://img.shields.io/badge/PayPal-Donate-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=hypery11@gmail.com&item_name=Tesla+FSD+Open+Source+Research&currency_code=USD) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-hypery11-EA4AAA?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/hypery11)
 
 加密货币请至 **[fsd.fkey.id](https://fsd.fkey.id/)** — 同一个地址、支持多链。实际可用的网络请直接打开页面查看。
 
-款项用于测试用的 Tesla 零件（待救援的封锁 VIN、不同 MCU/硬件组合）、各种 ESP32 硬件，以及逆向新固件版本所花的时间。
+款项用于测试用的 Tesla 零件（待救援的封禁 VIN、不同 MCU/HW 组合）、各种 ESP32 硬件，以及逆向新固件版本所花的时间。
 
 ## 授权
 
@@ -265,4 +385,4 @@ GPL-3.0
 
 ## 免责声明
 
-仅供教育与研究用途。**FSD 是 Tesla 的付费功能，必须合法购买或订阅使用。** 改装车辆系统可能导致保修失效，也可能违反当地法规。使用者需自行承担所有责任与风险。完整安全與責任使用说明見 [`SECURITY.md`](SECURITY.md)。
+仅供教育与研究用途。**FSD 是 Tesla 的付费功能，必须合法购买或订阅使用。** 改装车辆系统可能导致保修失效，也可能违反当地法规。使用者需自行承担所有责任与风险。完整安全与责任使用说明见 [`SECURITY.md`](SECURITY.md)。

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > **本翻譯可能落後於英文版。** 功能描述、CAN ID 表、硬體接線指南等以 [英文 README](README.md) 為準。如果你發現翻譯與英文版不一致，歡迎提交 PR 修正。
 
-# Tesla Mod — Flipper Zero
+# Tesla Mod for Flipper Zero
 
 [![GitHub stars](https://img.shields.io/github/stars/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/network)
@@ -11,16 +11,19 @@
 [![Downloads](https://img.shields.io/github/downloads/hypery11/flipper-tesla-fsd/total?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/releases)
 [![Last commit](https://img.shields.io/github/last-commit/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/commits/main)
 [![Open issues](https://img.shields.io/github/issues/hypery11/flipper-tesla-fsd?style=flat-square&logo=github)](https://github.com/hypery11/flipper-tesla-fsd/issues)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](CONTRIBUTING.md)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square)](LICENSE)
+[![Build](https://img.shields.io/badge/build-ufbt-brightgreen?style=flat-square)](https://github.com/flipperdevices/flipperzero-ufbt)
+[![Flipper target](https://img.shields.io/badge/Flipper%20target-7%20%2F%20API%2087.1-orange?style=flat-square)](https://github.com/flipperdevices/flipperzero-firmware)
+[![Tracked on FSD CAN Mod Hub](https://img.shields.io/badge/tracked%20on-FSD%20CAN%20Mod%20Hub-orange?style=flat-square)](https://fsdcanmod.com/project/hypery11-flipper-zero)
 
-> **Tesla FSD 區域鎖繞過 — Flipper Zero 版。** 讓**已經有 FSD 訂閱或購買**但所在地區的車機不顯示「交通號誌與停車標誌控制」選項的車主，能透過 CAN bus 層面啟用 FSD UI 開關。支援 HW3、HW4、Legacy HW1/HW2 Model S/X，FSD v14 可用。另含 Nag 抑制、限速提示音消除、OTA 自動暫停、電池預熱觸發、BMS 即時儀表板（這些功能**不需要** FSD 訂閱就能使用）。硬體成本：Flipper Zero + Electronic Cats CAN Bus Add-On + OBD-II 線；或做 [ESP32 移植版](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32)，總成本 ~$14 / ¥100。
+> **開源 Tesla CAN bus 工具組，支援 Flipper Zero 與 ESP32。** FSD 區域鎖繞過、給 VIN 被封禁車輛的 TLSSC Restore、帶擬真扭力變化的 nag killer、GTW Config Replay、BMS 即時儀表板，以及橫跨 Model 3、Model Y、Model S、Model X 的 30+ 個 CAN handler。支援 HW3、HW4 與 Legacy HW1/HW2。$200+ 的 S3XY Commander 的免費替代方案 — 搭配 [ESP32 移植版](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32) 總成本最低只要 **$14**。
 
 > [!IMPORTANT]
-> **FSD 相關功能必須有有效的 FSD 套件** — 購買或訂閱均可。此工具在 CAN bus 層面啟用 FSD 功能，但車輛仍需要來自 Tesla 的合法 FSD 授權。**這不是免費解鎖工具。**
->
-> 如果你所在的地區無法訂閱 FSD，上游社群記錄了一個變通方法：在可訂閱 FSD 的地區（如加拿大）建立 Tesla 帳號，將車輛轉移到該帳號，然後訂閱 FSD。詳見[上游文件](https://gitlab.com/slxslx/tesla-open-can-mod-slx-repo)。
->
-> Nag 抑制、限速提示音消除、BMS 儀表板、電池預熱等功能**無需 FSD 訂閱**，可獨立使用。
+> **FSD 相關功能需要有效的 FSD 套件** — 購買或訂閱皆可。此工具在 CAN bus 層面啟用 FSD 功能，但車輛仍需要來自 Tesla 的合法 FSD 授權。非 FSD 功能（nag killer、BMS 儀表板、診斷）無需任何訂閱即可使用。
+
+> [!CAUTION]
+> **Tesla 已開始實施 VIN 層級封禁**（2026 年 4 月）。受影響的車輛會靜默失去 TLSSC 開關 — 沒有 OTA、沒有警告，且在帳號轉移與重新訂閱後依然存在。**TLSSC Restore** 功能（v2.10+）可透過 0x331 DAS 設定偽造，在被封禁的 Palladium 與 HW4 車上恢復停車標誌／交通號誌控制。完整封禁研究見 [SECURITY.md](SECURITY.md) 與 [issue #18](https://github.com/hypery11/flipper-tesla-fsd/issues/18)。
 
 <p align="center">
   <img src="assets/demo.gif" alt="Tesla FSD 解鎖運作中 — 主選單、HW 偵測、BMS 即時儀表板" width="600">
@@ -47,119 +50,98 @@
 
 ## 功能
 
-- 自動偵測 HW3/HW4（從 `GTW_carConfig` `0x398` legacy / `0x7FF` Ethernet 讀取），也可手動強制指定 — **注意：** 2020 後 Model 3/Y HW3/HW4 的 `0x398` 在 Ethernet bus 上，CAN bus 可能看不到；遇到偵測不到的情況請用 Force HW3 或 Force HW4
-- 透過修改 `UI_autopilotControl`（`0x3FD`）的 bit 來啟用 FSD
-- Nag 抑制（消除方向盤握手提醒）
-- 速度檔位預設最快，自動從跟車距離撥桿同步
-- Flipper 螢幕即時顯示狀態
+### 核心 FSD
+- 從 `GTW_carConfig`（`0x398`）自動偵測 HW3/HW4；當所接的匯流排上沒有 `0x398` 時，改用 `0x3FD`/`0x399`/`0x3EE` 備援偵測
+- **Legacy→HW3 自動升級**（Palladium Model S/X）— 先偵測到 `das_hw=0`，之後當 `0x3FD` 出現在匯流排上時升級
+- 透過修改 `UI_autopilotControl`（`0x3FD` / `0x3EE`）的 bit 來解鎖 FSD
+- **Legacy 模式**，支援 HW1/HW2（Model S/X 2016-2019）
+- 速度檔位預設最快，並從跟車距離撥桿同步
 
-### 支援硬體
+### TLSSC Restore（v2.10+）
+- 在 **VIN 被封禁** 的車輛上恢復交通號誌與停車標誌控制
+- 對 CAN ID `0x331` 做讀取-修改-重發 — 將 `DAS_autopilot` 設為 SELF_DRIVING
+- 已在 Palladium（Model S Plaid 2023）、HW4 Highland（Model 3 Performance 2024）與 Intel HW3（需 AP-first 變通）上確認可用
+- 不會恢復完整 FSD 視覺化 — 只恢復 TLSSC（停車標誌／交通號誌）
+- **建議的封禁車組合**：同時啟用 **TLSSC Restore** + **TLSSC bit38**（`0x3FD` mux 0 bit 38）— @RoyRakete 在 HW3 / 2026.2.6 上確認可靠（[#18](https://github.com/hypery11/flipper-tesla-fsd/issues/18#issuecomment-4413430516)）。在某些封禁韌體上，單獨開任一個都不穩定；兩者搭配才能重新啟用 AP/TACC 接管
 
-| Tesla HW | 修改的 Bits | 速度檔位 |
-|----------|------------|----------|
-| HW3 | bit46 | 3 段（0-2） |
-| HW4（FSD V14+） | bit46 + bit60、bit47 | 5 段（0-4） |
+### GTW Config Replay（v2.9+，v2.15 從「Ban Shield」改名）
+- 監看 `GTW_carConfig`（`0x7FF`），當閘道器發出被修改的 frame 時，即時重播先前學到的健康匯流排廣播
+- 第一次執行時學習全部 8 個 mux frame，之後自動武裝
+- **它實際上做什麼：** 只在廣播層做遮罩。武裝後，AP ECU 看到的是重播的健康 frame，而不是閘道器修改過的那個。Tesla 的封禁會寫入 GTW NVRAM（重開機後仍在）與伺服器端旗標；本功能不會還原 NVRAM 狀態或後端紀錄，只影響其他匯流排上的 ECU 即時看到的內容。
+- **它不做什麼：** 不能預防封禁、不能解除封禁、也不能改變 Tesla 伺服器端的授權紀錄。在 v2.9-v2.14 部署的 6 週內，沒有任何實證確認可預防封禁。誠實說明見 [#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60) 與 [#67](https://github.com/hypery11/flipper-tesla-fsd/issues/67)。v2.14 的名字「Ban Shield」過度承諾了 — v2.15 改名反映程式碼實際的行為。
 
-HW4 車輛韌體版本 **2026.2.3 以前**請使用 HW3 模式。詳見[相容性](#相容性)。
+### Nag Killer（v2.1+）
+- DAS 感知閘門 — 只在 DAS 真的要求手扶方向盤時才回應，DAS 滿足時零匯流排流量
+- 擬真扭力變化 — 在 1.00-2.40 Nm 之間用 xorshift32 PRNG 隨機漫步，每 5-9 秒有一次到 3.10-3.30 Nm 的握力脈衝
+- **按需握力脈衝（v2.15+）** — 當 `handsOnLevel` 升到提醒需求狀態（0 即將 / 3 升級）時，立即發出一次握力脈衝並重置週期排程。補上 v2.14 及更早版本在排程脈衝之間可能出現的 2 秒黃色升級空窗
+- 在 `0x370` 做 EPAS counter+1 回應，並抑制 level 0（提醒即將出現）與 level 3（升級警報）
+- **請接 Party CAN（X179 pin 2/3）給 nag killer。** `0x370` 在 Party CAN — 不在 Vehicle CAN（9/10），而閘道器轉送的 Chassis 副本（13/14）會觸發 2026.14.x preflight。已在 HW4 2026.20 上以接 2/3 確認可用（[#100](https://github.com/hypery11/flipper-tesla-fsd/issues/100)）。接錯線對的單 CAN 板子沒有東西可回應 — 這是「nag killer 在 HW4 上沒反應」最常見的原因。用車上的 **Service Mode → CAN Port** 頁面確認你這條線束上哪一對是 Party；見 [HARDWARE.md](HARDWARE.md)。
 
----
+### AP-First 模式（v2.14+，給 2026.14.x 韌體）
+- Tesla 2026.14.x 新增了 preflight 檢查，若 CAN 注入已在進行就擋下 AP/TACC 接管
+- 啟用 **AP-First** 後，app 監看 `0x39B` 的 `DAS_autopilotState`，只在 AP 接管後才開始注入 `0x3FD`。在 ESP32 上，DAS 狀態來源會依偵測到的 HW 版本而定。
+- Nag killer、TLSSC Restore 與 GTW Config Replay 不受影響（它們針對不同的 CAN ID）
 
-## 硬體需求
+### 14.x 韌體警告（v2.15+）
+- **預設開啟。** 只要啟用警告開關，Flipper 執行畫面就會把 BMS / flags 那一行換成 `!14.x: TX may stop AP`。ESP32 網頁儀表板則在頂端顯示可關閉的黃色橫幅。
+- 悲觀預設：大多數 14.x 韌體使用者要到自動轉向在行駛中脫離時才知道自己受影響。這個警告會在他們啟用任何 TX 功能之前先提醒到。
+- 可透過 **On 14.x?** 設定開關（Flipper）或橫幅上的 **Dismiss** 按鈕（ESP32，存在 NVS）退出。若你確定是 pre-14.x 韌體就可關閉。
+- 地區注意：執法強度因市場而異。部分地區（沒有 Tesla 直營的市場）似乎執法較不積極。14.x / 2026.20 的即時追蹤見 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。
 
-| 元件 | 說明 | 價格 |
-|------|------|------|
-| [Flipper Zero](https://flipper.net/) | 本體 | ~$170 |
-| [Electronic Cats CAN Bus Add-On](https://electroniccats.com/store/flipper-addon-canbus/) | MCP2515 CAN 收發器模組 | ~$30 |
-| OBD-II 線或 T-tap | 接到 Tesla 的 Party CAN bus | ~$10 |
+### 診斷（唯讀，不需要 FSD）
+- BMS 即時儀表板：電池組電壓、電流、SoC、溫度範圍、**能耗（Wh/km）**
+- 車速、方向盤角度、馬達扭力、煞車狀態
+- DAS 狀態：autopilot 狀態、手扶提醒等級、變換車道狀態、盲點警示、FCW、視覺限速
+- GTW autopilot 層級回讀（NONE/HIGHWAY/ENHANCED/SELF_DRIVING/BASIC）
+- OTA 偵測含防抖 — 韌體更新期間自動暫停 TX，除非明確啟用 Ignore OTA 覆寫
 
-### 接線
+### CAN Capture + 測試設定檔（v2.16+）
+- **CAN Capture** — 將每個收到的 frame 以 candump 格式錄到 SD 卡（`apps_data/tesla_mod/captures/`）。唯讀；在任何車上執行都安全。可餵給 `tools/tesla_crc_cracker.py`。
+- **Send Test** — 從 SD 卡載入使用者自訂的 `.cantest` 文字設定檔並重播你自己的 frame。預設為 dry-run；傳送硬性限制在 **停妥、靜止** 的車（fail-closed），且每個 frame 前都會重新檢查。結果會記錄以利回報 bug。格式與流程：[docs/cantest-format.md](docs/cantest-format.md)，範例：[examples/example.cantest](examples/example.cantest)。
 
-<p align="center">
-  <img src="images/wiring_diagram.png" alt="接線圖" width="700">
-</p>
+### 額外解鎖（v2.16+，選用，預設關閉）
+- **Summon EU Unlock** — `0x3FD` mux1：清掉 bit19（EU AP 限制）並設 bit47（summon-enable），在受 EU 限制的車上開放召喚（Summon）
+- **Continue on Green** — `0x3FD` mux0 bit39 `UI_fsdContinueOnGreenWithCIPV` — 在有前車的情況下，不用撥桿確認就通過綠燈；搭配 TLSSC 使用
+- **右駕（RHD）覆寫** — `0x3F8` bit41 `UI_drivingSide` = RHD。僅限右駕市場
+- **AP 分支／層級選擇器** — `0x3FD` mux1 bits 40-42 `UI_apmv3Branch`：Live / Stage / Dev / Stage2 / EAP / Demo。實驗性，非持久化的 UI 提示 — 停止注入後即還原
+- **可調 Track Mode** — `0x313` `UI_trackModeSettings`：操控平衡（Handling Balance）+ 穩定輔助（Stability Assist）+ 收車後冷卻，校驗和會重算。走 Vehicle 匯流排；預設為 rotation 100 / stability 30%，非 Performance 車型也可用
 
-> **終端電阻：** Electronic Cats 這塊 Add-On 有兩個版本。v0.1 預設啟用 120 Ω 終端，要把板子背面靠近 SN65HVD230 的 `J1 / TERM` solder jumper 切開。v0.2+ 預設已經是斷開狀態，不用動。**接車前**先用三用電表量 CAN-H 跟 CAN-L 兩個 pin 之間的電阻：~120 Ω = 好（terminator 關閉），~60 Ω = 要切斷 jumper，無限大 = 也沒問題。完整說明見 [`HARDWARE.md`](HARDWARE.md#termination-resistor--important-detail)。
+### 設定（執行時開關）
 
-替代接點：後座中控台內的 **X179 診斷接頭**（20-pin 版 Pin 13/14 = CAN-H/L；26-pin 版 Pin 18/19）。
+**穩定（已上車測試）：**
 
-### 其他支援的硬體
+| 設定 | 說明 |
+|------|------|
+| **Mode** | `Active` / `Listen-Only` / `Service`。Listen-Only 是**首次開機的預設值** — MCP2515 處於硬體 listen-only 模式，實體上無法 TX。 |
+| **Nag Killer** | DAS 感知的 EPAS counter+1 回應，帶擬真扭力變化。 |
+| **Force FSD** | 繞過 `isFSDSelectedInUI` 檢查。不會繞過 Tesla 伺服器端授權 — 只影響本地 CAN frame 流。 |
+| **Ignore OTA** | 即使 `0x318` 回報 Tesla OTA 更新進行中，也允許在 Active 模式下 CAN TX。預設關閉。 |
+| **TLSSC Restore** | 0x331 DAS 設定偽造，在被封禁的車上恢復 TLSSC。會觸發 MCU 重開機。 |
+| **AP-First (14.x)** | 延後 0x3FD 注入直到 AP 接管。Tesla 韌體 2026.14.x 需要此項。 |
+| **GTW Config Replay** | 當閘道器發出被修改的 frame 時，重播先前學到的健康 `GTW_carConfig`（0x7FF）廣播。只在 CAN 廣播層做遮罩 — 不會還原 NVRAM 或後端封禁旗標，也不能預防封禁。v2.15 從「Ban Shield」改名（[#60](https://github.com/hypery11/flipper-tesla-fsd/issues/60)、[#67](https://github.com/hypery11/flipper-tesla-fsd/issues/67)）。 |
+| **Suppress Chime** | 消掉 ISA 限速警告提示音（僅 HW4，`0x399`）。在 ESP32 上只在偵測到 HW4 後生效；Legacy/HW3 把 `0x399` 當 DAS 狀態用。 |
+| **Emerg. Vehicle** | 啟用緊急車輛偵測旗標（僅 HW4，bit59）。 |
+| **Precondition** | 透過 `0x082` 觸發電池預熱。 |
 
-不想買 Flipper Zero？PR [#6](https://github.com/hypery11/flipper-tesla-fsd/pull/6) 提供完整 ESP32 移植版，整套硬體成本壓到 **~$14 / ¥100**，內建 WiFi 網頁儀表板。Aliexpress 上 ¥30 的通用 MCP2515 模組也能搭 Flipper Zero 用，自己拉幾條跳線就行。完整對照表見 [`HARDWARE.md`](HARDWARE.md)。
+**Beta（未測試，請回報結果）：**
 
----
+| 設定 | CAN ID | 說明 |
+|------|--------|------|
+| **ScrollPress AP** | `0x3C2` mux=1 | **僅 HW4、僅 Service 模式。** 以基於時間、擬人化的滾輪手勢（press ~250ms → scroll-up ~150ms → press ~250ms → scroll-up）在 `swcRightPressed`（bits 12-13）+ `swcRightScrollTicks`（bits 24-29）上接管 AP，於 `DAS_autopilotState` 由 0→1 上升時觸發 — 不動 `0x3FD`。已知第一個 2026.14.x 繞過法；由 @JakNo 在 Highland HW4 / 2026.14.2 上發現並台架驗證（[#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43)，計時流程 [#82](https://github.com/hypery11/flipper-tesla-fsd/pull/82)）。在 @DmitroPanteliuk 於 Intel HW3 2026.14.6 上回報緊急煞車後，HW3 已於 v2.15 停用 |
+| **Nav FSD Route** | `0x3F8` bits 13/48/49 | 啟用基於導航的 FSD routing（EU／受限地區） |
+| **TLSSC bit38** | `0x3FD` mux0 bit38 | 明確啟用 TLSSC；與 TLSSC Restore（0x331）搭配為建議的封禁車組合 |
+| **Lane Graph** | `0x3FD` mux1 bit45 | UI_showLaneGraph — 在非 FSD 層級顯示車道視覺化 |
+| **Tier Override** | `0x7FF` mux=2 | 強制 GTW_autopilot 為 SELF_DRIVING（比 GTW Config Replay 更激進 — 主動寫入而非重播） |
+| **Dev Mode** | `0x3F8` bit5 | UI_dasDeveloper 旗標 |
+| **右駕（RHD）** | `0x3F8` bit41 | `UI_drivingSide` = RHD（設 bit41、清 bit40 — 與舊的 LHD 探針互斥）。僅限右駕市場。誠實說明：先前的 Force-LHD 探針**實測無效** — 在被封禁的右駕 HW3 / 2026.2.6 上，值 0/1/2 都讓 FSD 停在 LHD 側（[#66](https://github.com/hypery11/flipper-tesla-fsd/issues/66)）；RHD 現在改以「請求的行駛方向」覆寫出貨 |
+| **Hands-Off** | `0x3F8` bit14 | UI 層的手扶停用（第二條 nag 向量） |
+| **Telemetry Off** | `0x3F8` bits 19/42/43/44/55 + `0x3FD` mux1 bits 48/50 | 清掉可觸及的遙測啟用旗標（0x3F8 上的 clip / trip / road-segment，0x3FD 上的座艙攝影機 / 中國）。實驗性 — **只涵蓋可觸及的旗標，不含 Vehicle 匯流排 ECU 日誌上傳，也不保證免於封禁。** 僅在拔掉 SIM 卡時使用 |
 
-## 安裝
+**14.x 實驗性（預設關閉，請回報）：**
 
-### 方法一：下載編譯好的 FAP
+這些針對 Tesla 2026.14.x / 2026.20 行為，**全部預設關閉**。它們是探針，不是已確認的通用修法 — 即時狀態見 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。在 ESP32 網頁儀表板切換（部分也在 Flipper 設定中）。
 
-1. 到 [Releases](https://github.com/hypery11/flipper-tesla-fsd/releases) 頁面
-2. 下載 `tesla_fsd.fap`
-3. 複製到 Flipper 的 SD 卡：`SD Card/apps/GPIO/tesla_fsd.fap`
-
-### 方法二：自行編譯
-
-```bash
-# Clone Flipper Zero 韌體
-git clone --recursive https://github.com/flipperdevices/flipperzero-firmware.git
-cd flipperzero-firmware
-
-# Clone 本 app 到 applications_user
-git clone https://github.com/hypery11/flipper-tesla-fsd.git applications_user/tesla_fsd
-
-# 編譯
-./fbt fap_tesla_fsd
-
-# 燒錄到 Flipper
-./fbt launch app=tesla_fsd
-```
-
----
-
-## 使用方式
-
-1. 把 CAN Add-On 插上 Flipper Zero
-2. 用 CAN-H/CAN-L 接到車上 OBD-II 口
-3. 開啟 app：`Apps > GPIO > Tesla FSD`
-4. 選 **「Auto Detect & Start」**（或手動選 HW3/HW4）
-5. 等待偵測（最多 8 秒）
-6. App 自動開始修改 CAN frame
-
-### 螢幕顯示
-
-```
-  Tesla FSD Active
-  HW: HW4    Profile: 4/4
-  FSD: ON    Nag: OFF
-  Frames modified: 12345
-       [BACK] to stop
-```
-
-### 啟動觸發條件
-
-車上 Autopilot 設定中的 **「交通號誌與停車標誌控制」** 開啟時，app 才會開始修改 frame。這個旗標是 CAN frame 裡的判斷依據。
-
----
-
-## 相容性
-
-| 車型 | HW | 韌體 | 模式 | 狀態 |
-|------|----|------|------|------|
-| Model 3 / Y（2019-2023） | HW3 | 任何 | Auto | 支援 |
-| Model 3 / Y（2023+） | HW4 | `< 2026.2.3` | Force HW3 | 支援 |
-| Model 3 / Y（2023+） | HW4 | `2026.2.3` ↔ `2026.2.8` | Auto | 支援 |
-| Model 3 / Y（2023+） | HW4 | `2026.2.9.x`（FSD v14） | Auto | 支援 |
-| Model 3 / Y（2023+） | HW4 | `2026.2.10` ↔ `2026.4.x` | Auto | 支援 |
-| Model 3 / Y（2023+） | HW4 | `2026.8.6` | **Force HW3** | HW4 path 在這個版本壞掉，要強制 HW3 |
-| Model 3 Highland（2024+） | HW4 | `2026.2.x` | Auto | 已有運作回報 — 需更多確認 |
-| Model 3 / Y（中規 MIC） | HW3 / HW4 | `2026.2.11` | Auto + Force FSD | 已有運作回報 — 見 issue #1, #4, #7 |
-| Model S / X（2021+） | HW4 | `>= 2026.2.3`（除 2026.8.6） | Auto | 支援 |
-| Model S / X（2016-2019） | HW1 / HW2 | 任何 | Legacy | v2.0 已實作，**待上車驗證** |
-
-### 14.x 實驗性開關（預設全部關閉）
-
-針對 Tesla 2026.14.x / 2026.20 行為，**預設全部關閉**。這些是探針，不是已確認的通用修法 — 即時狀態見 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。在 ESP32 網頁儀表板切換（部分也在 Flipper 設定中）。
-
-| 開關 | 說明 |
+| 設定 | 說明 |
 |------|------|
 | **Abort Guard**（ESP32） | Steer-jerk 緩解（[#108](https://github.com/hypery11/flipper-tesla-fsd/issues/108)）。啟動瞬間的方向盤抽動其實是車自己**中止**接管（`DAS_autopilotState` → `8 ABORTING` → `9 ABORTED`）。開啟後一偵測到 abort 狀態就立刻切掉所有 activation 注入，並維持到乾淨脫離。**已上車驗證：** 在寬／直路上消除了抽動（數百次循環 0 次，原本約 1/25–30）。侷限：部分窄路會直接跳到 `FAULT (9)`、沒有前導訊號，擋不住。 |
 | **Soft Engage** | Steer-jerk 緩解（[#108](https://github.com/hypery11/flipper-tesla-fsd/issues/108)）。把啟動邊緣的注入壓住，直到方向盤回到中心 ±5° 內。需要匯流排上有 `0x129`（方向盤角度）；沒有就退化成只有 AP-First。直路抽動已大致被 Abort Guard 取代。 |
@@ -167,49 +149,179 @@ git clone https://github.com/hypery11/flipper-tesla-fsd.git applications_user/te
 | **EPAS-faithful（Mode-C）** | 模擬真實 EPAS 的 demand-state 扭力模型，不去翻 `handsOnLevel`（[#100](https://github.com/hypery11/flipper-tesla-fsd/issues/100)）。用於標準 nag 抑制會觸發 preflight 的車。**尚未上車確認。** |
 | **Signal Map**（ESP32 → 進階） | 自訂 nag 抑制讀取 AP-state／hands-on／方向盤的位置：`id + byte/shift/mask`（[#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)）。用於 `0x39B`/`0x399` 佈局不同的車型變體。有新鮮度閘門 — 設錯會 fail-closed。DAS id 留 `0` 為自動偵測。 |
 
-### 社群測試回報
+**硬體：**
 
-實車回報（用 [Car compatibility report](https://github.com/hypery11/flipper-tesla-fsd/issues/new?template=car_compatibility.yml) issue template 自己回報）：
+| 設定 | 說明 |
+|------|------|
+| **MCP Crystal** | 16 / 8 / 12 MHz — 對應你 CAN 模組的晶振頻率。 |
+| **Hardware**（ESP32） | Auto-detect / Force HW4 / Force HW3 / Force Legacy。Auto-detect 需要 `0x398`，但許多 Model 3/Y 從不發送它 — 偵測錯誤時可自己指定車型。存於 NVS，開機時套用。 |
 
-| 回報者 | 車 | HW | 韌體 | 地區 | 模式 | 結果 |
-|--------|----|----|------|------|------|------|
-| @vbarrier | Model 3 | HW4 | 2026.4.x | 歐洲 | Auto | 運作 |
-| @kwangseok73-sudo | Model 3 | HW4 | 2026.2.x | 韓國 | Force FSD | 運作 |
-| @andreiboestean | Model 3 | HW4 | 2026.2.9.3（FSD v14） | 歐洲 | Auto | 運作 |
-| Marow | Model Y Juniper | HW4 | 2026.8.6 | 歐洲 | (Force HW3 尚未測試) | 顯示「Region not available」→ 用 Force FSD + Force HW3 |
+### HW 支援
 
-### HW1/HW2 Legacy 支援 — 徵求志願者
+| Tesla HW | 修改的 Bits | 速度檔位 |
+|----------|------------|----------|
+| Legacy（HW1/HW2） | bit46 | 3 段（0-2） |
+| HW3 | bit46 | 3 段（0-2） |
+| HW4（FSD V14+） | bit46 + bit60、bit47 | 5 段（0-4） |
 
-舊款 Model S/X（2016-2019）使用 Mobileye 架構，CAN ID 完全不同。Autopilot 控制 frame 在 `0x3EE`（1006）而非 `0x3FD`（1021），bit 排列也不一樣。
+---
 
-邏輯記錄在 [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod) 這個 CanFeather 鏡像（原始 `Starmixcraft/tesla-fsd-can-mod` GitLab 上游已被下架）。但我們需要有 HW1/HW2 車的人幫忙驗證才能上線。
+## 硬體
 
-**如果你有 2016-2019 Model S/X 且有 FSD，想幫忙的話：**
+### Flipper Zero
 
-1. Flipper + CAN Add-On 接上 OBD-II
-2. 開啟內建的 CAN sniffer app
-3. 確認 CAN ID `0x3EE`（1006）有出現在 bus 上
-4. 擷取幾個 frame，貼到 [issue #1](https://github.com/hypery11/flipper-tesla-fsd/issues/1)
+| 元件 | 說明 | 價格 |
+|------|------|------|
+| [Flipper Zero](https://flipper.net/) | 多功能工具本體 | ~$170 |
+| [Electronic Cats CAN Bus Add-On](https://electroniccats.com/store/flipper-addon-canbus/) | MCP2515 CAN 收發器（支援 v1.2） | ~$30 |
+| OBD-II 線或 X179 pigtail | 接到 Tesla 的 CAN bus | ~$5-10 |
 
-驗證通過後，Legacy 支援很快就能加上。
+### ESP32（$14 起）
+
+功能完整的 ESP32 移植版，內建 WiFi 網頁儀表板、NVS 設定保存、深度睡眠與出廠重設。與 Flipper app 相同的 CAN 邏輯。
+
+ESP32 韌體會依偵測到的硬體版本對應 AP/DAS 狀態來源：
+
+| 偵測到的 HW | `0x399` | `0x39B` | ISA 限速提示音 |
+|-------------|---------|---------|----------------|
+| Legacy HW1/HW2 | `DAS_status` | 不使用 | 停用 |
+| HW3 | `DAS_status` | 不使用 | 停用 |
+| HW4 | `ISA_SPEED` | `DAS_status` | 啟用 |
+
+| 板子 | 成本 | 編譯目標 |
+|------|------|----------|
+| M5Stack ATOM Lite + ATOMIC CAN | ~$14 | `m5stack-atom` |
+| Lilygo T-CAN485 | ~$15 | `esp32-lilygo` |
+| Waveshare ESP32-S3-RS485-CAN | ~$18 | `waveshare-s3-can` |
+| 通用 ESP32 + MCP2515 | ~$6 | `esp32-mcp2515` |
+
+設定見 [`esp32/README.md`](https://github.com/hypery11/flipper-tesla-fsd/tree/main/esp32)，完整對照＋接線圖＋X179 針腳見 [`HARDWARE.md`](HARDWARE.md)。
+
+### 接點
+
+- **OBD-II**（方向盤柱下方）— Party CAN。部分 Model 3/Y 車款在 Drive 檔可能靜默。
+- **X179**（副駕駛座腳踢板後方）— 建議使用。Pin 13/14 = Bus 6（混合轉送，在所有模式下都保持活動）。20-pin 與 26-pin 針腳見 [`HARDWARE.md`](HARDWARE.md)。
+
+<p align="center">
+  <img src="images/wiring_diagram.png" alt="接線圖" width="700">
+</p>
+
+---
+
+## 安裝
+
+### 快速開始（不需要編譯工具）
+
+第一次接觸、不太懂技術？選你的硬體 — 兩條路徑都不用命令列：
+
+**Flipper Zero**
+1. 打開 [Releases](https://github.com/hypery11/flipper-tesla-fsd/releases)，從最新版本下載 `tesla_mod.fap`。
+2. 接上 Flipper，打開 [qFlipper](https://flipperzero.one/update)（官方桌面 app）。
+3. 把 `tesla_mod.fap` 複製到 SD 卡的 `apps/GPIO/`。
+4. 在 Flipper 上：**Apps → GPIO → Tesla Mod**。
+
+**ESP32** — 直接從瀏覽器燒錄，什麼都不用裝：
+1. 取得燒錄器：打開線上的 **[Web Flasher](https://hypery11.github.io/flipper-tesla-fsd/install/)**，或從最新[版本](https://github.com/hypery11/flipper-tesla-fsd/releases)下載 `tesla-flasher.html` 打開 — 兩者都能在桌面版的 **Chrome、Edge 或 Opera** 上運作。
+2. 用 USB 接上板子，在你的板子旁按 **Install**，選擇序列埠。
+3. 完成後，連上板子的 Wi-Fi 網路並打開 `http://192.168.4.1` 來控制它。
+
+板子開機時處於 **Listen-Only 模式**（無法傳送），直到你在儀表板啟用 Active。接到車上的接線依你的 Tesla 車型／年份而定 — 見 [HARDWARE.md](HARDWARE.md) 或開 issue 詢問。
+
+### 方法一：下載編譯好的 FAP
+
+1. 到 [Releases](https://github.com/hypery11/flipper-tesla-fsd/releases) 頁面
+2. 下載 `tesla_mod.fap`
+3. 複製到 Flipper 的 SD 卡：`SD Card/apps/GPIO/tesla_mod.fap`
+
+### 方法二：自行編譯
+
+```bash
+git clone https://github.com/hypery11/flipper-tesla-fsd.git
+cd flipper-tesla-fsd
+ufbt
+# 輸出：dist/tesla_mod.fap
+```
+
+### ESP32
+
+> 不想自己編譯？從 **[Web Flasher](https://hypery11.github.io/flipper-tesla-fsd/install/)** 燒錄預先編譯好的映像檔 — 一鍵完成，不需要工具鏈。
+
+```bash
+git clone https://github.com/hypery11/flipper-tesla-fsd.git
+cd flipper-tesla-fsd/esp32
+pio run -e m5stack-atom    # 或：esp32-lilygo、waveshare-s3-can、esp32-mcp2515
+```
+
+---
+
+## 使用方式
+
+1. 把 CAN Add-On 插上 Flipper Zero（或燒錄 ESP32）
+2. 用 CAN-H/CAN-L 透過 OBD-II 或 X179 pin 13/14 接到車輛
+3. 開啟 app：`Apps > GPIO > Tesla Mod`
+4. 選 **「Auto Detect & Start」**（或手動 Force HW3/HW4）
+5. 等待偵測（最多 8 秒）— Palladium S/X 會自動從 Legacy 升級到 HW3
+6. 當車上啟用 TLSSC 開關時，app 就會自動開始修改 frame
+
+---
+
+## 相容性
+
+### 已確認可用（社群測試）
+
+| 車型 | HW | 韌體 | 測試者 | 功能 |
+|------|----|------|--------|------|
+| Model S Plaid 2023（Palladium） | HW3/MCU3 | 2026.2.9.3 | @MiniCS、@nagotti | TLSSC Restore、FSD |
+| Model 3 Highland Perf 2024 | HW4 | 2026.8.6 | @kp43h8 | TLSSC Restore，斷線後仍保留 |
+| Model 3 2019-2023 | HW3 | 多種 | @THER4iN 等多人 | FSD、nag killer |
+| Model X Raven 2017（HW3 retrofit） | HW3/MCU2 | 2026.8.3 | @dmagyar | Nag killer、EAP |
+| Model Y 2023（中規 MIC） | HW3 | 2026.2.11 | 社群 | FSD（Force FSD 模式） |
+| Model 3/Y 2023+ | HW4 | < 2026.2.9 | @vbarrier、@kwangseok73-sudo | FSD |
+
+### 已知限制
+
+| 韌體 | 問題 | 變通方法 |
+|------|------|----------|
+| 2026.8.6+ | 區域鎖 — FSD 神經網路在部分地區拒絕執行 | 拔 SIM 卡，用 Force FSD |
+| 2026.8.6 HW4 | HW4 注入路徑在這個特定版本壞掉 | 用 Force HW3 模式 |
+| Intel HW3（被封禁） | 透過 0x331 恢復了 TLSSC 開關，但啟用它會讓 AP 失效 | 先接管 AP，再透過 0x3FD 注入 TLSSC |
+
+用 [Car compatibility report](https://github.com/hypery11/flipper-tesla-fsd/issues/new?template=car_compatibility.yml) 範本回報你自己的測試結果。
 
 ---
 
 ## 運作原理
 
-在 Party CAN（Bus 0）上做單 bus 的讀取-修改-重發。不需要 MITM，不用接第二條 bus。
+在 Party CAN 上做單匯流排的讀取-修改-重發。不需要 MITM，不用接第二條匯流排。
 
-1. ECU 在 Bus 0 上發出 `UI_autopilotControl`（`0x3FD`）
-2. Flipper 收到，改掉 FSD 啟用 bit
-3. Flipper 重發修改版 — 接收端採用最新的 frame
+1. 閘道器／ECU 在 CAN bus 上發出一個 frame
+2. Flipper/ESP32 收到，修改目標 bit
+3. 重發 — 接收端採用最新的 frame
 
-### 使用的 CAN ID
+### CAN ID
 
-| CAN ID | 名稱 | 用途 |
-|--------|------|------|
-| `0x398` | `GTW_carConfig` | HW 偵測（`GTW_dasHw` byte0 bit6-7） |
-| `0x3F8` | Follow Distance | 速度檔位來源（byte5 bit5-7） |
-| `0x3FD` | `UI_autopilotControl` | FSD 解鎖目標（mux 0/1/2） |
+| CAN ID | 名稱 | 方向 | 用途 |
+|--------|------|------|------|
+| `0x331` | `DAS_autopilotConfig` | TX | TLSSC Restore — 將層級設為 SELF_DRIVING |
+| `0x370` | `EPAS3P_sysStatus` | TX | Nag killer — counter+1 回應帶擬真扭力 |
+| `0x399` | `ISA_speedLimit` / `DAS_status` | TX/RX | ESP32 依 HW 而定：Legacy/HW3 在此讀 DAS 狀態；HW4 用於 ISA 限速提示音抑制 |
+| `0x3FD` | `UI_autopilotControl` | TX | FSD 解鎖 — bit46/60（HW3/HW4）、TLSSC bit38、lane graph bit45 |
+| `0x3F8` | `UI_driverAssistControl` | TX | Nav FSD route、hands-off、dev mode、RHD 行駛方向（bit41）、telemetry-off（beta） |
+| `0x3EE` | `UI_autopilotControl` | TX | FSD 解鎖 — Legacy HW1/HW2 |
+| `0x3C2` | `VCLEFT_switchStatus` | TX | ScrollPress AP — 於 mux=1 注入右滾輪（HW4、Service 模式、beta） |
+| `0x7FF` | `GTW_carConfig` | TX | GTW Config Replay + 主動層級覆寫 |
+| `0x082` | `UI_tripPlanning` | TX | 電池預熱觸發 |
+| `0x313` | `UI_trackModeSettings` | TX | Track Mode — 操控平衡／穩定／冷卻（校驗和重算；Vehicle 匯流排） |
+| `0x398` | `GTW_carConfig` | RX | HW 版本偵測 |
+| `0x318` | `GTW_carState` | RX | OTA 偵測（自動暫停 TX） |
+| `0x399` | `DAS_status`（HW3/Legacy）/ `ISA_speedLimit`（HW4） | RX/TX | 依 HW 分派：pre-Highland HW3 讀為 DAS_status（AP 狀態＋手扶）；HW4 保留提示音抑制寫入路徑 |
+| `0x39B` | `DAS_status` | RX | HW4 + Highland HW3 — AP 狀態（給 AP-First）、nag 等級、變換車道、盲點 |
+| `0x132` | `BMS_hvBusStatus` | RX | 電池組電壓／電流 |
+| `0x292` | `BMS_socStatus` | RX | 充電狀態 |
+| `0x312` | `BMS_thermalStatus` | RX | 電池溫度 |
+| `0x33A` | `UI_ratedConsumption` | RX | 能耗（Wh/km） |
+
+完整 42 個 handler 清單（18 TX、24 RX）見 [`fsd_logic/fsd_handler.h`](fsd_logic/fsd_handler.h)。
 
 ---
 
@@ -218,11 +330,23 @@ git clone https://github.com/hypery11/flipper-tesla-fsd.git applications_user/te
 **拔掉之後 FSD 還會維持嗎？**
 不會。這是即時 frame 修改，拔掉就恢復原樣。
 
-**會不會把車搞壞？**
-只動 UI 設定 frame，不碰煞車、轉向、動力系統。但風險自負。
+**沒有 FSD 訂閱能用嗎？**
+FSD 功能（TLSSC、交通號誌／停車標誌控制）需要來自 Tesla 的 FSD 授權。沒有它，AP ECU 就沒有載入神經網路權重。非 FSD 功能（nag killer、BMS 儀表板、限速提示音抑制、診斷）在任何支援 AP 的車上都能用。
 
-**一定要 CAN Add-On 嗎？**
-對。Flipper 沒有內建 CAN bus，你需要 Electronic Cats 的板子或任何 MCP2515 模組接在 GPIO 上。
+**VIN 層級封禁怎麼辦？**
+Tesla 自 2026 年 4 月起在伺服器端封禁 VIN。封禁會把 `GTW_autopilot` 層級從 SELF_DRIVING 降到 ENHANCED，並移除 TLSSC 開關。**TLSSC Restore** 功能（0x331）可在 Palladium 與 HW4 上恢復停車標誌／交通號誌控制。完整研究見 [issue #18](https://github.com/hypery11/flipper-tesla-fsd/issues/18)。**GTW Config Replay**（0x7FF，前稱「Ban Shield」）可即時重播先前學到的健康設定，但只在 CAN 廣播層 — 不會還原底層的 NVRAM 或伺服器端狀態。
+
+**Flipper Zero vs ESP32 — 該買哪個？**
+ESP32 更便宜（$14 vs $200+），有 WiFi 儀表板、NVS 保存與深度睡眠。Flipper 更便攜，且有內建螢幕。兩者跑相同的 CAN 邏輯。如果你還沒有 Flipper，選 ESP32。
+
+**支援 Model S / Model X 嗎？**
+支援。Palladium S/X（2021+）已確認可用 TLSSC Restore。2021 前、做了 HW3 retrofit 的 S/X 透過 Legacy→HW3 自動升級可用。HW1/HW2 Model S/X 走 Legacy 模式（`0x3EE`）。Model S/X 使用不同的 BMS CAN ID — BMS 儀表板可能顯示錯誤數值。
+
+**這會不會把車搞壞（brick）？**
+只動 UI 設定 frame。不會寫入煞車、轉向或動力系統。App 預設以 Listen-Only 模式開機。完整 TX 面清單見 [SECURITY.md](SECURITY.md)。
+
+**一定要 Flipper CAN Add-On 嗎？**
+給 Flipper：是的，任何 MCP2515 模組（Electronic Cats、通用板子）都行。給 ESP32：多數支援的板子有內建 CAN 收發器（M5Stack ATOMIC CAN、Lilygo T-CAN485、Waveshare S3）。
 
 ---
 
@@ -230,34 +354,30 @@ git clone https://github.com/hypery11/flipper-tesla-fsd.git applications_user/te
 
 | 專案 | 是什麼 | 硬體 |
 |------|--------|------|
-| [slxslx/tesla-open-can-mod-slx-repo](https://gitlab.com/slxslx/tesla-open-can-mod-slx-repo) | 原始 Tesla-OPEN-CAN-MOD namespace 改名搬到 ev-open-can-tools（GitLab 仍在、開發移往 GitHub）後的社群 fork。範圍更廣 — 「general CAN mod tool, not just FSD」 | Adafruit RP2040 CAN、Feather M4、ESP32、M5Stack ATOMIC CAN |
-| ESP32 移植 — PR [#6](https://github.com/hypery11/flipper-tesla-fsd/pull/6) by @elonleo | 把本專案 CAN 邏輯完整移植到 ESP32，內建 WiFi 網頁儀表板。~$14 的 Flipper + Add-On 替代方案 | M5Stack ATOM Lite + ATOMIC CAN、Waveshare ESP32-S3-RS485-CAN |
-| [tumik/S3XY-candump](https://github.com/tumik/S3XY-candump) | 用 enhauto S3XY Commander 當 Panda-protocol bridge 透過 WiFi dump 整條 Tesla CAN bus 的 Python 工具 | Commander dongle |
-| [dzid26/ESP32-DualCAN](https://github.com/dzid26/ESP32-DualCAN) | 「Dorky Commander」— 開源硬體版的 enhauto S3XY Commander | ESP32 + dual CAN |
-| [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod) | 原始 `Starmixcraft/tesla-fsd-can-mod` CanFeather 研究的鏡像 — 我們移植的源頭。原始 GitLab 上游已被下架，這是目前還能看的版本。 | Adafruit Feather M4 CAN |
-| [tuncasoftbildik/tesla-can-mod](https://github.com/tuncasoftbildik/tesla-can-mod) | Arduino 參考實作，含多個非 FSD 功能的 frame template | Arduino + MCP2515 |
+| [ev-open-can-tools](https://github.com/ev-open-can-tools/ev-open-can-tools) | 上游社群專案。開發活動在 GitHub 上（v3.0.x，GPL-3.0）。前身是 GitLab 上的 `Tesla-OPEN-CAN-MOD`；該群組已改名為 `ev-open-can-tools`，GitLab repo 現已停擺（0 個開啟中的 issue/MR，最後一次 commit 2026-04-25）— 請追蹤 GitHub repo。 | RP2040 CAN、Feather M4、ESP32 |
+| [dzid26/ESP32-DualCAN](https://github.com/dzid26/ESP32-DualCAN) | 「Dorky Commander」— S3XY Commander 的開源硬體替代品 | ESP32 + dual CAN |
+| [tuncasoftbildik/tesla-can-mod](https://github.com/tuncasoftbildik/tesla-can-mod) | Arduino 參考實作，附 frame template | Arduino + MCP2515 |
+| [tumik/S3XY-candump](https://github.com/tumik/S3XY-candump) | 透過 S3XY Commander（Panda 協議）的 Python CAN dump 工具 | Commander dongle |
 
 ## 致謝
 
 - [commaai/opendbc](https://github.com/commaai/opendbc) — Tesla CAN 訊號資料庫
 - [ElectronicCats/flipper-MCP2515-CANBUS](https://github.com/ElectronicCats/flipper-MCP2515-CANBUS) — Flipper 用 MCP2515 驅動
 - 社群貢獻者 — 本專案賴以運作的實車測試、擷取與研究：
-  - **協議、nag killer 與 2026.14.x：** @jewelrylin（T-2CAN 雙匯流排擷取、frame-content preflight 測試、X179 Service Mode 針腳圖）、@DrStrangeglovebox（非凡 `0x370` 參考擷取 + HW4 雙 CAN 資料 + 安全發現）、@ssw0209-sys（Mode-C 轉向扭力參考 + HW4 14.x 測試）、@0xAccretion（HW4 Highland 國產車 DAS 佈局發現，#116/#117）、@dunckencn（國行 HW3 start-after-AP 驗證、steer-jerk 與 bus-off 回報）、@kristopf007（HW4 14.x 實車測試）
-  - **功能、擷取與 PR：** @JakNo（ScrollPress AP / `0x3C2`）、@vrs11（Continuous AP）、@sqladm1n（RTC 擷取日誌 PR + 匯流排/接線排查）、@DmitroPanteliuk（全速率 `0x229` 擷取）、@se7en7777777（`0x485` / Highland / 校驗和分析）、@RoyRakete（TLSSC 封禁車組合）、@mamixsystem（post-SOP10 連接器參考）
+  - **協議、nag killer 與 2026.14.x：** @jewelrylin（T-2CAN 雙匯流排擷取、frame-content preflight 測試、X179 Service Mode 針腳圖）、@DrStrangeglovebox（`0x370` 參考擷取 + HW4 雙 CAN 資料 + 安全發現）、@ssw0209-sys（Mode-C 轉向扭力參考 + HW4 14.x 測試）、@0xAccretion（HW4 Highland 中規 MIC DAS 佈局發現，#116/#117）、@dunckencn（國行 HW3 start-after-AP 驗證、steer-jerk 與 bus-off 回報）、@kristopf007（HW4 14.x 實車測試）
+  - **功能、擷取與 PR：** @JakNo（ScrollPress AP / `0x3C2`）、@vrs11（Continuous AP）、@sqladm1n（RTC 擷取日誌 PR + 匯流排/接線排查）、@DmitroPanteliuk（全速率 `0x229` 擷取）、@se7en7777777（`0x485` / Highland / 校驗和分析）、@RoyRakete（TLSSC 封禁車組合）、@mamixsystem（post-SOP10 連接器參考）、@p0sixturtle（Summon / tier-selector 線索，#139）、@dahua910（RHD 需求，#66）、@HamzaObaidat（劇院模式 `0x118` 研究，#149）、@fboulegue（EU / 新線束 Juniper 回報，#143/#109/#110）、@densen2014（ESP32 HW 選擇器建議，#110）
   - **封禁研究、平台測試、ESP32、bug 修復：** @THER4iN、@MiniCS、@kp43h8、@gauner1986、@dmagyar、@ViPiMP、@marcobellinoroci-source、@danpadure、@bruvv、@Symness、@hkloudou、@nagotti、@patatman、@JordanzhaoD
-- `Starmixcraft/tesla-fsd-can-mod` — 原始 CanFeather FSD 研究（GitLab 上已被下架，鏡像在 [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod)）
-- mikegapinski/tesla-can-explorer — 從 Tesla 主機 `libQtCarVAPI.so` 萃取的 4 萬個 Tesla CAN 訊號字典
-- talas9/tesla_can_signals — 各車型 wire format 對照
+- `Starmixcraft/tesla-fsd-can-mod` — 原始 CanFeather FSD 研究（GitLab repo 已被移除；鏡像在 [Karolynaz/waymo-fsd-can-mod](https://github.com/Karolynaz/waymo-fsd-can-mod)）
 
-## 支持這個專案
+## 支持這個研究
 
-如果這個專案幫你省下了改裝盒子的錢、讓你看懂 Tesla 的 CAN bus，或在封鎖後保住了你的 TLSSC，歡迎贊助持續的研究與測試。
+如果這個專案幫你省下了改裝盒子的錢、讓你看懂 Tesla 的 CAN bus，或在封禁後保住了你的 TLSSC，歡迎贊助持續的研究與測試。
 
 [![Crypto](https://img.shields.io/badge/Crypto-Donate-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white)](https://fsd.fkey.id/) [![PayPal](https://img.shields.io/badge/PayPal-Donate-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=hypery11@gmail.com&item_name=Tesla+FSD+Open+Source+Research&currency_code=USD) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-hypery11-EA4AAA?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/hypery11)
 
 加密貨幣請至 **[fsd.fkey.id](https://fsd.fkey.id/)** — 同一個地址、支援多鏈。實際可用的網路請直接開頁面查看。
 
-款項用於測試用的 Tesla 零件（待救援的封鎖 VIN、不同 MCU/硬體組合）、各種 ESP32 硬體，以及逆向新韌體版本所花的時間。
+款項用於測試用的 Tesla 零件（待救援的封禁 VIN、不同 MCU/HW 組合）、各種 ESP32 硬體，以及逆向新韌體版本所花的時間。
 
 ## 授權
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,29 +5,38 @@ actions whose CAN frame templates are already documented in public sources
 and can be implemented on our existing MCP2515 + Flipper stack without any
 new hardware or vendor firmware.
 
-## v2.15 — locked, in PR review (target: early June 2026)
+## v2.15 — shipped (first 2026.14.x bypass + HW3 DAS_status fix)
 
-The v2.15 stack is feature-complete and waiting on on-car verification
-before tagging beta. Public PR set:
+Tagged and released. The whole PR set landed:
 
-- **PR #82** — `0x3C2` Scroll-Press AP Engage (HW4-only, first confirmed 2026.14.x bypass) — needs @JakNo / pin-9/10 on-car verify
-- **PR #83** — On-demand grip pulse nag killer enhancement — needs @deftdawg on-car verify on MX HW3
-- **PR #84** — 14.x firmware warning banner (Flipper + ESP32, default ON, dismissible) — docs-style; ready to merge
-- **PR #81** — Ban Shield → GTW Config Replay rename (honest framing, NVS-key preserved) — needs @bruvv review (#67)
-- **PR #97** — Flipper HW3 0x399 DAS_status parser fix (mirror of merged ESP32 #92) — needs HW3 user verify
+- **PR #82** — `0x3C2` Scroll-Press AP Engage (HW4-only, first confirmed 2026.14.x bypass)
+- **PR #83** — On-demand grip pulse nag killer enhancement
+- **PR #84** — 14.x firmware warning banner (Flipper + ESP32, default ON, dismissible)
+- **PR #81** — Ban Shield → GTW Config Replay rename (honest framing, NVS-key preserved, #67)
+- **PR #97** — Flipper HW3 `0x399` DAS_status parser fix (mirror of ESP32 #92)
+- ESP32 side (vrs11): HW3 `0x399` DAS_status fix + `can_signals.h` refactor (#92), HTTP CAN log stream on port 82 (#94), Ignore OTA toggle (#93)
 
-Already landed in main (ESP32 side):
-- vrs11 PR #92 — HW3 0x399 DAS_status fix + `can_signals.h` refactor
-- vrs11 PR #94 — HTTP CAN log stream (port 82, candump-compatible)
-- vrs11 PR #93 — Ignore OTA toggle (cherry-picked after rebase)
+## v2.16 — shipped (beta line, currently beta.26)
 
-## v2.16 — candidate backlog (post v2.15 ship)
+The v2.16 beta line shipped and is on **beta.26**. What started as the
+baseline-capture tooling grew into the Field-Readiness initiative (#127)
+and a long run of on-car 14.x nag / steer-jerk fixes. Highlights across the
+line (see `changelog.md` for the full per-beta history):
 
-Open tracker issues, contributions welcome:
+- **Shared protocol core + host test suite / CI gate** (beta, beta.2) — one definition of the frame type, checksums, enums and parsers shared by the Flipper and ESP32 builds, gating both.
+- **Capture tooling** — Flipper CAN Capture (beta), full-rate single-ID capture (beta.3), user-loadable `.cantest` SEND profiles (beta.2), ESP32 STA WiFi + dashboard config (beta.2).
+- **Field-Readiness (#127)** — black-box incident recorder (#124), tap capability checker (#125), `0x39B`/`0x399` variant auto-profiles (#126), from beta.12 on.
+- **14.x nag / steer-jerk work** — ESP32 AP-First (beta.6), EPAS-faithful / Mode-C nag (beta.7/8/10), Nag Burst + ±1.8 Nm cap + Signal Map (beta.11), Abort Guard (beta.11), Soft Engage (beta.10), Instant Engage / Minimal Inject (beta.16/17/19), plus HW4-detect and dashboard fixes (beta.20–24).
+- **`0x229 SCCM_rightStalk` — resolved (#95).** The AUTOSAR-E2E checksum was cracked and documented (`tools/crack_0x229.py`, 224/224 real frames across two full-rate captures, beta.4). Outcome: injection is a dead end on a shared bus — the genuine SCCM never stops sending `0x229`, so an injected pull collides bit-for-bit and breaks the rolling-counter sequence (this is why `0x3C2` ScrollPress works and `0x229` doesn't). `0x229` is therefore blocked from loadable `.cantest` profiles for safety (a pulled-down stalk is a shift-to-DRIVE request the parked/stationary interlock can't catch). Credit @DmitroPanteliuk (full-rate captures), @se7en7777777, @jewelrylin.
+- **LILYGO T-2CAN dual-CAN — shipped (#96).** `lilygo-t2can` is a live PlatformIO env (onboard MCP2515/SPI as Vehicle CAN + native TWAI), carrying Bus 6 plus Vehicle CAN Bus 2 direct on one board. T-2CAN firmware / bus / wiring reference merged into `esp32/README.md` via #137 (beta.25). Credit @ssw0209-sys.
+- **EU / AP feature toggles (beta.25, all opt-in, default OFF)** — Summon EU Unlock (`0x3FD` mux1, clears bit19 + sets bit47, closing the HW3 gap; #111/#139, PR #144); Continue on Green (`0x3FD` mux0 bit39; PR #145); Right-Hand Drive override (`0x3F8` bit41; #66, PR #146); Telemetry Off (experimental — clears reachable telemetry-enable flags, not a ban guarantee; PR #147); AP branch/tier selector (`UI_apmv3Branch`, experimental, non-persistent; PR #148).
+- **Adjustable Track Mode (beta.26, PR #150)** — `0x313 UI_trackModeSettings`: Track Mode ON + Handling Balance (byte1) + Stability Assist (byte2) + post-drive cooling (byte3), additive checksum recomputed and counter preserved. Opt-in, default OFF, works on non-Performance trims. (See Tier 2 / Tier 3 below.)
 
-- **#95** — `0x229 SCCM_rightStalk` AP engage for pre-Highland HW3 (physical stalk cars). Sibling to v2.15's `0x3C2` HW4 path; requires counter + Tesla CRC handling. Source: @JakNo in [#43](https://github.com/hypery11/flipper-tesla-fsd/issues/43#issuecomment-4529411812). Gated on v2.15 HW3 DAS readback (#92, merged) being stable before exposing a new injection path on top of it.
-- **#96** — LILYGO T-2CAN dual-CAN platformio env (`help wanted`). Single-board solution that carries Bus 6 (existing feature set) + Vehicle CAN Bus 2 direct (`0x3C2` and future `0x229`). Needs board owner for pinout verification.
-- **HW3 `0x3C2` retest with v2.15 code** — @DmitroPanteliuk's earlier HW3 negative test (emergency brake on 2026.14.6) may have been caused by `0x399`-vs-`0x39B` DAS readback failure, now fixed in #92. Retest with v2.15 ESP32 code before deciding whether to expose `0x3C2` on HW3.
+### Now / next (post beta.26)
+
+Genuinely-open, contributions welcome:
+
+- **HW3 `0x3C2` retest with current code** — @DmitroPanteliuk's earlier HW3 negative test (emergency brake on 2026.14.6) may have been caused by the `0x399`-vs-`0x39B` DAS readback failure since fixed in #92. Retest with current ESP32 code before deciding whether to expose `0x3C2` on HW3.
 - **L2 nag trigger investigation** — @deftdawg flagged that residual 2-second yellow nags still appear on the on-demand grip pulse path. L2 (transitional / "marginal hands") may be the missing trigger. Needs CAN capture of L1→L2 transitions on a banned car before deciding to add to the trigger set — acting on L1 directly is a fingerprint risk.
 - **OpenWRT spoofing AP** — @vadimpelau raised the question of DNS-spoofing Tesla domains to keep maps/multimedia alive while reducing ban risk. Marginal improvement for ban prevention given Tesla's mutual-TLS-pinning on telemetry paths, but useful for UX. If anyone has a working OpenWRT writeup that handles cert pinning, drop in [#80](https://github.com/hypery11/flipper-tesla-fsd/issues/80).
 
@@ -71,7 +80,7 @@ retransmit. Estimated ~30 LOC each.
 - [ ] `FoldMirrors` / `MirrorsDip` / `MirrorsDim` (`0x273` bits) — read current state, toggle
 - [ ] `StoppingMode` select (`0x293`)
 - [ ] `TractionControl` off (`0x2A1 ESP_status`)
-- [ ] `TrackMode` enter/exit (`0x293` + `0x2B9`)
+- [x] `TrackMode` enter/exit — shipped via `0x313 UI_trackModeSettings` (beta.26, PR #150; the real frame, not the guessed `0x293`/`0x2B9`)
 - [ ] `WiperMode` cycle / `WipersWasher` pulse (`0x3E2`)
 - [ ] **Cybertruck Homelink bridge** — requested by @JoshuaSpain on [slxslx/tesla-open-can-mod-slx-repo#2](https://gitlab.com/slxslx/tesla-open-can-mod-slx-repo/-/issues/2). Tesla removed the Homelink module from Cybertruck and replaced it with a MyQ subscription. The CT's firmware almost certainly still runs the Homelink code path — Tesla is known to leave code for removed hardware (rain sensor, ultrasonic, etc.) — so the car is plausibly sending a "Homelink requested" frame every time the UI button is pressed, it just has no physical module to act on it.
   
@@ -96,7 +105,7 @@ retransmit. Estimated ~30 LOC each.
 - [ ] `CabinTemp` / `CabinTempLeft` / `CabinTempRight` — current temp read, setpoint write
 - [ ] Seat heat family: `FrontSeatHeatLeft/Right`, `RearSeatHeatLeft/Right/Central/All`, `AllSeatHeat`, `SteeringWheelHeat` (`0x2E1` bitfield)
 - [ ] `FrontSeatVentLeft` / `FrontSeatVentRight` (`0x2E1`)
-- [ ] `TrackModeStability` / `TrackModeHandling` sliders (`0x2B9` — the 0/10/20/…/100 bucket enum visible in .so symbols)
+- [x] `TrackModeStability` / `TrackModeHandling` sliders — shipped via `0x313` Stability Assist (byte2) + Handling Balance (byte1) (beta.26, PR #150; the real frame, not `0x2B9`)
 
 ## Tier 4 — multi-frame / safety-gated
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,8 +69,9 @@ is fine.
 For peace of mind, here is the explicit list of CAN ID classes this
 project's TX path can write to:
 
-- `0x3FD` `UI_autopilotControl` — modifies bits 19, 46, 47, 59, 60 only;
-  retransmits otherwise unchanged
+- `0x3FD` `UI_autopilotControl` — modifies bits 19, 39, 40-42, 46, 47, 48,
+  50, 59, 60 only (bit39 Continue on Green, bits 40-42 apmv3 branch/tier,
+  bits 48/50 cleared for Telemetry Off); retransmits otherwise unchanged
 - `0x3EE` `UI_autopilotControl` (Legacy HW1/HW2) — same as above on
   different bit positions
 - `0x370` `EPAS3P_sysStatus` — sends a counter+1 echo with handsOnLevel = 1
@@ -84,9 +85,13 @@ project's TX path can write to:
   0x1B (SELF_DRIVING) for TLSSC Restore on banned vehicles; only when
   the user enables the TLSSC Restore setting
 - `0x3F8` `UI_driverAssistControl` — Nav FSD Route (bits 13/48/49),
-  Hands-Off (bit14), Dev Mode (bit5), Force LHD (bits 40-41),
-  Telemetry Off (bit43); only when the corresponding Settings toggle
-  is ON
+  Hands-Off (bit14), Dev Mode (bit5), driving-side override — Force LHD /
+  RHD (bits 40-41), Telemetry Off (bits 19/42/43/44/55); only when the
+  corresponding Settings toggle is ON
+- `0x313` `UI_trackModeSettings` — when the Track Mode setting is ON,
+  requests Track Mode ON and writes the handling-balance / stability-assist
+  / cooling fields, then recomputes the additive checksum; the car's own
+  broadcast frame is modified in place
 - `0x7FF` `GTW_carConfig` — replays the learned-healthy snapshot when
   GTW Config Replay (formerly "Ban Shield") detects the gateway has
   modified a frame; only when the feature is armed

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+## 2.16-beta.26 — adjustable Track Mode (PR #150)
+
+- **Adjustable Track Mode via `0x313` `UI_trackModeSettings` (opt-in, default OFF).** Requests Track Mode ON plus **Handling Balance** (`UI_trackRotationTendency`, byte1), **Stability Assist** (`UI_trackStabilityAssist`, byte2), and post-drive cooling / compressor overclock (byte3). The additive checksum is recomputed and the message counter preserved (modify-and-resend on the Vehicle bus). Defaults: rotation 100 (rear-biased) / stability 30%. **Works on non-Performance trims.** Wired on the Flipper, the ESP32, and the dashboard. (PR #150)
+
+## 2.16-beta.25 — EU unlocks + experimental stealth/tier options (all opt-in, default OFF)
+
+- **Summon EU Unlock.** `0x3FD` mux1: clears bit19 (EU restriction) and sets bit47 (summon enable) — the HW3 gap is now closed. (#111, #139, PR #144)
+- **Continue on Green.** `0x3FD` mux0 bit39 (`UI_fsdContinueOnGreenWithCIPV`): continue through a green behind a lead car without stalk confirmation. (#111, PR #145)
+- **Right-Hand Drive (RHD) override.** `0x3F8` bit41 (`UI_drivingSide`). RHD markets only. (#66, PR #146)
+- **Telemetry Off (experimental).** Clears the reachable telemetry-enable flags on `0x3F8` (bits 19/42/43/44/55) and `0x3FD` mux1 (bits 48/50). It does **not** cover the Vehicle-bus ECU log-upload, so it is not a ban guarantee. (PR #147)
+- **AP branch/tier selector (experimental).** `0x3FD` mux1 bits 40–42 (`UI_apmv3Branch`: Live / Stage / Dev / Stage2 / EAP / Demo) — a non-persistent UI hint. (PR #148)
+- **Docs: LilyGO T-2CAN firmware / bus / wiring reference** added to `esp32/README.md` (thanks @ssw0209-sys, #137).
+
 ## 2.16-beta.24 — manual HW selection on the ESP32 dashboard (#110)
 
 - **Pick your hardware version yourself: Auto-detect / Force HW4 / Force HW3 / Force Legacy.** New selector in the ESP32 dashboard Controls, persisted in NVS and applied at boot. The Flipper build has had Force HW3/HW4 in its menu for a long time — the ESP32 build only ever auto-detected, which is the real gap behind this issue. Auto-detection needs `GTW_carConfig` (`0x398`), and **many Model 3 / Model Y never broadcast it**, so those cars fall back to HW3 and lose the HW4-only features. Rather than making detection guess harder — the beta.20 attempt that regressed working cars — an owner who knows their car can now just say so. **Default is Auto-detect, so nothing changes unless you choose to change it**; once set, auto-detection can no longer move it. Credit to @densen2014 for the suggestion, and @ssw0209-sys for the reports that showed why the automatic approach was the wrong lever.

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -55,12 +55,19 @@ All CAN protocol handling from hypery11's Flipper Zero implementation (`fsd_hand
 - **BMS Live Data UI hooks** — fields exist in UI/API, but BMS section is currently not working reliably on tested vehicle setup
 - **CAN Bus Stats** — RX frame count, TX modified count, CRC errors, frames/second
 - **HTTP CAN Log Stream** — phone-friendly candump collection via dashboard button; device streams CAN frames over HTTP on port 82 and the browser saves the collected `.dump` file on Stop
-- **Web Controls** — toggle buttons for:
+- **Web Controls** — toggle buttons and selectors for:
   - Activate/Stop FSD (Listen-Only ↔ Active mode switch)
   - Ignore OTA on/off (allows Active mode TX during a detected Tesla OTA)
   - NAG Killer on/off
   - BMS serial output on/off
   - Force FSD toggle
+  - Summon EU Unlock (clears the EU AP restriction and enables summon on `0x3FD` mux1)
+  - Continue on Green (proceed through a green light with a lead car; pairs with TLSSC)
+  - Right-Hand Drive (RHD) override (`0x3F8` driving-side — RHD markets only)
+  - Telemetry Off (experimental) (clears reachable telemetry-enable flags on `0x3F8` / `0x3FD` mux1)
+  - AP Branch/Tier selector (experimental apmv3 — Live / Stage / Dev / Stage2 / EAP / Demo, or Off)
+  - Track Mode (experimental) (adjustable rotation / stability / cooling via `0x313`)
+  - Hardware override selector (Auto-detect / Force HW4 / Force HW3 / Force Legacy)
 - **OTA Warning Banner** — pulsing red alert when vehicle OTA update is detected
 - **Connection Status** — green/red dot indicator with auto-reconnect on WebSocket disconnect
 - **Device Info** — firmware build date, uptime counter, WiFi client count
@@ -96,6 +103,13 @@ This avoids a manual AP/DAS profile. The dashboard hides the chime toggle until 
 | **Speed Profile** | `0x3FD` mux2 | Follow-distance stalk maps to speed offset |
 | **DAS Status** | `0x399` or `0x39B` | Runtime HW version selects status source |
 | **ISA Chime Suppress** | `0x399` | HW4 only; disabled for Legacy/HW3 because `0x399` is DAS status |
+| **Summon EU Unlock** | `0x3FD` mux1 | Clears EU AP restriction (bit19) + enables summon (bit47) |
+| **Continue on Green** | `0x3FD` mux0 | Proceed through a green light with a lead car (bit39); pairs with TLSSC |
+| **AP Branch/Tier** | `0x3FD` mux1 | Experimental apmv3 branch/tier hint (bits 40-42); off by default |
+| **RHD Override** | `0x3F8` | Right-Hand Drive driving-side override (bits 40-41); RHD markets only |
+| **Telemetry Off** | `0x3F8` / `0x3FD` mux1 | Experimental; clears reachable telemetry-enable flags |
+| **Track Mode** | `0x313` | Experimental adjustable Track Mode (rotation / stability / cooling) |
+| **HW Override** | — | Manual Auto-detect / Force HW4 / Force HW3 / Force Legacy selector |
 | **Battery Precondition** | `0x082` | Frame builder implemented; no user control exposed yet |
 | **BMS Dashboard** | `0x132`/`0x292`/`0x312` | Parsing/UI path implemented, but currently not working reliably |
 | **OTA Protection** | `0x318` | Auto-stops TX when OTA update detected unless Ignore OTA is enabled |
@@ -128,7 +142,7 @@ Any ESP32 board + CAN transceiver works. Pick the matching build env in `platfor
 | `esp32-mcp2515` | Generic ESP32 + MCP2515 module | MCP2515 SPI | SPI CS=5 | 8 MHz crystal |
 | `esp32-lilygo` | LilyGO T-CAN485 | TWAI | 27 / 26 | Built-in SN65HVD230 + SD slot |
 | `ttgo-tdisplay` | LilyGO/TTGO T-Display + MCP2515 | MCP2515 SPI (HSPI) | CS=26, SCK=33, MISO=32, MOSI=25 | Built-in ST7789 dashboard, MISO needs 5V→3.3V divider |
-| `lilygo-t2can` | LilyGO-T2CAN | TWAI/MCP2515 SPI | 7 / 6 | ESP32-S3-WROOM-1U（MCN16R8）with MCP2515 |
+| `lilygo-t2can` | LilyGO-T2CAN | TWAI/MCP2515 SPI | 7 / 6 | ESP32-S3-WROOM-1U (MCN16R8) with MCP2515 |
 | `waveshare-s3-can` | Waveshare ESP32-S3-RS485-CAN | TWAI | 15 / 16 | ESP32-S3, 8MB flash/PSRAM, USB-CDC |
 | generic | ESP32-C3/S3 Super Mini + SN65HVD230 | TWAI | any two pins | Override `PIN_CAN_TX` / `PIN_CAN_RX` |
 
@@ -197,6 +211,14 @@ Only 2 wires needed. Power via USB-C (car USB port or power bank).
 Located in the rear center console area:
 - 20-pin connector: Pin 13 (CAN-H), Pin 14 (CAN-L)
 - 26-pin connector: Pin 18 (CAN-H), Pin 19 (CAN-L)
+
+> [!IMPORTANT]
+> **The X179 pin→bus map is not fixed — verify it on your own car.** On many
+> harnesses pins 13/14 are **Chassis CAN**, not the "Bus 6" mix, and the third
+> CAN pair has moved to other pins on newer builds. The deterministic check is
+> the car's **Service Mode → CAN Port** page, which lists each pin's bus by name.
+> See [HARDWARE.md – X179](../HARDWARE.md#x179--behind-the-rear-center-console-2021-model-3y)
+> for the per-harness maps before you tap.
 
 ---
 
@@ -372,6 +394,7 @@ esp32/
 - **[wjsall/tesla-fsd-controller](https://github.com/wjsall/tesla-fsd-controller)** — ESP32 WiFi Web architecture reference.
 - **[tuncasoftbildik/tesla-can-mod](https://github.com/tuncasoftbildik/tesla-can-mod)** — Tesla-inspired dark theme UI design reference.
 - **[tesla-can-explorer](https://github.com/mikegapinski/tesla-can-explorer)** by @mikegapinski — CAN signal names and DBC definitions.
+- **@ssw0209-sys** ([#137](https://github.com/hypery11/flipper-tesla-fsd/issues/137)) — LilyGO T-2CAN firmware / bus / wiring reference.
 
 ---
 


### PR DESCRIPTION
Brings the docs up to date with everything shipped in **v2.16-beta.25 / beta.26**. No code changes — docs only, verified against the current firmware.

### What was stale (found by an audit against the code + releases)
- **README.md** — Features section was missing 5 of the 6 newest features; Credits omitted this cycle's contributors; the Force-LHD / Telemetry-Off rows and the CAN-ID table were out of date; the handler count was stale.
- **README_zh-TW.md / README_zh-CN.md** — badly behind: ~5 features vs the current set, wrong app name / `.fap` filename, old `fbt` build flow, a 3-row CAN table, and no VIN-ban caution or Getting-Started/flasher section.
- **changelog.md** — two releases behind (no beta.25/beta.26).
- **ROADMAP.md** — frozen pre-v2.15; Track Mode still listed as a TODO; #95/#96 shown as open.
- **esp32/README.md / HARDWARE.md / SECURITY.md** — stale feature tables, a non-existent `esp32-twai` build env, the T-2CAN mislabeled as "dual MCP2515", and TX-surface bit lists that predated the new features.

### What changed
- All three READMEs now list the full feature set (incl. Summon EU Unlock, Continue on Green, RHD override, Telemetry Off, AP branch/tier selector, adjustable Track Mode) and a consistent CAN-ID table + handler count (42: 18 TX / 24 RX). Chinese READMEs rewritten to parity, app/filename fixed (`tesla_mod.fap`, "Tesla Mod"), build flow updated to `ufbt`, VIN caution + Getting-Started added.
- `changelog.md`: beta.25 + beta.26 entries. `ROADMAP.md`: shipped items checked off, Track Mode frame corrected (`0x313`), status re-anchored to beta.26.
- `esp32/README.md` / `HARDWARE.md` / `SECURITY.md`: feature tables, build env (`m5stack-atom`), T-2CAN description (TWAI + MCP2515), and the TX-surface bit lists (added `0x313`, expanded `0x3FD`/`0x3F8`) all corrected.
- Credits updated across all READMEs: @ssw0209-sys, @p0sixturtle, @dahua910, @HamzaObaidat, @fboulegue, @densen2014, @dunckencn.

Every DBC/bit/env claim was re-checked against `fsd_logic/`, `esp32/.firmware/`, and `platformio.ini`.
