### PR TITLE
feat(flipper): Signal Map preset picker (relocate DAS AP/hands-on read for nonstandard cars)

### DIFF
--- a/scenes/fsd_running.c
+++ b/scenes/fsd_running.c
@@ -158,6 +158,9 @@ static int32_t fsd_running_worker(void* context) {
     state.assist_show_lane_graph = app->assist_show_lane_graph;
     state.assist_tlssc_bit38 = app->assist_tlssc_bit38;
     state.assist_telemetry_off = app->assist_telemetry_off;
+    // DAS AP/hands-on read location preset (fsd_state_init cleared cfg_* on HW
+    // select, so re-apply the chosen mapping here).
+    signal_map_apply(&state, app->signal_map);
     furi_mutex_release(app->mutex);
 
     // Listen-only mode → MCP2515 hardware listen-only register
@@ -464,6 +467,13 @@ static int32_t fsd_running_worker(void* context) {
                         send_can_frame(mcp, &frame);
                     }
                 }
+
+                // Signal Map override: when a non-Auto preset is selected, relocate
+                // the DAS AP/hands-on read to the configured byte (per-car 0x39B/0x399
+                // layouts). No-op when cfg_das_id == 0. Runs after the standard
+                // parsers so the override wins; stamps das_ctx_seen_ms for the
+                // nag killer's freshness gate on the worker clock.
+                fsd_apply_signal_config(&state, &frame, now);
 
                 if((now - last_display) >= furi_ms_to_ticks(FSD_DISPLAY_REFRESH_MS)) {
                     furi_mutex_acquire(app->mutex, FuriWaitForever);

--- a/scenes/settings.c
+++ b/scenes/settings.c
@@ -166,6 +166,18 @@ static void telemetry_off_changed(VariableItem* item) {
     app->assist_telemetry_off = (idx == 1);
 }
 
+// DAS AP/hands-on read location. Order matches signal_map_apply() in the header.
+static const char* const signal_map_text[] = {
+    "Auto", "0x39B b0 (HW4)", "0x39B b1 (HW4)", "0x399 b0 (HW3)"};
+static void signal_map_changed(VariableItem* item) {
+    TeslaFSDApp* app = variable_item_get_context(item);
+    uint8_t idx = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, signal_map_text[idx]);
+    app->signal_map = idx;
+    // Reflect the choice in the live state so a re-entry shows the right value.
+    signal_map_apply(&app->fsd_state, idx);
+}
+
 static const char* const clock_text[] = {"16 MHz", "8 MHz", "12 MHz"};
 static void clock_changed(VariableItem* item) {
     TeslaFSDApp* app = variable_item_get_context(item);
@@ -214,6 +226,12 @@ void tesla_fsd_scene_settings_on_enter(void* context) {
     ADD_TOGGLE("Instant Engage (exp.)", ap_first_edge_changed, ap_first_edge)
     ADD_TOGGLE("Minimal Inject (exp.)", ap_first_minimal_changed, ap_first_minimal)
     ADD_TOGGLE("Soft Engage",      soft_engage_changed,      soft_engage)
+
+    // DAS AP/hands-on read location (per-car 0x39B/0x399 variants)
+    item = variable_item_list_add(list, "Signal Map", SIGNAL_MAP_COUNT, signal_map_changed, app);
+    variable_item_set_current_value_index(item, app->signal_map);
+    variable_item_set_current_value_text(item, signal_map_text[app->signal_map]);
+
     ADD_TOGGLE("Nag Burst (14.x)", nag_burst_changed,        nag_burst)
     ADD_TOGGLE("On 14.x?",         warning_14x_changed,      firmware_14x_warning)
     ADD_TOGGLE("GTW Cfg Replay",   shield_changed,           gtw_shield)

--- a/tesla_fsd_app.h
+++ b/tesla_fsd_app.h
@@ -84,6 +84,7 @@ typedef struct {
     bool precondition;       // periodic 0x082 inject for battery preheat
     OpMode op_mode;          // Active / ListenOnly / Service
     uint8_t mcp_clock;       // 0 = 16MHz (default), 1 = 8MHz
+    uint8_t signal_map;      // DAS AP/hands-on read location preset (see signal_map_apply)
     bool gtw_shield;         // 0x7FF GTW Config Replay — replay learned-healthy frames
     bool tlssc_restore;      // 0x331 DAS config spoof to restore TLSSC
     bool ap_first;           // 2026.14.x: delay injection until AP is engaged
@@ -123,3 +124,51 @@ typedef struct {
 TeslaFSDApp* tesla_fsd_app_alloc(void);
 void tesla_fsd_app_free(TeslaFSDApp* app);
 int32_t tesla_fsd_main(void* p);
+
+// Signal Map presets — where the nag/AP logic reads DAS_autopilotState and
+// DAS_handsOnState. Some cars carry the live state in a non-standard byte of
+// 0x39B/0x399, so let the owner relocate the read without a firmware fallback.
+// The configurable-mapping mechanism itself lives in the shared core
+// (cfg_das_id + fsd_apply_signal_config); this only picks a position.
+//   0 Auto           — cfg_das_id = 0, auto-detect (default)
+//   1 0x39B b0 (HW4) — live DAS state in byte0 low nibble (Juniper-style)
+//   2 0x39B b1 (HW4) — standard HW4 byte1 high nibble
+//   3 0x399 b0 (HW3) — HW3 / Legacy byte0 low nibble
+#define SIGNAL_MAP_COUNT 4
+
+static inline void signal_map_apply(FSDState* state, uint8_t idx) {
+    // handsOnState is byte5[5:2] low nibble on both 0x39B and 0x399.
+    state->cfg_handson_byte = 5;
+    state->cfg_handson_shift = 2;
+    state->cfg_handson_mask = 0x0F;
+    switch(idx) {
+    case 1: // 0x39B byte0 low nibble (live state on some HW4 cars)
+        state->cfg_das_id = 0x39B;
+        state->cfg_apstate_byte = 0;
+        state->cfg_apstate_shift = 0;
+        state->cfg_apstate_mask = 0x0F;
+        break;
+    case 2: // 0x39B byte1 high nibble (standard HW4)
+        state->cfg_das_id = 0x39B;
+        state->cfg_apstate_byte = 1;
+        state->cfg_apstate_shift = 4;
+        state->cfg_apstate_mask = 0x0F;
+        break;
+    case 3: // 0x399 byte0 low nibble (HW3 / Legacy)
+        state->cfg_das_id = 0x399;
+        state->cfg_apstate_byte = 0;
+        state->cfg_apstate_shift = 0;
+        state->cfg_apstate_mask = 0x0F;
+        break;
+    default: // 0 = Auto: cfg_das_id == 0 disables the override
+        state->cfg_das_id = 0;
+        state->cfg_apstate_byte = 0;
+        state->cfg_apstate_shift = 0;
+        state->cfg_apstate_mask = 0x0F;
+        state->cfg_handson_byte = 0;
+        state->cfg_handson_shift = 0;
+        state->cfg_handson_mask = 0x0F;
+        break;
+    }
+    // cfg_steer_* stay on auto (untouched) for every preset.
+}


### PR DESCRIPTION
## What

Adds a **Signal Map** picker to the Flipper Settings scene — a 4-option preset that relocates where the nag / AP logic reads `DAS_autopilotState` + `DAS_handsOnState`, for cars whose `0x39B` / `0x399` layout is nonstandard.

| Preset | DAS id | AP-state read | hands-on read |
|---|---|---|---|
| **Auto** (default) | — | auto-detect (`cfg_das_id = 0`) | — |
| **0x39B b0 (HW4)** | 0x39B | byte0 low nibble (live DAS state on Juniper-style HW4) | byte5[5:2] |
| **0x39B b1 (HW4)** | 0x39B | byte1 high nibble (standard HW4) | byte5[5:2] |
| **0x399 b0 (HW3)** | 0x399 | byte0 low nibble (HW3 / Legacy) | byte5[5:2] |

## Why

The configurable-signal-mapping mechanism (`cfg_das_id` + `fsd_apply_signal_config()` + the `fsd_das_ctx_fresh()` freshness gate) has been in the shared core since #122 and is exposed on the ESP32 dashboard, but the **Flipper had no way to reach it** — so cars like the HW4 Highland/Juniper variants that carry the live AP-state in a non-standard byte (see #122 / #163) could not have their read relocated on the Flipper, and the nag/AP-First gate stayed stuck. The Flipper has no free-form numeric entry, so this exposes it as a small preset list (the right idiom) covering every layout we've actually seen. When the mapping is wrong or the source frame is absent, the freshness gate already fails to a clean no-op rather than misbehaving.

## Notes

- The Flipper worker did not actually **call** `fsd_apply_signal_config()` (only the ESP32 side did), so the picker would have been dead UI. This wires it in `fsd_running.c` after the standard per-ID parsers (so the override wins) on the worker's `furi_get_tick()` clock — the same domain as the freshness gate. No `fsd_logic/` changes.
- `signal_map_apply()` is a single `static inline` in `tesla_fsd_app.h` used by both the settings callback and the worker, so the 4 tuples have one source of truth. It is re-applied at worker start because `fsd_state_init()` memsets `cfg_*` during HW selection.
- Steering mapping stays on auto for every preset. Default is **Auto**, so existing behaviour is unchanged unless the owner picks a preset.

## Verification

`ufbt` build succeeds — APPCHK passes, `tesla_mod.fap` produced (Target 7, API 87.1), clean compile of all touched TUs.
