### PR TITLE
docs: point the 14.x warning at the pinned FSD-on-14.x FAQ (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 - Pessimistic default: most users on 14.x firmware don't know they're affected until autosteer disengages mid-drive. The warning reaches them before they enable any TX feature.
 - Opt-out via the **On 14.x?** Settings toggle (Flipper) or the **Dismiss** button on the banner (ESP32, persisted in NVS). Disable if you are sure you're on pre-14.x firmware.
 - Regional caveat: enforcement intensity varies by market. Some regions (markets without Tesla direct presence) appear to enforce less aggressively. See [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122) for the running 14.x / 2026.20 tracker.
+- **"Does this unlock FSD on 2026.14.x / .20 / .26.x?"** Short answer: no — the activation preflight and an off-CAN region lock block it, while nag killer / TLSSC / Summon EU / captures still work. Full explanation in the pinned [FSD-on-14.x FAQ (#168)](https://github.com/hypery11/flipper-tesla-fsd/discussions/168), with the frame-level proof in [#163](https://github.com/hypery11/flipper-tesla-fsd/discussions/163).
 
 ### Diagnostics (read-only, no FSD required)
 - Live BMS dashboard: pack voltage, current, SoC, temperature range, **energy consumption (Wh/km)**

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -87,6 +87,7 @@
 - 悲观默认：大多数 14.x 固件用户要到自动转向在行驶中脱离时才知道自己受影响。这个警告会在他们启用任何 TX 功能之前先提醒到。
 - 可通过 **On 14.x?** 设置开关（Flipper）或横幅上的 **Dismiss** 按钮（ESP32，存在 NVS）退出。若你确定是 pre-14.x 固件就可关闭。
 - 地区注意：执法强度因市场而异。部分地区（没有 Tesla 直营的市场）似乎执法较不积极。14.x / 2026.20 的实时追踪见 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。
+- **「2026.14.x / .20 / .26.x 还能解锁 FSD 吗？」** 简短答案：不行——激活 preflight 加上链外区域锁挡住了,但 nag killer / TLSSC / Summon EU / 抓包仍可用。完整说明见置顶的 [FSD-on-14.x FAQ (#168)](https://github.com/hypery11/flipper-tesla-fsd/discussions/168),frame 级证明见 [#163](https://github.com/hypery11/flipper-tesla-fsd/discussions/163)。
 
 ### 诊断（只读，不需要 FSD）
 - BMS 实时仪表板：电池组电压、电流、SoC、温度范围、**能耗（Wh/km）**

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -87,6 +87,7 @@
 - 悲觀預設：大多數 14.x 韌體使用者要到自動轉向在行駛中脫離時才知道自己受影響。這個警告會在他們啟用任何 TX 功能之前先提醒到。
 - 可透過 **On 14.x?** 設定開關（Flipper）或橫幅上的 **Dismiss** 按鈕（ESP32，存在 NVS）退出。若你確定是 pre-14.x 韌體就可關閉。
 - 地區注意：執法強度因市場而異。部分地區（沒有 Tesla 直營的市場）似乎執法較不積極。14.x / 2026.20 的即時追蹤見 [#122](https://github.com/hypery11/flipper-tesla-fsd/issues/122)。
+- **「2026.14.x / .20 / .26.x 還能解鎖 FSD 嗎？」** 簡短答案：不行——啟用 preflight 加上鏈外區域鎖擋住了,但 nag killer / TLSSC / Summon EU / 擷取仍可用。完整說明見釘選的 [FSD-on-14.x FAQ (#168)](https://github.com/hypery11/flipper-tesla-fsd/discussions/168),frame 級證明見 [#163](https://github.com/hypery11/flipper-tesla-fsd/discussions/163)。
 
 ### 診斷（唯讀，不需要 FSD）
 - BMS 即時儀表板：電池組電壓、電流、SoC、溫度範圍、**能耗（Wh/km）**


### PR DESCRIPTION
Adds a one-line pointer in the **14.x firmware warning** section of all three READMEs (EN / zh-TW / zh-CN) to the new pinned FAQ #168 and the frame-level proof in #163.

This is the single most-recurring question in Issues/Discussions (#162, #164, #166, #2, …). Sending people to the canonical answer from the README cuts the repeated back-and-forth. No content change beyond the pointer.