### PR TITLE
feat(esp32): SNIFFER_ONLY hardware listen-only build + classic ESP32/SN65HVD230 env

### DIFF
--- a/esp32/.firmware/can_driver.cpp
+++ b/esp32/.firmware/can_driver.cpp
@@ -33,6 +33,12 @@ class TwaiDriver : public CanDriver {
     bool     busoff_event_  = false;  // consume-on-read edge: recovery just started
 
     bool install_and_start(bool listen_only) {
+#ifdef SNIFFER_ONLY
+        // Research sniffer build: hardware-forced Listen-Only. TWAI_MODE_LISTEN_ONLY
+        // never emits dominant bits (not even ACKs), so the node is physically
+        // incapable of transmitting — zero ban risk from injected frames.
+        listen_only = true;
+#endif
         twai_general_config_t g = TWAI_GENERAL_CONFIG_DEFAULT(
             (gpio_num_t)tx_pin_,
             (gpio_num_t)rx_pin_,
@@ -154,6 +160,10 @@ public:
     uint32_t rxCount() override { return rx_count_; }
 
     void setListenOnly(bool enable) override {
+#ifdef SNIFFER_ONLY
+        (void)enable;   // sniffer build is permanently Listen-Only; ignore mode switches
+        return;
+#endif
         if (listen_only_ == enable) return;
         stop_and_uninstall();
         if (!install_and_start(enable)) {

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -54,6 +54,45 @@ lib_deps =
     adafruit/Adafruit NeoPixel@^1.12.0
     Links2004/WebSockets@^2.4.0
 
+# Custom env: classic ESP32 DevKit + SN65HVD230 transceiver via built-in TWAI.
+# TX=21 / RX=22 are safe GPIOs (not strapping, not input-only, not flash pins).
+# PIN_LED=-1 disables the NeoPixel routine (plain DevKits have no addressable LED).
+[env:esp32-generic-twai]
+platform = espressif32@6.9.0   ; Arduino-ESP32 2.0.x — lower static DRAM; 3.x overflows dram0 on classic ESP32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = min_spiffs.csv
+build_flags =
+    -D BOARD_ESP32_GENERIC
+    -D CAN_DRIVER_TWAI
+    -D PIN_CAN_TX=21
+    -D PIN_CAN_RX=22
+    -D PIN_LED=-1
+lib_deps =
+    adafruit/Adafruit NeoPixel@^1.12.0
+    Links2004/WebSockets@^2.4.0
+
+# Research sniffer: same as esp32-generic-twai but hardware-forced Listen-Only
+# (-D SNIFFER_ONLY). The TWAI controller is pinned to TWAI_MODE_LISTEN_ONLY and
+# can never transmit — pure CAN capture, zero injection / zero ban risk.
+[env:esp32-generic-twai-sniffer]
+platform = espressif32@6.9.0
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = min_spiffs.csv
+build_flags =
+    -D BOARD_ESP32_GENERIC
+    -D CAN_DRIVER_TWAI
+    -D SNIFFER_ONLY
+    -D PIN_CAN_TX=21
+    -D PIN_CAN_RX=22
+    -D PIN_LED=-1
+lib_deps =
+    adafruit/Adafruit NeoPixel@^1.12.0
+    Links2004/WebSockets@^2.4.0
+
 [env:esp32-mcp2515]
 platform = espressif32
 board = esp32dev


### PR DESCRIPTION
Two parts (the diff posted in #153, which you already confirmed applies to main and builds):

1. **`-D SNIFFER_ONLY` guard** (`can_driver.cpp`) — pins TWAI to `TWAI_MODE_LISTEN_ONLY` at install and short-circuits `setListenOnly()`, so even the dashboard Active toggle cannot re-enable TX. The node is physically incapable of transmitting: the right primitive for ban-safe passive capture.

2. **PlatformIO envs** (`platformio.ini`) — `esp32-generic-twai` / `esp32-generic-twai-sniffer` for the classic ESP32 (D0WD-V3) + SN65HVD230 on the native TWAI controller (`TX=GPIO21`, `RX=GPIO22`, `PIN_LED=-1`); platform pinned to `espressif32@6.9.0` because core 3.x overflows DRAM on the classic board. Cheapest working hardware path in the project so far.

Field-tested: the sniffer env produced the 359 s passive EU driving capture on a Model S Plaid HW3 (fw 2026.26.1, Italy) — see #153.
