### PR TITLE
ci(esp32): pin all envs to espressif32@6.9.0 (prevent Arduino-ESP32 3.x DRAM overflow)

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -7,7 +7,7 @@ src_dir = .firmware
 extra_scripts = post:merge_firmware.py
 
 [env:m5stack-atom]
-platform = espressif32
+platform = espressif32@6.9.0
 board = m5stack-atom
 framework = arduino
 monitor_speed = 115200
@@ -20,7 +20,7 @@ lib_deps =
     Links2004/WebSockets@^2.4.0
 
 [env:m5stack-atom-matrix]
-platform = espressif32
+platform = espressif32@6.9.0
 board = m5stack-atom
 framework = arduino
 monitor_speed = 115200
@@ -40,7 +40,7 @@ lib_deps =
     Links2004/WebSockets@^2.4.0
 
 [env:m5stack-atom-swap-pins]
-platform = espressif32
+platform = espressif32@6.9.0
 board = m5stack-atom
 framework = arduino
 monitor_speed = 115200
@@ -94,7 +94,7 @@ lib_deps =
     Links2004/WebSockets@^2.4.0
 
 [env:esp32-mcp2515]
-platform = espressif32
+platform = espressif32@6.9.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
@@ -108,7 +108,7 @@ lib_deps =
     Links2004/WebSockets@^2.4.0
 
 [env:esp32-lilygo]
-platform = espressif32
+platform = espressif32@6.9.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
@@ -121,7 +121,7 @@ lib_deps =
     Links2004/WebSockets@^2.4.0
 
 [env:lilygo-t2can]
-platform = espressif32
+platform = espressif32@6.9.0
 board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
@@ -144,7 +144,7 @@ lib_deps =
     Links2004/WebSockets@^2.4.0
 
 [env:ttgo-tdisplay]
-platform = espressif32
+platform = espressif32@6.9.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
@@ -176,7 +176,7 @@ lib_deps =
     bodmer/TFT_eSPI@^2.5.43
 
 [env:waveshare-s3-can]
-platform = espressif32
+platform = espressif32@6.9.0
 board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
Pins every ESP32 env to `platform = espressif32@6.9.0`, matching the two envs (`esp32-generic-twai` / `-sniffer`) that were already pinned.

### Why
The other eight envs used a bare `platform = espressif32`, i.e. "resolve latest." On a current PlatformIO toolchain that now resolves **Arduino-ESP32 3.x**, which overflows `dram0` on the classic `esp32dev` board (`.dram0.bss overflowed by ~1768 bytes`) — a hard link failure. CI passes today only because its resolved/cached platform is still an older 2.x; the moment a runner or cache resolves 3.x, `esp32-lilygo`, `esp32-mcp2515`, `ttgo-tdisplay` and the M5 envs all break at once. This is the exact condition the `esp32-generic-twai` env already documents inline and pins around.

### Change
`platform = espressif32` → `platform = espressif32@6.9.0` on the 8 previously-unpinned envs. No source changes, no functional change — it just makes the toolchain deterministic on the known-good, lower-static-DRAM Arduino-ESP32 2.0.x.

### Verified
Built locally on a toolchain that was resolving 3.x:
- `esp32-lilygo` (classic ESP32, the one that was overflowing) → **SUCCESS** after the pin.
- `lilygo-t2can` (ESP32-S3) → **SUCCESS** (confirms 6.9.0 is fine for the S3 boards too).

CI will build all eight to confirm the rest.
