### PR TITLE
feat(esp32): auto-disable Summon EU Unlock on drive-gear engage (#160)

### DIFF
--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -1188,6 +1188,35 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
 
     // ── Continuous AP HW3/Legacy state parsers (read-only, always) ──────────
     if (frame.id == CAN_ID_SCCM_RSTALK) {
+        // Safety guard (#160): auto-disable Summon EU Unlock when the driver
+        // shifts into drive (0x229 gear lever full-down / D detent), so a
+        // leftover Summon override can't interfere with normal AP. Runs before
+        // the HW3/Legacy Continuous-AP gate below because Summon EU Unlock
+        // applies on HW3 + HW4, and that gate returns early on HW4. Edge-
+        // triggered by the summon_unlock==true guard: NVS is written only on the
+        // true→false flip, so repeated full-down 0x229 frames can't thrash NVS.
+        if (frame.dlc > SIG_GEAR_LEVER_POS_BYTE) {
+            uint8_t detent =
+                (frame.data[SIG_GEAR_LEVER_POS_BYTE] >> SIG_GEAR_LEVER_POS_SHIFT) &
+                SIG_GEAR_LEVER_POS_MASK;
+            if (detent == SIG_GEAR_LEVER_FULL_DOWN) {
+                FSDState saved;
+                bool disabled = false;
+                state_enter();
+                if (g_state.summon_unlock) {
+                    g_state.summon_unlock = false;
+                    saved = g_state;
+                    disabled = true;
+                }
+                state_exit();
+                if (disabled) {
+                    Serial.println("[SAFETY] Summon EU Unlock auto-disabled on drive-gear (0x229)");
+                    can_dump_log("[SAFETY] Summon EU Unlock auto-disabled on drive-gear (0x229)");
+                    prefs_save(&saved);
+                }
+            }
+        }
+
         FSDState s = state_snapshot();
         if (s.hw_version != TeslaHW_HW3 && s.hw_version != TeslaHW_Legacy) return;
         uint32_t now_ms = millis();


### PR DESCRIPTION
Implements the safety guard requested in #160 (thanks @densen2014): on the ESP32, auto-disable **Summon EU Unlock** when the driver shifts into drive, so a leftover Summon override can't interfere with normal AP.

### Behaviour
When a `0x229` (SCCM_RSTALK / GearLever) frame shows the **full-down / D detent** (`SIG_GEAR_LEVER_FULL_DOWN`) and `summon_unlock` is on, the firmware sets it OFF, logs `[SAFETY] Summon EU Unlock auto-disabled on drive-gear (0x229)`, and persists to NVS.

### Notes
- **One file** (`esp32/.firmware/main.cpp`), inside the existing `0x229` dispatch. The detent is decoded with the same `SIG_GEAR_LEVER_*` macros the surrounding code already uses; `state_enter → mutate → snapshot → state_exit → prefs_save` matches every other toggle.
- **Edge-triggered / no NVS thrash:** the write only happens on the `true→false` flip (guarded by `if(summon_unlock)`), so the streaming full-down detent can't hammer NVS.
- Placed **before** the HW3/Legacy Continuous-AP gate on purpose — Summon EU Unlock applies on HW3 **and** HW4, and that gate returns early on HW4, so the guard has to run first to cover both.
- ESP32-only, no protocol/UI change; the existing toggle stays and just gets turned off automatically. Flipper build out of scope.
- **Tests:** `make -C test check` green (518). The trigger lives in non-host-testable `main.cpp`; verified it compiles + links.

Separate heads-up (not part of this PR): on a fresh PlatformIO toolchain the unpinned `esp32-lilygo` env resolves Arduino-ESP32 3.x and overflows dram0 (~1768 bytes) — reproduces on `main`, independent of this change. The `esp32-generic-twai` env already pins `@6.9.0` to avoid exactly this. Worth pinning the other envs too in a separate infra PR.
