### PR TITLE
feat(esp32): surface controller rx_missed + capture mode (self-labeling captures)

### DIFF
--- a/esp32/.firmware/can_driver.cpp
+++ b/esp32/.firmware/can_driver.cpp
@@ -159,6 +159,12 @@ public:
 
     uint32_t rxCount() override { return rx_count_; }
 
+    uint32_t rxMissedCount() override {
+        twai_status_info_t info;
+        if (twai_get_status_info(&info) != ESP_OK) return 0;
+        return info.rx_missed_count;
+    }
+
     void setListenOnly(bool enable) override {
 #ifdef SNIFFER_ONLY
         (void)enable;   // sniffer build is permanently Listen-Only; ignore mode switches
@@ -346,6 +352,9 @@ public:
     uint32_t txCount() override { return tx_count_; }
 
     uint32_t rxCount() override { return rx_count_; }
+
+    // rxMissedCount(): use the CanDriver default (0). The MCP2515 overflow flag
+    // would need an extra SPI read on the hot path, so it is not surfaced here.
 
     void setListenOnly(bool enable) override {
         if (!installed_ || listen_only_ == enable) return;

--- a/esp32/.firmware/can_driver.h
+++ b/esp32/.firmware/can_driver.h
@@ -40,6 +40,11 @@ public:
     /** Cumulative count of frames received from the bus. */
     virtual uint32_t rxCount() = 0;
 
+    /** Cumulative count of frames the CONTROLLER dropped because its RX queue
+     *  overflowed (silent decimation of a busy bus). TWAI: twai_status_info_t
+     *  .rx_missed_count. Drivers without the metric return 0. */
+    virtual uint32_t rxMissedCount() { return 0; }
+
     /** Switch between listen-only and normal TX mode at runtime.
      *  Implementations must reinitialise the hardware as needed. */
     virtual void setListenOnly(bool enable) = 0;

--- a/esp32/.firmware/http_can_stream.cpp
+++ b/esp32/.firmware/http_can_stream.cpp
@@ -31,6 +31,9 @@ static uint32_t   g_filter_ids[HTTP_CAN_STREAM_MAX_FILTER_IDS];
 static uint8_t    g_filter_count = 0;
 static bool       g_bus_filter_enabled = false;
 static CanBusId   g_bus_filter = CAN_BUS_PRIMARY;
+static bool       g_meta_enabled = false;
+static uint32_t   g_rx_missed_now = 0;   // latest fed-in controller total
+static uint32_t   g_rx_missed_base = 0;  // snapshot at capture start
 
 static uint16_t ring_next(uint16_t index) {
     return (uint16_t)((index + 1u) % HTTP_CAN_STREAM_RING_SIZE);
@@ -62,6 +65,7 @@ static void stream_filter_reset() {
     g_filter_count = 0;
     g_bus_filter_enabled = false;
     g_bus_filter = CAN_BUS_PRIMARY;
+    g_meta_enabled = false;
 }
 
 static bool filter_matches(uint32_t id) {
@@ -185,6 +189,9 @@ static bool configure_filter_from_path(char *path) {
             if (!parse_filter(param + 4)) return false;
         } else if (strncmp(param, "bus=", 4) == 0) {
             if (!parse_bus_filter(param + 4)) return false;
+        } else if (strncmp(param, "meta=", 5) == 0) {
+            const char *v = param + 5;
+            g_meta_enabled = (strcmp(v, "1") == 0 || strcmp(v, "true") == 0);
         }
         param = next;
     }
@@ -192,6 +199,16 @@ static bool configure_filter_from_path(char *path) {
 }
 
 static void close_stream() {
+    // Opt-in (?meta=1) self-labeling footer — best-effort, before the socket is
+    // torn down and only while the client is still attached. #-prefixed so
+    // importers skip it. Ignore any write failure.
+    if (g_active && g_meta_enabled && g_client && g_client.connected()) {
+        g_client.printf("# end sent=%lu dropped=%lu filtered=%lu rx_missed_delta=%lu\r\n",
+                        (unsigned long)g_sent,
+                        (unsigned long)g_dropped,
+                        (unsigned long)g_filtered,
+                        (unsigned long)http_can_stream_rx_missed());
+    }
     if (g_client) {
         g_client.flush();
         g_client.stop();
@@ -233,10 +250,31 @@ static void begin_stream(WiFiClient &client) {
     g_client.print("X-Content-Type-Options: nosniff\r\n");
     g_client.print("Connection: close\r\n\r\n");
     g_active = true;
-    Serial.printf("[HTTP-CAN] Stream started on :%u/stream filter_ids=%u bus=%s\n",
+    g_rx_missed_base = g_rx_missed_now;
+
+    // Opt-in (?meta=1) self-labeling header. Emitted as a #-prefixed comment so
+    // candump/SavvyCAN importers skip it; the default path stays byte-identical.
+    if (g_meta_enabled) {
+        g_client.print("# capture ids=");
+        if (g_filter_count == 0) {
+            g_client.print("all");
+        } else {
+            for (uint8_t i = 0; i < g_filter_count; i++) {
+                if (i) g_client.print(",");
+                g_client.printf("%lX", (unsigned long)g_filter_ids[i]);
+            }
+        }
+        g_client.printf(" bus=%s mode=%s rx_missed_at_start=%lu\r\n",
+                        g_bus_filter_enabled ? can_bus_name(g_bus_filter) : "all",
+                        g_filter_count == 1 ? "single-id-hwfilter" : "all-id-decimated",
+                        (unsigned long)g_rx_missed_now);
+    }
+
+    Serial.printf("[HTTP-CAN] Stream started on :%u/stream filter_ids=%u bus=%s meta=%d\n",
                   HTTP_CAN_STREAM_PORT,
                   g_filter_count,
-                  g_bus_filter_enabled ? can_bus_name(g_bus_filter) : "all");
+                  g_bus_filter_enabled ? can_bus_name(g_bus_filter) : "all",
+                  g_meta_enabled ? 1 : 0);
 }
 
 static bool parse_request_path(WiFiClient &client, char *path, size_t path_len) {
@@ -286,12 +324,14 @@ static void accept_client() {
     memcpy(old_filter_ids, g_filter_ids, sizeof(old_filter_ids));
     bool old_bus_filter_enabled = g_bus_filter_enabled;
     CanBusId old_bus_filter = g_bus_filter;
+    bool old_meta_enabled = g_meta_enabled;
 
     if (!configure_filter_from_path(path)) {
         g_filter_count = old_filter_count;
         memcpy(g_filter_ids, old_filter_ids, sizeof(g_filter_ids));
         g_bus_filter_enabled = old_bus_filter_enabled;
         g_bus_filter = old_bus_filter;
+        g_meta_enabled = old_meta_enabled;
         send_response(incoming, 400, "Bad Request", "Invalid stream filter\n");
         return;
     }
@@ -301,6 +341,7 @@ static void accept_client() {
         memcpy(g_filter_ids, old_filter_ids, sizeof(g_filter_ids));
         g_bus_filter_enabled = old_bus_filter_enabled;
         g_bus_filter = old_bus_filter;
+        g_meta_enabled = old_meta_enabled;
         send_response(incoming, 404, "Not Found", "Not Found\n");
         return;
     }
@@ -455,4 +496,18 @@ uint32_t http_can_stream_frames_filtered() {
 
 uint16_t http_can_stream_buffered_frames() {
     return ring_count();
+}
+
+void http_can_stream_note_rx_missed(uint32_t total_rx_missed) {
+    g_rx_missed_now = total_rx_missed;
+}
+
+uint32_t http_can_stream_rx_missed(void) {
+    if (g_rx_missed_now < g_rx_missed_base) {
+        // Counter reset (e.g. driver reinstall after bus-off) — rebase and
+        // report 0 rather than underflowing the unsigned subtraction.
+        g_rx_missed_base = g_rx_missed_now;
+        return 0;
+    }
+    return g_rx_missed_now - g_rx_missed_base;
 }

--- a/esp32/.firmware/http_can_stream.h
+++ b/esp32/.firmware/http_can_stream.h
@@ -30,3 +30,15 @@ uint32_t http_can_stream_frames_sent();
 uint32_t http_can_stream_frames_dropped();
 uint32_t http_can_stream_frames_filtered();
 uint16_t http_can_stream_buffered_frames();
+
+/** Feed the module the running SUM of every installed controller's
+ *  rxMissedCount() (frames the CAN controller silently dropped on a full RX
+ *  queue). Call once per main-loop iteration; the stream snapshots this at
+ *  capture start so it can report a per-capture delta without holding driver
+ *  pointers. */
+void     http_can_stream_note_rx_missed(uint32_t total_rx_missed);
+
+/** Controller-level frames missed since the current capture began (delta of the
+ *  fed-in total against the value snapshotted at stream start). Returns 0 when a
+ *  counter reset would otherwise underflow the unsigned subtraction. */
+uint32_t http_can_stream_rx_missed(void);

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -1662,6 +1662,7 @@ void loop() {
     serial_command_tick();
 
     // Drain all available CAN frames in one shot
+    uint32_t rx_missed_total = 0;
     for (uint8_t i = 0; i < CAN_ACTIVE_BUS_COUNT; i++) {
         if (!g_can_ok[i] || !g_can[i]) continue;
         CanBusId bus = bus_id_from_index(i);
@@ -1673,7 +1674,12 @@ void loop() {
         g_can[i]->serviceHealth();
         // Bus-off just fired → arm a black-box capture via the event-core (#124).
         if (g_can[i]->busOffEvent()) blackbox_busoff(now);
+        // Controller-level silent-decimation counter for capture-fidelity labels.
+        rx_missed_total += g_can[i]->rxMissedCount();
     }
+    // Feed the summed controller RX-missed total to the web stream so a capture
+    // can self-report how many frames the hardware dropped while it ran.
+    http_can_stream_note_rx_missed(rx_missed_total);
 
     // ── Periodic error counter refresh (~every 250 ms) ────────────────────────
     static uint32_t last_err_ms = 0;

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -1056,7 +1056,7 @@ function upd(d){
   if(document.getElementById('httpLogBuf'))
     document.getElementById('httpLogBuf').textContent=((d.http_can_stream&&d.http_can_stream.buffered)||0)+' frames';
   if(document.getElementById('httpLogDrop'))
-    document.getElementById('httpLogDrop').textContent=((d.http_can_stream&&d.http_can_stream.dropped)||0)+' frames';
+    document.getElementById('httpLogDrop').textContent=((d.http_can_stream&&d.http_can_stream.dropped)||0)+' frames / rx-missed '+((d.http_can_stream&&d.http_can_stream.rx_missed)||0);
   if(document.getElementById('httpLogFiltered'))
     document.getElementById('httpLogFiltered').textContent=((d.http_can_stream&&d.http_can_stream.filtered)||0)+' frames';
 
@@ -1652,6 +1652,7 @@ static String build_json() {
     j += "\"active\":";       j += http_can_stream_active()           ? "true" : "false"; j += ',';
     j += "\"sent\":";         j += http_can_stream_frames_sent();      j += ',';
     j += "\"dropped\":";      j += http_can_stream_frames_dropped();   j += ',';
+    j += "\"rx_missed\":";    j += http_can_stream_rx_missed();        j += ',';
     j += "\"filtered\":";     j += http_can_stream_frames_filtered();  j += ',';
     j += "\"buffered\":";     j += http_can_stream_buffered_frames();  j += "},";
     j += "\"ota_partition\":"; j += ota_part;

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -340,6 +340,45 @@ pio device monitor -b 115200
 5. REST API available at `http://192.168.4.1/api/status`
 6. Raw CAN stream endpoint: `http://192.168.4.1:82/stream`
 
+### Capture fidelity — the two drop metrics
+
+A downloaded capture is only useful if you know whether it saw every frame. The
+stream reports two independent drop counters:
+
+- **`dropped`** (stream-ring) — frames the device received but could not push to
+  the WiFi client fast enough, so they fell out of the outbound ring buffer.
+- **`rx_missed`** (controller) — frames the CAN controller itself discarded
+  because its hardware RX queue was full before firmware ever read them. This is
+  the real *silent decimation* on a busy bus and is invisible in the frame data.
+
+Both appear in `GET /api/status` under `http_can_stream` and on the dashboard;
+`rx_missed` is a per-capture delta that resets when a new stream starts.
+
+Full-rate vs. decimated:
+
+- **All-ID capture** (`/stream`, no `?ids=`) — accept-all; on a busy bus the
+  controller RX queue overflows and the capture is **decimated**. Expect a
+  rising `rx_missed`.
+- **Single-ID capture** (`/stream?ids=<one id>`) — installs a **hardware
+  acceptance filter** for that id, so the controller only queues matching
+  frames = **full-rate** for that id. `?ids=` also accepts a comma list, and
+  `?bus=can0|can1` scopes to one controller.
+
+Self-labeling captures (`?meta=1`):
+
+Add `?meta=1` (e.g. `/stream?ids=39B&meta=1`) to bracket the capture with two
+`#`-prefixed comment lines that candump/SavvyCAN importers ignore:
+
+```
+# capture ids=39B bus=all mode=single-id-hwfilter rx_missed_at_start=0
+(0.001234) can0 39B#DEADBEEF...
+# end sent=1024 dropped=0 filtered=0 rx_missed_delta=0
+```
+
+`mode` is `single-id-hwfilter` when exactly one id filter is active, otherwise
+`all-id-decimated`. Without `?meta=1` the stream body is byte-for-byte identical
+to before, so existing tooling is unaffected.
+
 ---
 
 ## Safety


### PR DESCRIPTION
## What

Web-stream CAN captures now **self-label their fidelity**. Two independent drop metrics are exposed instead of one:

- **`dropped`** (existing) — stream-ring overflow: frames we saw but couldn't push to the WiFi client fast enough.
- **`rx_missed`** (new) — controller-level: frames the CAN controller silently discarded because its hardware RX queue was full. **This is the real decimation source on a busy all-ID capture**, and until now it was invisible — a downloaded log gave no hint whether it was full-rate or lossy.

## Why

All-ID web-stream captures are decimated at the TWAI RX queue (~2 Hz per ID on a busy bus) with no signal to the person analyzing the log. Single-ID `?ids=<one id>` installs a hardware acceptance filter and *is* full-rate. Without surfacing `rx_missed` + the capture mode, you can't tell recorder loss from bus behaviour — which silently corrupts counter/CRC cracking and any timing analysis.

## Changes

- `CanDriver::rxMissedCount()` — virtual, default 0; TWAI reads `twai_status_info_t.rx_missed_count`. MCP2515 keeps the default (its overflow flag would cost an SPI read on the hot path).
- `main` sums `rxMissedCount()` over installed buses each loop and feeds it to the stream, which reports a **per-capture delta** (underflow-guarded against a driver reinstall / bus-off counter reset).
- **Opt-in `?meta=1`** brackets the stream with `#`-prefixed header/footer comment lines carrying `ids`, `bus`, `mode=single-id-hwfilter|all-id-decimated`, and `rx_missed`. candump/SavvyCAN importers skip `#` lines, and **the default stream body is byte-identical to before** — no regression for existing consumers.
- Dashboard JSON gains `http_can_stream.rx_missed`; the UI shows it beside `dropped`.
- `esp32/README.md` documents the two drop metrics and the `?meta=1` self-labeling.

## Verification

Builds pass on both driver paths + S3:

| env | RAM | Flash |
|---|---|---|
| `esp32-generic-twai` (TWAI) | 37.5% | 47.8% |
| `esp32-mcp2515` (MCP2515) | 37.5% | 48.4% |
| `lilygo-t2can` (S3 dual-CAN) | 37.4% | 14.3% |

No behavioural change to injection or to the default capture output; the new metric is read-only and the header/footer is opt-in.
