### PR TITLE
feat(esp32): add summon brake safety and unified web controls #173

### DIFF
--- a/esp32/.firmware/can_signals.h
+++ b/esp32/.firmware/can_signals.h
@@ -173,6 +173,16 @@
 #define SIG_GEAR_LEVER_COUNTER_BYTE         1
 #define SIG_GEAR_LEVER_COUNTER_MASK      0x0Fu
 
+// DI_systemStatus (0x118), little-endian:
+// DI_gear: bit21|3 (accepted/current gear, not a shift request).
+#define SIG_DI_GEAR_BYTE                     2
+#define SIG_DI_GEAR_SHIFT                    5
+#define SIG_DI_GEAR_MASK                  0x07u
+#define SIG_DI_GEAR_PARK                     1u
+#define SIG_DI_GEAR_REVERSE                  2u
+#define SIG_DI_GEAR_NEUTRAL                  3u
+#define SIG_DI_GEAR_DRIVE                    4u
+
 // VCFRONT_lighting (0x3F5), little-endian:
 //   indicatorLeftRequest: bit0|2, indicatorRightRequest: bit2|2.
 //   0=off, 1=active low, 2=active high.

--- a/esp32/.firmware/can_signals.h
+++ b/esp32/.firmware/can_signals.h
@@ -175,6 +175,7 @@
 
 // DI_systemStatus (0x118), little-endian:
 // DI_gear: bit21|3 (accepted/current gear, not a shift request).
+// DI_accelPedalPos: bit32|8, 0.4% per bit, 0xFF=SNA.
 #define SIG_DI_GEAR_BYTE                     2
 #define SIG_DI_GEAR_SHIFT                    5
 #define SIG_DI_GEAR_MASK                  0x07u
@@ -182,6 +183,8 @@
 #define SIG_DI_GEAR_REVERSE                  2u
 #define SIG_DI_GEAR_NEUTRAL                  3u
 #define SIG_DI_GEAR_DRIVE                    4u
+#define SIG_DI_ACCEL_PEDAL_BYTE              4
+#define SIG_DI_ACCEL_PEDAL_SNA            0xFFu
 
 // VCFRONT_lighting (0x3F5), little-endian:
 //   indicatorLeftRequest: bit0|2, indicatorRightRequest: bit2|2.

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -2,6 +2,7 @@
 
 // ── CAN IDs ───────────────────────────────────────────────────────────────────
 #define CAN_ID_STW_ACTN_RQ    0x045u  // 69   - STW_ACTN_RQ:  steering stalk (Legacy follow distance)
+#define CAN_ID_DI_SYSTEM      0x118u  // 280  - DI_systemStatus: accepted vehicle gear
 #define CAN_ID_TRIP_PLANNING  0x082u  // 130  - UI_tripPlanning: precondition trigger
 #define CAN_ID_ESP_STATUS     0x145u  // 325  - ESP_status: driver brake pedal state
 #define CAN_ID_STEER_ANGLE    0x129u  // 297  - SCCM_steeringAngleSensor (Soft Engage gate, #108)
@@ -10,6 +11,7 @@
 #define CAN_ID_BMS_THERMAL    0x312u  // 786  - BMS_thermalStatus: battery temp
 #define CAN_ID_GTW_CAR_STATE  0x318u  // 792  - GTW_carState:    OTA detection
 #define CAN_ID_UI_MAP_DATA    0x238u  // 568  - UI_driverAssistMapData: map speed limit
+#define CAN_ID_DI_SPEED       0x257u  // 599  - DI_speed: vehicle speed / UI speed
 #define CAN_ID_SCCM_RSTALK    0x229u  // 553  - GearLever / right stalk
 #define CAN_ID_DAS_CONTROL    0x2B9u  // 697  - DAS_control: cruise set speed / ACC state
 #define CAN_ID_DAS_STATUS2    0x389u  // 905  - DAS_status2: ACC speed limit

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -2,8 +2,8 @@
 
 // ── CAN IDs ───────────────────────────────────────────────────────────────────
 #define CAN_ID_STW_ACTN_RQ    0x045u  // 69   - STW_ACTN_RQ:  steering stalk (Legacy follow distance)
-#define CAN_ID_DI_TORQUE      0x108u  // 264  - DI_torque: drive motor torque / accelerator state
-#define CAN_ID_DI_SYSTEM      0x118u  // 280  - DI_systemStatus: accepted vehicle gear
+#define CAN_ID_DI_TORQUE      0x108u  // 264  - DI_torque: drive motor torque telemetry
+#define CAN_ID_DI_SYSTEM      0x118u  // 280  - DI_systemStatus: gear / accelerator pedal
 #define CAN_ID_TRIP_PLANNING  0x082u  // 130  - UI_tripPlanning: precondition trigger
 #define CAN_ID_ESP_STATUS     0x145u  // 325  - ESP_status: driver brake pedal state
 #define CAN_ID_STEER_ANGLE    0x129u  // 297  - SCCM_steeringAngleSensor (Soft Engage gate, #108)

--- a/esp32/.firmware/config.h
+++ b/esp32/.firmware/config.h
@@ -2,6 +2,7 @@
 
 // ── CAN IDs ───────────────────────────────────────────────────────────────────
 #define CAN_ID_STW_ACTN_RQ    0x045u  // 69   - STW_ACTN_RQ:  steering stalk (Legacy follow distance)
+#define CAN_ID_DI_TORQUE      0x108u  // 264  - DI_torque: drive motor torque / accelerator state
 #define CAN_ID_DI_SYSTEM      0x118u  // 280  - DI_systemStatus: accepted vehicle gear
 #define CAN_ID_TRIP_PLANNING  0x082u  // 130  - UI_tripPlanning: precondition trigger
 #define CAN_ID_ESP_STATUS     0x145u  // 325  - ESP_status: driver brake pedal state

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -47,6 +47,10 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->ignore_ota           = false;
     state->emergency_vehicle_detect = false;
     state->summon_unlock        = false;    // opt-in Summon EU Unlock, default OFF
+    state->summon_auto_control  = SummonAutoControl_BrakeTemporary;
+    state->summon_temp_disabled = false;
+    state->summon_temp_recovery_armed = false;
+    state->summon_temp_disabled_ms = 0;
     state->apmv3_branch         = 0xFF;      // opt-in AP branch/tier selector, default OFF (0xFF sentinel)
     state->assist_tlssc_bit38   = false;    // opt-in TLSSC bit38 explicit enable, default OFF
     state->continue_on_green    = false;    // opt-in Continue on Green, default OFF
@@ -280,6 +284,7 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
     uint8_t mux     = read_mux_id(frame);
     bool    fsd_ui  = is_fsd_selected(frame, state->force_fsd, state->china_mode);
     bool    modified = false;
+    bool    summon_active = state->summon_unlock && !state->summon_temp_disabled;
 
     // mux 0 is the authoritative "is FSD requested" mux
     if (mux == CAN_MUX_0) state->fsd_enabled = fsd_ui;
@@ -320,7 +325,7 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             modified = true;
         }
         if (mux == CAN_MUX_1 &&
-            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off ||
+            (state->nag_killer || summon_active || state->assist_telemetry_off ||
              state->apmv3_branch <= 5)) {
             if (state->nag_killer) {
                 // Nag suppression via bit 19 (clear = no hands-on-wheel request)
@@ -328,7 +333,7 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
                 state->nag_suppressed = true;
                 modified = true;
             }
-            if (state->summon_unlock) {
+            if (summon_active) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);       // bit19 EU restriction clear
                 set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true);  // bit47 summon enable
                 modified = true;
@@ -371,7 +376,7 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
             modified = true;
         }
         if (mux == CAN_MUX_1 &&
-            (state->nag_killer || state->summon_unlock || state->assist_telemetry_off ||
+            (state->nag_killer || summon_active || state->assist_telemetry_off ||
              state->apmv3_branch <= 5)) {
             if (state->nag_killer) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);      // clear hands-on-wheel nag
@@ -379,7 +384,7 @@ bool fsd_handle_autopilot_frame(FSDState *state, CanFrame *frame) {
                 state->nag_suppressed = true;
                 modified = true;
             }
-            if (state->summon_unlock) {
+            if (summon_active) {
                 set_bit(frame, SIG_AP_NAG_CLEAR_BIT, false);       // bit19 EU restriction clear
                 set_bit(frame, SIG_AP_HW4_NAG_CONFIRM_BIT, true);  // bit47 summon enable
                 modified = true;
@@ -796,6 +801,15 @@ void fsd_handle_esp_status(FSDState *state, const CanFrame *frame) {
     state->brake_status_seen = true;
 }
 
+void fsd_handle_di_speed(FSDState *state, const CanFrame *frame) {
+    if (frame->dlc < 4) return;
+    uint16_t raw = ((uint16_t)frame->data[2] << 4) | (frame->data[1] >> 4);
+    state->vehicle_speed_kph = (float)raw * 0.08f - 40.0f;
+    if (state->vehicle_speed_kph < 0.0f) state->vehicle_speed_kph = 0.0f;
+    state->ui_speed = frame->data[3];
+    state->speed_seen = true;
+}
+
 // ── BMS read-only parsers ─────────────────────────────────────────────────────
 
 void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame) {
@@ -1019,6 +1033,13 @@ void fsd_handle_gear_lever(FSDState *state, const CanFrame *frame, uint32_t now_
         best_pos = gear_stronger_pos(best_pos, pos);
     }
     last_seen_ms = now_ms;
+}
+
+void fsd_handle_di_system(FSDState *state, const CanFrame *frame) {
+    if (frame->dlc <= SIG_DI_GEAR_BYTE) return;
+    state->vehicle_gear =
+        (frame->data[SIG_DI_GEAR_BYTE] >> SIG_DI_GEAR_SHIFT) & SIG_DI_GEAR_MASK;
+    state->vehicle_gear_seen = true;
 }
 
 void fsd_handle_ui_map_data(FSDState *state, const CanFrame *frame, uint32_t now_ms) {

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -802,33 +802,17 @@ void fsd_handle_esp_status(FSDState *state, const CanFrame *frame) {
 }
 
 void fsd_handle_di_torque(FSDState *state, const CanFrame *frame) {
-    if (frame->dlc < 2) return;
-    uint16_t raw = ((uint16_t)(frame->data[1] & 0x1Fu) << 8) | frame->data[0];
-    state->di_torque_nm = (float)raw * 0.25f - 750.0f;
+    if (frame->dlc < 5) return;
+    uint16_t raw = ((uint16_t)frame->data[3] >> 3) |
+                   ((uint16_t)frame->data[4] << 5);
+    int16_t signed_raw = (raw & 0x1000u) ? (int16_t)(raw | 0xE000u) : (int16_t)raw;
+    if (signed_raw == -4096) return;
+    state->di_torque_nm = (float)signed_raw * 2.0f;
     state->di_torque_seen = true;
-
-    if (state->di_torque_nm > DI_PEDAL_PRESS_TORQUE_NM) {
-        state->accelerator_release_count = 0;
-        if (!state->accelerator_pressed &&
-            ++state->accelerator_press_count >= DI_PEDAL_DEBOUNCE_FRAMES) {
-            state->accelerator_pressed = true;
-            state->accelerator_press_count = 0;
-        }
-    } else if (state->di_torque_nm < DI_PEDAL_RELEASE_TORQUE_NM) {
-        state->accelerator_press_count = 0;
-        if (state->accelerator_pressed &&
-            ++state->accelerator_release_count >= DI_PEDAL_DEBOUNCE_FRAMES) {
-            state->accelerator_pressed = false;
-            state->accelerator_release_count = 0;
-        }
-    } else {
-        state->accelerator_press_count = 0;
-        state->accelerator_release_count = 0;
-    }
 }
 
 bool fsd_accelerator_pressed(const FSDState *state) {
-    return state->di_torque_seen && state->accelerator_pressed;
+    return state->accelerator_pedal_seen && state->accelerator_pressed;
 }
 
 bool fsd_speed_chime_suppression_active(const FSDState *state) {
@@ -1079,6 +1063,31 @@ void fsd_handle_di_system(FSDState *state, const CanFrame *frame) {
     state->vehicle_gear =
         (frame->data[SIG_DI_GEAR_BYTE] >> SIG_DI_GEAR_SHIFT) & SIG_DI_GEAR_MASK;
     state->vehicle_gear_seen = true;
+
+    if (frame->dlc <= SIG_DI_ACCEL_PEDAL_BYTE) return;
+    uint8_t pedal_raw = frame->data[SIG_DI_ACCEL_PEDAL_BYTE];
+    if (pedal_raw == SIG_DI_ACCEL_PEDAL_SNA) return;
+
+    state->accelerator_pedal_percent = (float)pedal_raw * 0.4f;
+    state->accelerator_pedal_seen = true;
+    if (pedal_raw >= DI_PEDAL_PRESS_RAW) {
+        state->accelerator_release_count = 0;
+        if (!state->accelerator_pressed &&
+            ++state->accelerator_press_count >= DI_PEDAL_DEBOUNCE_FRAMES) {
+            state->accelerator_pressed = true;
+            state->accelerator_press_count = 0;
+        }
+    } else if (pedal_raw <= DI_PEDAL_RELEASE_RAW) {
+        state->accelerator_press_count = 0;
+        if (state->accelerator_pressed &&
+            ++state->accelerator_release_count >= DI_PEDAL_DEBOUNCE_FRAMES) {
+            state->accelerator_pressed = false;
+            state->accelerator_release_count = 0;
+        }
+    } else {
+        state->accelerator_press_count = 0;
+        state->accelerator_release_count = 0;
+    }
 }
 
 void fsd_handle_ui_map_data(FSDState *state, const CanFrame *frame, uint32_t now_ms) {

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -806,11 +806,29 @@ void fsd_handle_di_torque(FSDState *state, const CanFrame *frame) {
     uint16_t raw = ((uint16_t)(frame->data[1] & 0x1Fu) << 8) | frame->data[0];
     state->di_torque_nm = (float)raw * 0.25f - 750.0f;
     state->di_torque_seen = true;
+
+    if (state->di_torque_nm > DI_PEDAL_PRESS_TORQUE_NM) {
+        state->accelerator_release_count = 0;
+        if (!state->accelerator_pressed &&
+            ++state->accelerator_press_count >= DI_PEDAL_DEBOUNCE_FRAMES) {
+            state->accelerator_pressed = true;
+            state->accelerator_press_count = 0;
+        }
+    } else if (state->di_torque_nm < DI_PEDAL_RELEASE_TORQUE_NM) {
+        state->accelerator_press_count = 0;
+        if (state->accelerator_pressed &&
+            ++state->accelerator_release_count >= DI_PEDAL_DEBOUNCE_FRAMES) {
+            state->accelerator_pressed = false;
+            state->accelerator_release_count = 0;
+        }
+    } else {
+        state->accelerator_press_count = 0;
+        state->accelerator_release_count = 0;
+    }
 }
 
 bool fsd_accelerator_pressed(const FSDState *state) {
-    return state->di_torque_seen &&
-           state->di_torque_nm > DI_PEDAL_PRESSED_TORQUE_NM;
+    return state->di_torque_seen && state->accelerator_pressed;
 }
 
 bool fsd_speed_chime_suppression_active(const FSDState *state) {

--- a/esp32/.firmware/fsd_handler.cpp
+++ b/esp32/.firmware/fsd_handler.cpp
@@ -47,7 +47,7 @@ void fsd_state_init(FSDState *state, TeslaHWVersion hw) {
     state->ignore_ota           = false;
     state->emergency_vehicle_detect = false;
     state->summon_unlock        = false;    // opt-in Summon EU Unlock, default OFF
-    state->summon_auto_control  = SummonAutoControl_BrakeTemporary;
+    state->summon_auto_control  = SummonAutoControl_AcceleratorTemporary;
     state->summon_temp_disabled = false;
     state->summon_temp_recovery_armed = false;
     state->summon_temp_disabled_ms = 0;
@@ -799,6 +799,27 @@ void fsd_handle_esp_status(FSDState *state, const CanFrame *frame) {
         SIG_ESP_DRIVER_BRAKE_MASK;
     state->driver_brake_applied = brake >= SIG_ESP_DRIVER_BRAKE_APPLYING;
     state->brake_status_seen = true;
+}
+
+void fsd_handle_di_torque(FSDState *state, const CanFrame *frame) {
+    if (frame->dlc < 2) return;
+    uint16_t raw = ((uint16_t)(frame->data[1] & 0x1Fu) << 8) | frame->data[0];
+    state->di_torque_nm = (float)raw * 0.25f - 750.0f;
+    state->di_torque_seen = true;
+}
+
+bool fsd_accelerator_pressed(const FSDState *state) {
+    return state->di_torque_seen &&
+           state->di_torque_nm > DI_PEDAL_PRESSED_TORQUE_NM;
+}
+
+bool fsd_speed_chime_suppression_active(const FSDState *state) {
+    if (state->summon_unlock &&
+        state->summon_auto_control == SummonAutoControl_AcceleratorTemporary &&
+        state->suppress_speed_chime) {
+        return state->summon_temp_disabled;
+    }
+    return state->suppress_speed_chime;
 }
 
 void fsd_handle_di_speed(FSDState *state, const CanFrame *frame) {

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -141,6 +141,9 @@ void fsd_handle_epas_status(FSDState *state, const CanFrame *frame);
 /** Parse ESP_status (0x145) brake pedal state. */
 void fsd_handle_esp_status(FSDState *state, const CanFrame *frame);
 
+/** Parse DI_speed (0x257) vehicle and UI speed. */
+void fsd_handle_di_speed(FSDState *state, const CanFrame *frame);
+
 /** Parse BMS_hvBusStatus (0x132) — updates pack_voltage_v / pack_current_a. */
 void fsd_handle_bms_hv(FSDState *state, const CanFrame *frame);
 
@@ -171,6 +174,9 @@ void fsd_handle_das_handsonly_399(FSDState *state, const CanFrame *frame);
 
 /** Parse GearLever / right stalk 0x229 for right-stalk detents. */
 void fsd_handle_gear_lever(FSDState *state, const CanFrame *frame, uint32_t now_ms);
+
+/** Parse the accepted vehicle gear from DI_systemStatus (0x118). */
+void fsd_handle_di_system(FSDState *state, const CanFrame *frame);
 
 /** Parse UI_driverAssistMapData 0x238 map/location speed limit. */
 void fsd_handle_ui_map_data(FSDState *state, const CanFrame *frame, uint32_t now_ms);

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -144,11 +144,11 @@ void fsd_handle_esp_status(FSDState *state, const CanFrame *frame);
 /** Parse DI_torque (0x108) drive motor torque. */
 void fsd_handle_di_torque(FSDState *state, const CanFrame *frame);
 
-#define DI_PEDAL_PRESS_TORQUE_NM    8.0f
-#define DI_PEDAL_RELEASE_TORQUE_NM  3.0f
-#define DI_PEDAL_DEBOUNCE_FRAMES    3u
+#define DI_PEDAL_PRESS_RAW           3u
+#define DI_PEDAL_RELEASE_RAW         1u
+#define DI_PEDAL_DEBOUNCE_FRAMES     3u
 
-/** True once DI_torque is available and indicates accelerator demand. */
+/** True once DI_accelPedalPos is available and indicates pedal demand. */
 bool fsd_accelerator_pressed(const FSDState *state);
 
 /** Effective (possibly temporary) chime suppression state. */
@@ -188,7 +188,7 @@ void fsd_handle_das_handsonly_399(FSDState *state, const CanFrame *frame);
 /** Parse GearLever / right stalk 0x229 for right-stalk detents. */
 void fsd_handle_gear_lever(FSDState *state, const CanFrame *frame, uint32_t now_ms);
 
-/** Parse the accepted vehicle gear from DI_systemStatus (0x118). */
+/** Parse accepted gear and accelerator position from DI_systemStatus (0x118). */
 void fsd_handle_di_system(FSDState *state, const CanFrame *frame);
 
 /** Parse UI_driverAssistMapData 0x238 map/location speed limit. */

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -144,7 +144,9 @@ void fsd_handle_esp_status(FSDState *state, const CanFrame *frame);
 /** Parse DI_torque (0x108) drive motor torque. */
 void fsd_handle_di_torque(FSDState *state, const CanFrame *frame);
 
-#define DI_PEDAL_PRESSED_TORQUE_NM 5.0f
+#define DI_PEDAL_PRESS_TORQUE_NM    8.0f
+#define DI_PEDAL_RELEASE_TORQUE_NM  3.0f
+#define DI_PEDAL_DEBOUNCE_FRAMES    3u
 
 /** True once DI_torque is available and indicates accelerator demand. */
 bool fsd_accelerator_pressed(const FSDState *state);

--- a/esp32/.firmware/fsd_handler.h
+++ b/esp32/.firmware/fsd_handler.h
@@ -141,6 +141,17 @@ void fsd_handle_epas_status(FSDState *state, const CanFrame *frame);
 /** Parse ESP_status (0x145) brake pedal state. */
 void fsd_handle_esp_status(FSDState *state, const CanFrame *frame);
 
+/** Parse DI_torque (0x108) drive motor torque. */
+void fsd_handle_di_torque(FSDState *state, const CanFrame *frame);
+
+#define DI_PEDAL_PRESSED_TORQUE_NM 5.0f
+
+/** True once DI_torque is available and indicates accelerator demand. */
+bool fsd_accelerator_pressed(const FSDState *state);
+
+/** Effective (possibly temporary) chime suppression state. */
+bool fsd_speed_chime_suppression_active(const FSDState *state);
+
 /** Parse DI_speed (0x257) vehicle and UI speed. */
 void fsd_handle_di_speed(FSDState *state, const CanFrame *frame);
 

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -110,8 +110,8 @@ static bool serial_cmd_equals(const char *cmd, const char *expected) {
 }
 
 static void serial_command_tick() {
-    static char buf[24];
-    static uint8_t len = 0;
+    static char buf[320];
+    static size_t len = 0;
 
     while (Serial.available() > 0) {
         char c = (char)Serial.read();
@@ -122,10 +122,13 @@ static void serial_command_tick() {
 
             if (serial_cmd_equals(buf, "ip") || serial_cmd_equals(buf, "wifi")) {
                 wifi_print_status();
+            } else if (web_dashboard_handle_serial_json(buf)) {
+                // JSON lines are handled by the dashboard command path so USB
+                // Web Serial can act as a backup control channel.
             } else if (serial_cmd_equals(buf, "help") || serial_cmd_equals(buf, "?")) {
-                Serial.println("[SER] Commands: ip");
+                Serial.println("[SER] Commands: ip, {\"cmd\":\"...\",\"value\":...}");
             } else {
-                Serial.println("[SER] Unknown command. Type: ip");
+                Serial.println("[SER] Unknown command. Type: ip or JSON command");
             }
             continue;
         }
@@ -1188,38 +1191,20 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
 
     // ── Continuous AP HW3/Legacy state parsers (read-only, always) ──────────
     if (frame.id == CAN_ID_SCCM_RSTALK) {
-        // Safety guard (#160): auto-disable Summon EU Unlock when the driver
-        // shifts into drive (0x229 gear lever full-down / D detent), so a
-        // leftover Summon override can't interfere with normal AP. Runs before
-        // the HW3/Legacy Continuous-AP gate below because Summon EU Unlock
-        // applies on HW3 + HW4, and that gate returns early on HW4. Edge-
-        // triggered by the summon_unlock==true guard: NVS is written only on the
-        // true→false flip, so repeated full-down 0x229 frames can't thrash NVS.
+        uint32_t now_ms = millis();
         if (frame.dlc > SIG_GEAR_LEVER_POS_BYTE) {
             uint8_t detent =
                 (frame.data[SIG_GEAR_LEVER_POS_BYTE] >> SIG_GEAR_LEVER_POS_SHIFT) &
                 SIG_GEAR_LEVER_POS_MASK;
-            if (detent == SIG_GEAR_LEVER_FULL_DOWN) {
-                FSDState saved;
-                bool disabled = false;
-                state_enter();
-                if (g_state.summon_unlock) {
-                    g_state.summon_unlock = false;
-                    saved = g_state;
-                    disabled = true;
-                }
-                state_exit();
-                if (disabled) {
-                    Serial.println("[SAFETY] Summon EU Unlock auto-disabled on drive-gear (0x229)");
-                    can_dump_log("[SAFETY] Summon EU Unlock auto-disabled on drive-gear (0x229)");
-                    prefs_save(&saved);
-                }
-            }
+            state_enter();
+            g_state.gear_lever_last_pos = detent;
+            g_state.gear_lever_seen = true;
+            g_state.gear_lever_last_ms = now_ms;
+            state_exit();
         }
 
         FSDState s = state_snapshot();
         if (s.hw_version != TeslaHW_HW3 && s.hw_version != TeslaHW_Legacy) return;
-        uint32_t now_ms = millis();
         if (frame.dlc > SIG_GEAR_LEVER_POS_BYTE) {
             uint8_t gear_pos =
                 (frame.data[SIG_GEAR_LEVER_POS_BYTE] >> SIG_GEAR_LEVER_POS_SHIFT) &
@@ -1237,10 +1222,16 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
         }
         state_exit();
         if (frame.dlc > SIG_GEAR_LEVER_COUNTER_BYTE) {
-            g_last_gear_counter =
+            uint8_t counter =
                 frame.data[SIG_GEAR_LEVER_COUNTER_BYTE] & SIG_GEAR_LEVER_COUNTER_MASK;
+            g_last_gear_counter = counter;
             g_last_gear_counter_valid = true;
             g_last_gear_counter_ms = now_ms;
+            state_enter();
+            g_state.gear_lever_last_counter = counter;
+            g_state.gear_lever_counter_seen = true;
+            g_state.gear_lever_last_ms = now_ms;
+            state_exit();
         }
         if (frame.dlc > SIG_GEAR_LEVER_COUNTER_BYTE) {
             if (gear_sequence_active() && fsd_can_transmit(&s)) gear_sequence_tick(now_ms, "CONT-AP");
@@ -1265,6 +1256,22 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
         state_exit();
         return;
     }
+    if (frame.id == CAN_ID_DI_SYSTEM) {
+        state_enter();
+        fsd_handle_di_system(&g_state, &frame);
+        if (g_state.summon_temp_disabled && g_state.vehicle_gear_seen &&
+            g_state.vehicle_gear != SIG_DI_GEAR_PARK) {
+            g_state.summon_temp_recovery_armed = true;
+        }
+        state_exit();
+        return;
+    }
+    if (frame.id == CAN_ID_DI_SPEED) {
+        state_enter();
+        fsd_handle_di_speed(&g_state, &frame);
+        state_exit();
+        return;
+    }
     if (frame.id == CAN_ID_VCFRONT_LIGHT) {
         state_enter();
         fsd_handle_vcfront_lighting(&g_state, &frame);
@@ -1273,10 +1280,37 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
     }
     if (frame.id == CAN_ID_ESP_STATUS) {
         uint32_t now_ms = millis();
+        bool summon_temp_disabled = false;
+        bool summon_temp_restored = false;
         state_enter();
+        bool brake_was_seen = g_state.brake_status_seen;
+        bool brake_was_applied = g_state.driver_brake_applied;
+        bool summon_was_temp_disabled = g_state.summon_temp_disabled;
         fsd_handle_esp_status(&g_state, &frame);
         if (g_state.driver_brake_applied) g_cont_ap_last_brake_ms = now_ms;
+        if (g_state.summon_auto_control == SummonAutoControl_BrakeTemporary &&
+            brake_was_seen &&
+            !brake_was_applied && g_state.driver_brake_applied) {
+            if (g_state.summon_unlock && summon_was_temp_disabled &&
+                g_state.vehicle_gear_seen &&
+                g_state.vehicle_gear == SIG_DI_GEAR_PARK &&
+                g_state.summon_temp_recovery_armed) {
+                g_state.summon_temp_disabled = false;
+                g_state.summon_temp_recovery_armed = false;
+                g_state.summon_temp_disabled_ms = 0;
+                summon_temp_restored = true;
+            } else if (g_state.summon_unlock && !summon_was_temp_disabled) {
+                g_state.summon_temp_disabled = true;
+                g_state.summon_temp_recovery_armed = false;
+                g_state.summon_temp_disabled_ms = now_ms;
+                summon_temp_disabled = true;
+            }
+        }
         state_exit();
+        if (summon_temp_disabled)
+            Serial.println("[SAFETY] Summon EU Unlock temporarily disabled on brake apply");
+        else if (summon_temp_restored)
+            Serial.println("[SAFETY] Summon EU Unlock restored by parked brake apply");
         return;
     }
     // Steering angle (0x129) — read-only, feeds the Soft Engage gate (#108).
@@ -1636,6 +1670,10 @@ void setup() {
     Serial.println("[BTN] Long press 3s: toggle NAG Killer");
     Serial.println("[BTN] Double click : toggle BMS serial output");
     Serial.println("[LED] Blue=Listen  Green=Active  Yellow=OTA  Red=Error");
+
+    // Bind control/state first so serial JSON control works even if WiFi/web
+    // init fails; web_dashboard_init() will start HTTP/WS if WiFi is available.
+    web_dashboard_bind_control(&g_state, g_can, CAN_ACTIVE_BUS_COUNT, &g_state_mux);
 
     // ── WiFi + Web dashboard (non-fatal if WiFi fails) ───────────────────────
     if (wifi_init(&g_state)) {

--- a/esp32/.firmware/main.cpp
+++ b/esp32/.firmware/main.cpp
@@ -1061,6 +1061,45 @@ static void update_led() {
 }
 
 // ── CAN frame dispatcher ──────────────────────────────────────────────────────
+enum SummonAutoUpdate : uint8_t {
+    SummonAutoUpdate_None = 0,
+    SummonAutoUpdate_Disabled,
+    SummonAutoUpdate_Restored,
+};
+
+static SummonAutoUpdate update_summon_auto_control_locked(uint32_t now_ms) {
+    if (!g_state.summon_unlock || !g_state.suppress_speed_chime ||
+        g_state.summon_auto_control != SummonAutoControl_AcceleratorTemporary ||
+        !g_state.vehicle_gear_seen) {
+        return SummonAutoUpdate_None;
+    }
+
+    if (g_state.vehicle_gear == SIG_DI_GEAR_PARK) {
+        if (!g_state.summon_temp_disabled) return SummonAutoUpdate_None;
+        g_state.summon_temp_disabled = false;
+        g_state.summon_temp_recovery_armed = false;
+        g_state.summon_temp_disabled_ms = 0;
+        return SummonAutoUpdate_Restored;
+    }
+
+    if (fsd_accelerator_pressed(&g_state) && !g_state.summon_temp_disabled) {
+        g_state.summon_temp_disabled = true;
+        g_state.summon_temp_recovery_armed = false;
+        g_state.summon_temp_disabled_ms = now_ms;
+        return SummonAutoUpdate_Disabled;
+    }
+
+    return SummonAutoUpdate_None;
+}
+
+static void log_summon_auto_update(SummonAutoUpdate update) {
+    if (update == SummonAutoUpdate_Disabled) {
+        Serial.println("[SAFETY] Accelerator pressed outside P: Summon disabled, speed chime suppression enabled");
+    } else if (update == SummonAutoUpdate_Restored) {
+        Serial.println("[SAFETY] Park selected: Summon restored, speed chime suppression disabled");
+    }
+}
+
 static void process_frame(CanBusId bus, const CanFrame &frame) {
     uint32_t now = millis();
     state_enter();
@@ -1257,13 +1296,21 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
         return;
     }
     if (frame.id == CAN_ID_DI_SYSTEM) {
+        SummonAutoUpdate summon_update;
         state_enter();
         fsd_handle_di_system(&g_state, &frame);
-        if (g_state.summon_temp_disabled && g_state.vehicle_gear_seen &&
-            g_state.vehicle_gear != SIG_DI_GEAR_PARK) {
-            g_state.summon_temp_recovery_armed = true;
-        }
+        summon_update = update_summon_auto_control_locked(now);
         state_exit();
+        log_summon_auto_update(summon_update);
+        return;
+    }
+    if (frame.id == CAN_ID_DI_TORQUE) {
+        SummonAutoUpdate summon_update;
+        state_enter();
+        fsd_handle_di_torque(&g_state, &frame);
+        summon_update = update_summon_auto_control_locked(now);
+        state_exit();
+        log_summon_auto_update(summon_update);
         return;
     }
     if (frame.id == CAN_ID_DI_SPEED) {
@@ -1280,37 +1327,10 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
     }
     if (frame.id == CAN_ID_ESP_STATUS) {
         uint32_t now_ms = millis();
-        bool summon_temp_disabled = false;
-        bool summon_temp_restored = false;
         state_enter();
-        bool brake_was_seen = g_state.brake_status_seen;
-        bool brake_was_applied = g_state.driver_brake_applied;
-        bool summon_was_temp_disabled = g_state.summon_temp_disabled;
         fsd_handle_esp_status(&g_state, &frame);
         if (g_state.driver_brake_applied) g_cont_ap_last_brake_ms = now_ms;
-        if (g_state.summon_auto_control == SummonAutoControl_BrakeTemporary &&
-            brake_was_seen &&
-            !brake_was_applied && g_state.driver_brake_applied) {
-            if (g_state.summon_unlock && summon_was_temp_disabled &&
-                g_state.vehicle_gear_seen &&
-                g_state.vehicle_gear == SIG_DI_GEAR_PARK &&
-                g_state.summon_temp_recovery_armed) {
-                g_state.summon_temp_disabled = false;
-                g_state.summon_temp_recovery_armed = false;
-                g_state.summon_temp_disabled_ms = 0;
-                summon_temp_restored = true;
-            } else if (g_state.summon_unlock && !summon_was_temp_disabled) {
-                g_state.summon_temp_disabled = true;
-                g_state.summon_temp_recovery_armed = false;
-                g_state.summon_temp_disabled_ms = now_ms;
-                summon_temp_disabled = true;
-            }
-        }
         state_exit();
-        if (summon_temp_disabled)
-            Serial.println("[SAFETY] Summon EU Unlock temporarily disabled on brake apply");
-        else if (summon_temp_restored)
-            Serial.println("[SAFETY] Summon EU Unlock restored by parked brake apply");
         return;
     }
     // Steering angle (0x129) — read-only, feeds the Soft Engage gate (#108).
@@ -1415,7 +1435,7 @@ static void process_frame(CanBusId bus, const CanFrame &frame) {
     FSDState s = state_snapshot();
     if (frame.id == CAN_ID_ISA_SPEED &&
         s.hw_version == TeslaHW_HW4 &&
-        s.suppress_speed_chime) {
+        fsd_speed_chime_suppression_active(&s)) {
         CanFrame f = frame;
         if (fsd_handle_isa_speed_chime(&f) && tx)
             send_on_bus(bus, f);

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -16,6 +16,8 @@
 #include "capability.h"
 #include "profile_match.h"
 #include "prefs.h"
+#include "config.h"
+#include "can_signals.h"
 #include <WebServer.h>
 #include <WebSocketsServer.h>
 #include <WiFi.h>
@@ -32,6 +34,7 @@ static portMUX_TYPE *g_state_mux = nullptr;
 
 static WebServer        g_http(80);
 static WebSocketsServer g_ws(81);
+static bool             g_web_started = false;
 
 static uint32_t g_start_ms    = 0;
 static uint32_t g_last_rx     = 0;
@@ -155,6 +158,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
 /* ── Cards ── */
 .card{background:var(--card);border-radius:16px;padding:16px;
   margin-bottom:12px;border:1px solid var(--border)}
+.card>summary{position:relative;cursor:pointer;list-style:none}
+.card>summary::-webkit-details-marker{display:none}
+.card>summary .card-head{margin-bottom:0}
+.card>summary:after{content:"";position:absolute;right:18px;top:6px;width:9px;height:9px;
+  border-right:2px solid var(--text2);border-bottom:2px solid var(--text2);
+  transform:rotate(45deg);transition:transform .2s}
+.card[open]>summary:after{transform:rotate(225deg);top:6px}
 .card-head{display:flex;align-items:center;gap:8px;margin-bottom:12px}
 .config-section{background:var(--card);border:1px solid var(--border);
   border-radius:16px;margin-bottom:12px;overflow:hidden}
@@ -371,7 +381,31 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">CAN Vehicle</span>
     <span class="pill off" id="canVeh"><span class="pd"></span>--</span>
   </div>
+  <div class="row">
+    <span class="lbl">Summon Status</span>
+    <span class="pill off" id="summonStatus" title="Click to toggle" onclick="toggleSummonTemp()"><span class="pd"></span>--</span>
+  </div>
 </div>
+
+<details class="card" open>
+  <summary><div class="card-head"><div class="icon ic-d">V</div><h2>Vehicle Status</h2></div></summary>
+  <div class="row">
+    <span class="lbl">Vehicle Speed</span>
+    <span class="pill off" id="vehicleSpeed"><span class="pd"></span>--</span>
+  </div>
+  <div class="row">
+    <span class="lbl">Vehicle Gear</span>
+    <span class="pill off" id="vehicleGear"><span class="pd"></span>--</span>
+  </div>
+  <div class="row">
+    <span class="lbl">Brake</span>
+    <span class="pill off" id="brakeStatus"><span class="pd"></span>--</span>
+  </div>
+  <div class="row">
+    <span class="lbl">Turn Signal</span>
+    <span class="pill off" id="turnSignal"><span class="pd"></span>--</span>
+  </div>
+</details>
 
 <!-- Battery -->
 <div class="card">
@@ -814,6 +848,7 @@ function pill(id,on,txt,warnClass){
   e.className='pill '+(warnClass||''+(on?'on':'off'));
   e.innerHTML='<span class="pd"></span>'+txt;
 }
+var summonTempDisabled=false;
 function dot(id,on){
   var e=document.getElementById(id);
   if(e)e.className='blinkdot'+(on?' hit':'');
@@ -966,6 +1001,29 @@ function upd(d){
 
   pill('nagSt', d.nag_killer, d.nag_killer?'ON':'OFF');
   pill('canVeh', d.can_vehicle_detected, d.can_vehicle_detected?'Detected':'No CAN Traffic');
+  var summonEnabled=!!d.summon_unlock;
+  var summonDisabled=!!d.summon_temp_disabled;
+  pill('summonStatus', summonEnabled && !summonDisabled,
+    summonDisabled?'Temp disabled':(summonEnabled?'Enabled':'Disabled'));
+  var summonEl=document.getElementById('summonStatus');
+  summonTempDisabled=summonDisabled;
+  if(summonEl) {
+    summonEl.dataset.tempDisabled=summonDisabled?'true':'false';
+    summonEl.dataset.summonEnabled=summonEnabled?'true':'false';
+    summonEl.style.cursor=summonEnabled?'pointer':'default';
+    summonEl.title=summonEnabled?'Click to toggle':'';
+  }
+  var speedFresh=d.speed_seen===true;
+  pill('vehicleSpeed', speedFresh, speedFresh?(Number(d.vehicle_speed_kph||0).toFixed(1)+' km/h'):'Waiting');
+  var gearNames={1:'P',2:'R',3:'N',4:'D'};
+  var gearSeen=d.vehicle_gear_seen===true;
+  pill('vehicleGear', gearSeen, gearSeen?(gearNames[d.vehicle_gear]||'Unknown'):'Waiting');
+  var brakeSeen=d.brake_status_seen===true;
+  pill('brakeStatus', brakeSeen, brakeSeen?(d.driver_brake_applied?'Pressed':'Released'):'Waiting');
+  var turnSeen=d.turn_status_seen===true;
+  var turnLabel=turnSeen ? ((d.left_turn_active?'L':'')+(d.right_turn_active?'R':'' )||'Off') : 'Waiting';
+  pill('turnSignal', turnSeen && !!(d.left_turn_active||d.right_turn_active),
+    turnLabel);
   pill('bmsSt', d.bms && d.bms.seen, (d.bms && d.bms.seen)?'Live':'Waiting Frames');
   var bF=document.getElementById('bmsFrames');
   if(bF) bF.textContent='HV:'+(d.bms_hv_seen||0)+' SOC:'+(d.bms_soc_seen||0)+' TH:'+(d.bms_thermal_seen||0);
@@ -1246,6 +1304,19 @@ function cmd(c,v){
     busy = Date.now() + 3000;
   }
 }
+function toggleSummonTemp(){
+  var e=document.getElementById('summonStatus');
+  if(e && e.dataset.summonEnabled==='true') {
+    var disabled=e.dataset.tempDisabled==='true';
+    cmd(disabled?'summon_force_recover':'summon_temp_disable',true);
+    busy=0;
+    summonTempDisabled=!disabled;
+    if(e) {
+      e.dataset.tempDisabled=disabled?'false':'true';
+    }
+    pill('summonStatus',!disabled,disabled?'Enabled':'Temp disabled');
+  }
+}
 function toggleMode(){ cmd('mode',null); }
 function gv(id){ var e=document.getElementById(id); return (e&&e.value.trim()!=='')?e.value.trim():'0'; }
 function saveSigCfg(){
@@ -1517,6 +1588,17 @@ static String json_escape(const char *s) {
     return out;
 }
 
+static const char *gear_detent_name(uint8_t pos) {
+    switch (pos) {
+        case SIG_GEAR_LEVER_CENTER: return "center";
+        case SIG_GEAR_LEVER_HALF_UP: return "half_up";
+        case SIG_GEAR_LEVER_FULL_UP: return "full_up";
+        case SIG_GEAR_LEVER_HALF_DOWN: return "half_down";
+        case SIG_GEAR_LEVER_FULL_DOWN: return "full_down";
+        default: return "unknown";
+    }
+}
+
 // ── JSON builder ──────────────────────────────────────────────────────────────
 static String build_json() {
     FSDState state;
@@ -1563,6 +1645,11 @@ static String build_json() {
 
     String j;
     bool isa_speed_enabled = state.hw_version == TeslaHW_HW4;
+    bool pedal_pressed = state.di_torque_seen && state.di_torque_nm > 5.0f;
+    char di_torque_s[16];
+    char vehicle_speed_s[16];
+    snprintf(di_torque_s, sizeof(di_torque_s), "%.1f", state.di_torque_nm);
+    snprintf(vehicle_speed_s, sizeof(vehicle_speed_s), "%.1f", state.vehicle_speed_kph);
     const char *ap_das_profile =
         (state.hw_version == TeslaHW_HW4) ? "HW4: DAS 0x39B + ISA 0x399" :
         (state.hw_version == TeslaHW_HW3) ? "HW3: DAS 0x399" :
@@ -1609,6 +1696,29 @@ static String build_json() {
     j += "\"suppress_speed_chime\":"; j += state.suppress_speed_chime  ? "true" : "false"; j += ',';
     j += "\"tlssc_restore\":"; j += state.tlssc_restore                ? "true" : "false"; j += ',';
     j += "\"summon_unlock\":"; j += state.summon_unlock                ? "true" : "false"; j += ',';
+    j += "\"summon_auto_control\":"; j += (int)state.summon_auto_control; j += ',';
+    j += "\"summon_temp_disabled\":"; j += state.summon_temp_disabled ? "true" : "false"; j += ',';
+    j += "\"driver_brake_applied\":"; j += state.driver_brake_applied  ? "true" : "false"; j += ',';
+    j += "\"brake_status_seen\":"; j += state.brake_status_seen        ? "true" : "false"; j += ',';
+    j += "\"left_turn_active\":"; j += state.left_turn_active          ? "true" : "false"; j += ',';
+    j += "\"right_turn_active\":"; j += state.right_turn_active        ? "true" : "false"; j += ',';
+    j += "\"turn_status_seen\":"; j += state.turn_status_seen          ? "true" : "false"; j += ',';
+    j += "\"steering_angle_deg\":"; j += String(state.steering_angle_deg); j += ',';
+    j += "\"speed_seen\":"; j += state.speed_seen                      ? "true" : "false"; j += ',';
+    j += "\"vehicle_speed_kph\":"; j += vehicle_speed_s;                j += ',';
+    j += "\"di_digital_speed\":"; j += (int)state.di_digital_speed;     j += ',';
+    j += "\"ui_speed\":"; j += (int)state.ui_speed;                     j += ',';
+    j += "\"vehicle_gear\":"; j += (int)state.vehicle_gear;             j += ',';
+    j += "\"vehicle_gear_seen\":"; j += state.vehicle_gear_seen ? "true" : "false"; j += ',';
+    j += "\"pedal_pressed\":"; j += pedal_pressed                       ? "true" : "false"; j += ',';
+    j += "\"di_torque_seen\":"; j += state.di_torque_seen              ? "true" : "false"; j += ',';
+    j += "\"di_torque_nm\":"; j += di_torque_s;                         j += ',';
+    j += "\"gear_lever_seen\":"; j += state.gear_lever_seen            ? "true" : "false"; j += ',';
+    j += "\"gear_lever_counter_seen\":"; j += state.gear_lever_counter_seen ? "true" : "false"; j += ',';
+    j += "\"gear_lever_pos\":"; j += (int)state.gear_lever_last_pos;   j += ',';
+    j += "\"gear_lever_counter\":"; j += (int)state.gear_lever_last_counter; j += ',';
+    j += "\"gear_lever_last_ms\":"; j += state.gear_lever_last_ms;      j += ',';
+    j += "\"gear_lever_label\":\""; j += gear_detent_name(state.gear_lever_last_pos); j += "\",";
     j += "\"continue_on_green\":"; j += state.continue_on_green         ? "true" : "false"; j += ',';
     j += "\"assist_tlssc_bit38\":"; j += state.assist_tlssc_bit38       ? "true" : "false"; j += ',';
     j += "\"assist_rhd_override\":"; j += state.assist_rhd_override      ? "true" : "false"; j += ',';
@@ -2052,6 +2162,26 @@ static void ws_event(uint8_t num, WStype_t type,
             Serial.printf("[Web] Suppress Speed Chime: %s\n", enabled ? "ON" : "OFF");
             prefs_save(&saved);
         }
+    } else if (strstr(buf, "\"summon_temp_disable\"")) {
+        state_enter();
+        if (g_state->summon_unlock) {
+            g_state->summon_temp_disabled = true;
+            g_state->summon_temp_recovery_armed = false;
+            g_state->summon_temp_disabled_ms = millis();
+        }
+        state_exit();
+        Serial.println("[Web] Summon temporary disable: ENABLED");
+    } else if (strstr(buf, "\"summon_force_recover\"")) {
+        bool recovered = false;
+        state_enter();
+        if (g_state->summon_unlock && g_state->summon_temp_disabled) {
+            g_state->summon_temp_disabled = false;
+            g_state->summon_temp_recovery_armed = false;
+            g_state->summon_temp_disabled_ms = 0;
+            recovered = true;
+        }
+        state_exit();
+        Serial.printf("[Web] Summon force recovery: %s\n", recovered ? "ENABLED" : "ignored");
     } else if (strstr(buf, "\"summon_unlock\"")) {
         if (vptr) {
             while (*vptr == ' ' || *vptr == ':') vptr++;
@@ -2059,6 +2189,11 @@ static void ws_event(uint8_t num, WStype_t type,
             FSDState saved;
             state_enter();
             g_state->summon_unlock = enabled;
+            if (!enabled) {
+                g_state->summon_temp_disabled = false;
+                g_state->summon_temp_recovery_armed = false;
+                g_state->summon_temp_disabled_ms = 0;
+            }
             saved = *g_state;
             state_exit();
             Serial.printf("[Web] Summon EU Unlock: %s\n", enabled ? "ON" : "OFF");
@@ -2518,10 +2653,10 @@ static void handle_ota_done() {
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
-void web_dashboard_init(FSDState *state,
-                        CanDriver **can_buses,
-                        uint8_t can_count,
-                        portMUX_TYPE *state_mux) {
+void web_dashboard_bind_control(FSDState *state,
+                                CanDriver **can_buses,
+                                uint8_t can_count,
+                                portMUX_TYPE *state_mux) {
     g_state       = state;
     g_can_buses   = can_buses;
     g_can_count   = can_count;
@@ -2530,6 +2665,13 @@ void web_dashboard_init(FSDState *state,
     g_last_fps_ms = millis();
     g_last_rx     = state ? state->rx_count : 0;
     g_last_can_seen_ms = (state && state->rx_count > 0) ? millis() : 0;
+}
+
+void web_dashboard_init(FSDState *state,
+                        CanDriver **can_buses,
+                        uint8_t can_count,
+                        portMUX_TYPE *state_mux) {
+    web_dashboard_bind_control(state, can_buses, can_count, state_mux);
 
     g_http.on("/",           HTTP_GET,  handle_root);
     g_http.on("/api/status", HTTP_GET,  handle_status);
@@ -2545,16 +2687,201 @@ void web_dashboard_init(FSDState *state,
 
     g_ws.begin();
     g_ws.onEvent(ws_event);
+    g_web_started = true;
 
     Serial.println("[Web] HTTP :80  WS :81 — ready");
+}
+
+static bool serial_json_get_string_value(const char *line,
+                                         const char *key,
+                                         char *out,
+                                         size_t out_len) {
+    if (line == nullptr || key == nullptr || out == nullptr || out_len == 0) return false;
+
+    char key_pat[32];
+    snprintf(key_pat, sizeof(key_pat), "\"%s\"", key);
+    const char *p = strstr(line, key_pat);
+    if (p == nullptr) return false;
+    p = strchr(p, ':');
+    if (p == nullptr) return false;
+    p++;
+    while (*p == ' ' || *p == '\t') p++;
+    if (*p != '"') return false;
+    p++;
+
+    size_t i = 0;
+    while (*p && *p != '"' && i + 1 < out_len) out[i++] = *p++;
+    out[i] = '\0';
+    return *p == '"' && i > 0;
+}
+
+static CanDriver *serial_gear_bus() {
+    if (g_can_buses == nullptr || g_can_count == 0) return nullptr;
+    uint8_t index = (GEAR_LEVER_TX_BUS_INDEX < g_can_count) ? GEAR_LEVER_TX_BUS_INDEX : 0u;
+    return g_can_buses[index];
+}
+
+static bool serial_send_gear_pulse(uint8_t detent,
+                                   uint8_t *out_counter,
+                                   const char **out_error) {
+    if (out_error) *out_error = nullptr;
+    FSDState s;
+    if (!state_copy(&s)) {
+        if (out_error) *out_error = "state_unavailable";
+        return false;
+    }
+    if (s.op_mode != OpMode_Active) {
+        if (out_error) *out_error = "listen_only_mode";
+        return false;
+    }
+    if (!s.gear_lever_counter_seen) {
+        if (out_error) *out_error = "gear_counter_unavailable";
+        return false;
+    }
+    uint32_t now = millis();
+    if (s.gear_lever_last_ms == 0u ||
+        (uint32_t)(now - s.gear_lever_last_ms) > GEAR_LEVER_CACHED_COUNTER_MAX_AGE_MS) {
+        if (out_error) *out_error = "gear_counter_stale";
+        return false;
+    }
+
+    CanDriver *bus = serial_gear_bus();
+    if (bus == nullptr) {
+        if (out_error) *out_error = "gear_bus_unavailable";
+        return false;
+    }
+
+    uint8_t c1 = (uint8_t)((s.gear_lever_last_counter + 1u) & SIG_GEAR_LEVER_COUNTER_MASK);
+    uint8_t c2 = (uint8_t)((c1 + 1u) & SIG_GEAR_LEVER_COUNTER_MASK);
+    CanFrame detent_frame;
+    CanFrame center_frame;
+    if (!fsd_build_gear_lever_frame(&detent_frame, detent, c1) ||
+        !fsd_build_gear_lever_frame(&center_frame, SIG_GEAR_LEVER_CENTER, c2)) {
+        if (out_error) *out_error = "gear_build_failed";
+        return false;
+    }
+    if (!bus->send(detent_frame) || !bus->send(center_frame)) {
+        if (out_error) *out_error = "gear_send_failed";
+        return false;
+    }
+
+    state_enter();
+    g_state->gear_lever_last_counter = c2;
+    g_state->gear_lever_counter_seen = true;
+    g_state->gear_lever_last_pos = SIG_GEAR_LEVER_CENTER;
+    g_state->gear_lever_seen = true;
+    g_state->gear_lever_last_ms = now;
+    state_exit();
+
+    if (out_counter) *out_counter = c2;
+    return true;
+}
+
+bool web_dashboard_handle_serial_json(const char *line) {
+    if (line == nullptr) return false;
+
+    while (*line == ' ' || *line == '\t') line++;
+    if (*line != '{') return false;
+    if (strstr(line, "\"cmd\"") == nullptr) return false;
+
+    size_t len = strlen(line);
+    while (len > 0) {
+        char c = line[len - 1];
+        if (c == '\r' || c == '\n' || c == ' ' || c == '\t') len--;
+        else break;
+    }
+
+    if (len == 0) return false;
+    if (g_state == nullptr) {
+        Serial.println("{\"ok\":false,\"error\":\"dashboard_not_ready\"}");
+        return true;
+    }
+
+    char cmd[32] = {};
+    if (!serial_json_get_string_value(line, "cmd", cmd, sizeof(cmd))) {
+        Serial.println("{\"ok\":false,\"error\":\"missing_cmd\"}");
+        return true;
+    }
+    if (strcmp(cmd, "status") == 0) {
+        Serial.println(build_json());
+        return true;
+    }
+    if (strcmp(cmd, "summon_force_recover") == 0) {
+        bool recovered = false;
+        state_enter();
+        if (g_state->summon_unlock && g_state->summon_temp_disabled) {
+            g_state->summon_temp_disabled = false;
+            g_state->summon_temp_recovery_armed = false;
+            g_state->summon_temp_disabled_ms = 0;
+            recovered = true;
+        }
+        state_exit();
+        Serial.printf("{\"ok\":true,\"cmd\":\"summon_force_recover\",\"recovered\":%s}\n",
+                      recovered ? "true" : "false");
+        return true;
+    }
+    if (strcmp(cmd, "summon_temp_disable") == 0) {
+        state_enter();
+        if (g_state->summon_unlock) {
+            g_state->summon_temp_disabled = true;
+            g_state->summon_temp_recovery_armed = false;
+            g_state->summon_temp_disabled_ms = millis();
+        }
+        state_exit();
+        Serial.println("{\"ok\":true,\"cmd\":\"summon_temp_disable\"}");
+        return true;
+    }
+    if (strcmp(cmd, "gear") == 0) {
+        char value[32] = {};
+        if (!serial_json_get_string_value(line, "value", value, sizeof(value))) {
+            Serial.println("{\"ok\":false,\"error\":\"missing_gear_value\"}");
+            return true;
+        }
+
+        uint8_t detent = SIG_GEAR_LEVER_CENTER;
+        if (strcmp(value, "down") == 0 || strcmp(value, "drive") == 0 || strcmp(value, "d") == 0) {
+            detent = SIG_GEAR_LEVER_FULL_DOWN;
+        } else if (strcmp(value, "up") == 0 || strcmp(value, "park") == 0 ||
+                   strcmp(value, "reverse") == 0 || strcmp(value, "neutral") == 0 ||
+                   strcmp(value, "p") == 0 || strcmp(value, "r") == 0 || strcmp(value, "n") == 0) {
+            detent = SIG_GEAR_LEVER_FULL_UP;
+        } else {
+            Serial.println("{\"ok\":false,\"error\":\"unsupported_gear_value\"}");
+            return true;
+        }
+
+        uint8_t counter = 0;
+        const char *err = nullptr;
+        if (!serial_send_gear_pulse(detent, &counter, &err)) {
+            Serial.printf("{\"ok\":false,\"error\":\"%s\"}\n", err ? err : "gear_send_failed");
+            return true;
+        }
+        Serial.printf("{\"ok\":true,\"cmd\":\"gear\",\"value\":\"%s\",\"counter\":%u}\n",
+                      value, counter);
+        return true;
+    }
+
+    uint8_t payload[256];
+    if (len >= sizeof(payload)) {
+        Serial.println("{\"ok\":false,\"error\":\"command_too_long\"}");
+        return true;
+    }
+    size_t n = len;
+    memcpy(payload, line, n);
+    payload[n] = '\0';
+    ws_event(0, WStype_TEXT, payload, n);
+    Serial.println("{\"ok\":true}");
+    return true;
 }
 
 void web_dashboard_update() {
     if (g_state == nullptr) return;   // init was never called (WiFi failed)
 
-    g_http.handleClient();
-    g_ws.loop();
-    http_can_stream_update();
+    if (g_web_started) {
+        g_http.handleClient();
+        g_ws.loop();
+        http_can_stream_update();
+    }
 
     // FPS calculation + 1 Hz WebSocket broadcast
     uint32_t now = millis();
@@ -2568,8 +2895,10 @@ void web_dashboard_update() {
         g_last_rx    = rx;
         g_last_fps_ms = now;
 
-        String json = build_json();
-        Serial.printf("[WS] state json=%u bytes\n", (unsigned)json.length());
-        g_ws.broadcastTXT(json.c_str(), json.length());
+        if (g_web_started) {
+            String json = build_json();
+            Serial.printf("[WS] state json=%u bytes\n", (unsigned)json.length());
+            g_ws.broadcastTXT(json.c_str(), json.length());
+        }
     }
 }

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -385,7 +385,7 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">Summon Status</span>
     <span class="pill off" id="summonStatus" title="Click to toggle" onclick="toggleSummonTemp()"><span class="pd"></span>--</span>
   </div>
-  <div class="row">
+  <div class="row" id="chimeStatusRow">
     <span class="lbl">Suppress Chime</span>
     <span class="pill off" id="chimeStatus"><span class="pd"></span>--</span>
   </div>
@@ -1023,6 +1023,8 @@ function upd(d){
   }
   var chimeConfigured=d.suppress_speed_chime_configured!==undefined?
     !!d.suppress_speed_chime_configured:!!d.suppress_speed_chime;
+  var chimeStatusRow=document.getElementById('chimeStatusRow');
+  if(chimeStatusRow)chimeStatusRow.hidden=!chimeConfigured;
   pill('chimeStatus', !!d.suppress_speed_chime,
     chimeConfigured?(d.suppress_speed_chime?'Suppressed':'Not suppressed'):'Disabled');
   var speedFresh=d.speed_seen===true;
@@ -1030,7 +1032,7 @@ function upd(d){
   var gearNames={1:'P',2:'R',3:'N',4:'D'};
   var gearSeen=d.vehicle_gear_seen===true;
   pill('vehicleGear', gearSeen, gearSeen?(gearNames[d.vehicle_gear]||'Unknown'):'Waiting');
-  var pedalSeen=d.di_torque_seen===true;
+  var pedalSeen=d.accelerator_pedal_seen===true;
   pill('acceleratorStatus', pedalSeen && d.pedal_pressed,
     pedalSeen?(d.pedal_pressed?'Pressed':'Released'):'Waiting');
   var brakeSeen=d.brake_status_seen===true;
@@ -1664,8 +1666,11 @@ static String build_json() {
     bool pedal_pressed = fsd_accelerator_pressed(&state);
     bool chime_suppression_active = fsd_speed_chime_suppression_active(&state);
     char di_torque_s[16];
+    char accelerator_pedal_s[16];
     char vehicle_speed_s[16];
     snprintf(di_torque_s, sizeof(di_torque_s), "%.1f", state.di_torque_nm);
+    snprintf(accelerator_pedal_s, sizeof(accelerator_pedal_s), "%.1f",
+         state.accelerator_pedal_percent);
     snprintf(vehicle_speed_s, sizeof(vehicle_speed_s), "%.1f", state.vehicle_speed_kph);
     const char *ap_das_profile =
         (state.hw_version == TeslaHW_HW4) ? "HW4: DAS 0x39B + ISA 0x399" :
@@ -1729,6 +1734,8 @@ static String build_json() {
     j += "\"vehicle_gear\":"; j += (int)state.vehicle_gear;             j += ',';
     j += "\"vehicle_gear_seen\":"; j += state.vehicle_gear_seen ? "true" : "false"; j += ',';
     j += "\"pedal_pressed\":"; j += pedal_pressed                       ? "true" : "false"; j += ',';
+    j += "\"accelerator_pedal_seen\":"; j += state.accelerator_pedal_seen ? "true" : "false"; j += ',';
+    j += "\"accelerator_pedal_percent\":"; j += accelerator_pedal_s;     j += ',';
     j += "\"di_torque_seen\":"; j += state.di_torque_seen              ? "true" : "false"; j += ',';
     j += "\"di_torque_nm\":"; j += di_torque_s;                         j += ',';
     j += "\"gear_lever_seen\":"; j += state.gear_lever_seen            ? "true" : "false"; j += ',';

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -385,6 +385,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="lbl">Summon Status</span>
     <span class="pill off" id="summonStatus" title="Click to toggle" onclick="toggleSummonTemp()"><span class="pd"></span>--</span>
   </div>
+  <div class="row">
+    <span class="lbl">Suppress Chime</span>
+    <span class="pill off" id="chimeStatus"><span class="pd"></span>--</span>
+  </div>
 </div>
 
 <details class="card" open>
@@ -875,7 +879,7 @@ function updateControlsSummary(d){
   if(d.bms_output)items.push('BMS');
   if(d.force_fsd)items.push('Force FSD');
   if(d.china_mode)items.push('China');
-  if(d.isa_speed_enabled&&d.suppress_speed_chime)items.push('Chime');
+  if(d.isa_speed_enabled&&d.suppress_speed_chime_configured)items.push('Chime');
   if(d.tlssc_restore)items.push('TLSSC');
   if(d.assist_tlssc_bit38)items.push('TLSSC bit38');
   if(d.display_enabled)items.push('Display');
@@ -1017,6 +1021,10 @@ function upd(d){
     summonEl.style.cursor=summonEnabled?'pointer':'default';
     summonEl.title=summonEnabled?'Click to toggle':'';
   }
+  var chimeConfigured=d.suppress_speed_chime_configured!==undefined?
+    !!d.suppress_speed_chime_configured:!!d.suppress_speed_chime;
+  pill('chimeStatus', !!d.suppress_speed_chime,
+    chimeConfigured?(d.suppress_speed_chime?'Suppressed':'Not suppressed'):'Disabled');
   var speedFresh=d.speed_seen===true;
   pill('vehicleSpeed', speedFresh, speedFresh?(Number(d.vehicle_speed_kph||0).toFixed(1)+' km/h'):'Waiting');
   var gearNames={1:'P',2:'R',3:'N',4:'D'};
@@ -1024,9 +1032,10 @@ function upd(d){
   pill('vehicleGear', gearSeen, gearSeen?(gearNames[d.vehicle_gear]||'Unknown'):'Waiting');
   var pedalSeen=d.di_torque_seen===true;
   pill('acceleratorStatus', pedalSeen && d.pedal_pressed,
-    pedalSeen?((d.pedal_pressed?'Pressed ':'Released ')+Number(d.di_torque_nm||0).toFixed(1)+' Nm'):'Waiting');
+    pedalSeen?(d.pedal_pressed?'Pressed':'Released'):'Waiting');
   var brakeSeen=d.brake_status_seen===true;
-  pill('brakeStatus', brakeSeen, brakeSeen?(d.driver_brake_applied?'Pressed':'Released'):'Waiting');
+  pill('brakeStatus', brakeSeen && d.driver_brake_applied,
+    brakeSeen?(d.driver_brake_applied?'Pressed':'Released'):'Waiting');
   var turnSeen=d.turn_status_seen===true;
   var turnLabel=turnSeen ? ((d.left_turn_active?'L':'')+(d.right_turn_active?'R':'' )||'Off') : 'Waiting';
   pill('turnSignal', turnSeen && !!(d.left_turn_active||d.right_turn_active),
@@ -1073,7 +1082,7 @@ function upd(d){
   if(document.getElementById('swBms')) document.getElementById('swBms').checked=d.bms_output;
   if(document.getElementById('swFsd')) document.getElementById('swFsd').checked=d.force_fsd;
   if(document.getElementById('swChina')) document.getElementById('swChina').checked=d.china_mode;
-  if(document.getElementById('swChime')) document.getElementById('swChime').checked=d.suppress_speed_chime;
+  if(document.getElementById('swChime')) document.getElementById('swChime').checked=chimeConfigured;
   if(document.getElementById('rowChime')) document.getElementById('rowChime').style.display=d.isa_speed_enabled?'flex':'none';
   if(document.getElementById('swTlssc')) document.getElementById('swTlssc').checked=d.tlssc_restore;
   if(document.getElementById('swSummon')) document.getElementById('swSummon').checked=d.summon_unlock;

--- a/esp32/.firmware/web_dashboard.cpp
+++ b/esp32/.firmware/web_dashboard.cpp
@@ -398,6 +398,10 @@ input:checked+.sl2:before{transform:translateX(20px);background:#fff}
     <span class="pill off" id="vehicleGear"><span class="pd"></span>--</span>
   </div>
   <div class="row">
+    <span class="lbl">Accelerator</span>
+    <span class="pill off" id="acceleratorStatus"><span class="pd"></span>--</span>
+  </div>
+  <div class="row">
     <span class="lbl">Brake</span>
     <span class="pill off" id="brakeStatus"><span class="pd"></span>--</span>
   </div>
@@ -1018,6 +1022,9 @@ function upd(d){
   var gearNames={1:'P',2:'R',3:'N',4:'D'};
   var gearSeen=d.vehicle_gear_seen===true;
   pill('vehicleGear', gearSeen, gearSeen?(gearNames[d.vehicle_gear]||'Unknown'):'Waiting');
+  var pedalSeen=d.di_torque_seen===true;
+  pill('acceleratorStatus', pedalSeen && d.pedal_pressed,
+    pedalSeen?((d.pedal_pressed?'Pressed ':'Released ')+Number(d.di_torque_nm||0).toFixed(1)+' Nm'):'Waiting');
   var brakeSeen=d.brake_status_seen===true;
   pill('brakeStatus', brakeSeen, brakeSeen?(d.driver_brake_applied?'Pressed':'Released'):'Waiting');
   var turnSeen=d.turn_status_seen===true;
@@ -1645,7 +1652,8 @@ static String build_json() {
 
     String j;
     bool isa_speed_enabled = state.hw_version == TeslaHW_HW4;
-    bool pedal_pressed = state.di_torque_seen && state.di_torque_nm > 5.0f;
+    bool pedal_pressed = fsd_accelerator_pressed(&state);
+    bool chime_suppression_active = fsd_speed_chime_suppression_active(&state);
     char di_torque_s[16];
     char vehicle_speed_s[16];
     snprintf(di_torque_s, sizeof(di_torque_s), "%.1f", state.di_torque_nm);
@@ -1693,7 +1701,8 @@ static String build_json() {
     j += "\"bms_output\":";    j += state.bms_output                   ? "true" : "false"; j += ',';
     j += "\"force_fsd\":";     j += state.force_fsd                    ? "true" : "false"; j += ',';
     j += "\"china_mode\":";    j += state.china_mode                   ? "true" : "false"; j += ',';
-    j += "\"suppress_speed_chime\":"; j += state.suppress_speed_chime  ? "true" : "false"; j += ',';
+    j += "\"suppress_speed_chime\":"; j += chime_suppression_active    ? "true" : "false"; j += ',';
+    j += "\"suppress_speed_chime_configured\":"; j += state.suppress_speed_chime ? "true" : "false"; j += ',';
     j += "\"tlssc_restore\":"; j += state.tlssc_restore                ? "true" : "false"; j += ',';
     j += "\"summon_unlock\":"; j += state.summon_unlock                ? "true" : "false"; j += ',';
     j += "\"summon_auto_control\":"; j += (int)state.summon_auto_control; j += ',';

--- a/esp32/.firmware/web_dashboard.h
+++ b/esp32/.firmware/web_dashboard.h
@@ -29,5 +29,23 @@ void web_dashboard_init(FSDState *state,
                         uint8_t can_count,
                         portMUX_TYPE *state_mux);
 
+/**
+ * Bind shared state/control pointers without starting HTTP/WS servers.
+ * Useful for serial-only control fallback when WiFi init fails.
+ */
+void web_dashboard_bind_control(FSDState *state,
+                                CanDriver **can_buses,
+                                uint8_t can_count,
+                                portMUX_TYPE *state_mux);
+
 /** Service HTTP requests and WebSocket messages; broadcast state at 1 Hz. */
 void web_dashboard_update();
+
+/**
+ * Handle one serial JSON control line (same command JSON shape as WebSocket).
+ *
+ * @param line One complete JSON line (without trailing newline required).
+ * @return true if the line was treated as a serial JSON command (handled or rejected);
+ *         false when the line is not JSON and should be handled by other serial commands.
+ */
+bool web_dashboard_handle_serial_json(const char *line);

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -340,6 +340,37 @@ pio device monitor -b 115200
 5. REST API available at `http://192.168.4.1/api/status`
 6. Raw CAN stream endpoint: `http://192.168.4.1:82/stream`
 
+### Web Serial fallback control (external page)
+
+If WiFi is unavailable, or you prefer an external browser UI over USB, use the
+Web Serial control page:
+
+1. Connect ESP32 by USB.
+2. From `esp32/`, start a local web server:
+   ```bash
+   python3 -m http.server 8080
+   ```
+3. Open `http://localhost:8080/webserial-control.html` in Chrome/Edge.
+4. Click **Connect**, select the ESP32 serial port, then send quick commands or raw JSON.
+
+Serial JSON command format (one line per command):
+
+```json
+{"cmd":"status","value":true}
+{"cmd":"mode","value":true}
+{"cmd":"nag","value":true}
+{"cmd":"ap_first","value":false}
+{"cmd":"gear","value":"down"}
+{"cmd":"gear","value":"up"}
+```
+
+Device ack format:
+
+```json
+{"ok":true}
+{"ok":false,"error":"dashboard_not_ready"}
+```
+
 ### Capture fidelity — the two drop metrics
 
 A downloaded capture is only useful if you know whether it saw every frame. The

--- a/esp32/webserial-control.html
+++ b/esp32/webserial-control.html
@@ -506,27 +506,30 @@
         try {
           const localReader = port.readable.getReader();
           reader = localReader;
-          while (readLoopRunning) {
-            const { value, done } = await localReader.read();
-            if (done) break;
-            if (!value) continue;
-            text += new TextDecoder().decode(value, { stream: true });
-            let idx;
-            while ((idx = text.indexOf("\n")) >= 0) {
-              const line = text.slice(0, idx).trim();
-              text = text.slice(idx + 1);
-              if (line) {
-                appendLog(`RX ${line}`);
-                try {
-                  const obj = JSON.parse(line);
-                  if (obj && Object.prototype.hasOwnProperty.call(obj, "op_mode")) {
-                    applyStatus(obj);
-                  }
-                } catch (_) {}
+          try {
+            while (readLoopRunning) {
+              const { value, done } = await localReader.read();
+              if (done) break;
+              if (!value) continue;
+              text += new TextDecoder().decode(value, { stream: true });
+              let idx;
+              while ((idx = text.indexOf("\n")) >= 0) {
+                const line = text.slice(0, idx).trim();
+                text = text.slice(idx + 1);
+                if (line) {
+                  appendLog(`RX ${line}`);
+                  try {
+                    const obj = JSON.parse(line);
+                    if (obj && Object.prototype.hasOwnProperty.call(obj, "op_mode")) {
+                      applyStatus(obj);
+                    }
+                  } catch (_) {}
+                }
               }
             }
+          } finally {
+            localReader.releaseLock();
           }
-          localReader.releaseLock();
         } catch (err) {
           appendLog(`RX error: ${err.message || err}`);
           break;

--- a/esp32/webserial-control.html
+++ b/esp32/webserial-control.html
@@ -1,0 +1,669 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tesla FSD ESP32 - Web Serial Control</title>
+  <style>
+    :root {
+      --bg: #0a0a1a;
+      --card: #111827;
+      --border: #1e293b;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --ok: #00d4aa;
+      --warn: #ffd93d;
+      --err: #ff6b6b;
+      --btn: #1f2937;
+      --card2: #1a1f35;
+      --text2: #94a3b8;
+      --text3: #475569;
+      --accent2: #00b894;
+      --blue: #4dabf7;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    .wrap {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 18px;
+    }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+      margin-bottom: 12px;
+    }
+    details.card > summary {
+      cursor: pointer;
+      list-style: none;
+    }
+    details.card > summary::-webkit-details-marker {
+      display: none;
+    }
+    details.card > summary::after {
+      content: "+";
+      float: right;
+      color: var(--muted);
+    }
+    details.card[open] > summary::after {
+      content: "";
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: 1.2rem;
+    }
+    h2 {
+      margin: 0 0 10px;
+      font-size: 1rem;
+    }
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .status {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .ok { color: var(--ok); }
+    .warn { color: var(--warn); }
+    .err { color: var(--err); }
+    button, select, input, textarea {
+      background: var(--btn);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px 10px;
+      font-size: 0.9rem;
+    }
+    button {
+      cursor: pointer;
+    }
+    button:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
+    textarea {
+      width: 100%;
+      min-height: 84px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      resize: vertical;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 8px;
+    }
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+      gap: 8px;
+    }
+    .status-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 16px;
+      margin-bottom: 12px;
+    }
+    .status-card h2 {
+      margin: 0 0 12px;
+      color: var(--text2);
+      font-size: 0.78rem;
+      font-weight: 600;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+    }
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 9px 0;
+    }
+    .status-row + .status-row {
+      border-top: 1px solid rgba(255,255,255,.04);
+    }
+    .status-label {
+      color: var(--text2);
+      font-size: 0.85rem;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 3px 10px;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .pill.ok { background: rgba(0,212,170,.14); color: var(--ok); }
+    .pill.warn { background: rgba(255,107,107,.14); color: var(--err); }
+    .pill.off { background: rgba(71,85,105,.22); color: var(--text3); }
+    .pill.err { background: rgba(255,107,107,.14); color: var(--err); }
+    .pill.actionable { cursor: pointer; }
+    .pill-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      background: currentColor;
+      box-shadow: 0 0 5px currentColor;
+    }
+    .switch-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      padding: 9px 0;
+    }
+    .switch-row + .switch-row { border-top: 1px solid rgba(255,255,255,.04); }
+    .switch-label { color: var(--text2); font-size: 0.85rem; }
+    .main-grid { display: flex; flex-direction: column; }
+    @media (min-width: 900px) {
+      .main-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 12px; align-items: start; }
+      .status-column { grid-column: 1; grid-row: 1; }
+      .control-column { grid-column: 2; grid-row: 1; }
+    }
+    .sw { position: relative; width: 44px; height: 24px; flex-shrink: 0; }
+    .sw input { opacity: 0; width: 0; height: 0; }
+    .sl2 { position: absolute; inset: 0; cursor: pointer; background: #2a2a3e; border-radius: 24px; transition: .3s; }
+    .sl2:before { content: ""; position: absolute; height: 18px; width: 18px; left: 3px; bottom: 3px; background: #555; border-radius: 50%; transition: .3s; }
+    .sw input:checked + .sl2 { background: var(--ok); }
+    .sw input:checked + .sl2:before { transform: translateX(20px); background: #fff; }
+    .kv {
+      background: #0b1020;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px;
+    }
+    .k {
+      color: var(--muted);
+      font-size: 0.78rem;
+      margin-bottom: 3px;
+    }
+    .v {
+      font-size: 0.98rem;
+      font-weight: 600;
+    }
+    .hint {
+      color: var(--muted);
+      font-size: 0.84rem;
+      line-height: 1.35;
+    }
+    pre {
+      margin: 0;
+      max-height: 280px;
+      overflow: auto;
+      background: #0b1020;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px;
+      font-size: 0.8rem;
+      line-height: 1.35;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h1>Tesla FSD ESP32 - Web Serial Control</h1>
+      <div class="row">
+        <button id="connectBtn">Connect</button>
+        <button id="disconnectBtn" disabled>Disconnect</button>
+        <button id="ipBtn" disabled>Print WiFi URLs (ip)</button>
+        <select id="baud">
+          <option value="115200" selected>115200 baud</option>
+          <option value="921600">921600 baud</option>
+        </select>
+      </div>
+      <div id="connStatus" class="status warn">Disconnected</div>
+      <div class="hint" style="margin-top: 8px;">
+        Works in Chromium browsers with Web Serial support (Chrome / Edge). Use HTTPS or localhost.
+      </div>
+    </div>
+
+    <div class="main-grid">
+    <div class="control-column">
+    <div class="status-card">
+      <h2>Controls</h2>
+      <div class="switch-row"><span class="switch-label">Hardware</span><select data-state="hw_override" data-cmd="hw_override">
+        <option value="0">Auto-detect</option><option value="3">Force HW4</option><option value="2">Force HW3</option><option value="1">Force Legacy</option>
+      </select></div>
+      <div class="switch-row"><span class="switch-label">Listen-Only / Active</span><label class="sw"><input type="checkbox" data-cmd="mode"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Ignore OTA</span><label class="sw"><input type="checkbox" data-state="ignore_ota" data-cmd="ignore_ota"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">FSD Unlock</span><label class="sw"><input type="checkbox" data-state="fsd_unlock" data-cmd="fsd_unlock"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">NAG Killer</span><label class="sw"><input type="checkbox" data-state="nag_killer" data-cmd="nag"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Continuous AP</span><label class="sw"><input type="checkbox" data-state="continuous_ap" data-cmd="continuous_ap"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">AP-First</span><label class="sw"><input type="checkbox" data-state="ap_first" data-cmd="ap_first"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Instant Engage</span><label class="sw"><input type="checkbox" data-state="ap_first_edge" data-cmd="ap_first_edge"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Minimal Inject</span><label class="sw"><input type="checkbox" data-state="ap_first_minimal" data-cmd="ap_first_minimal"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">NAG EPAS-faithful</span><label class="sw"><input type="checkbox" data-state="nag_faithful" data-cmd="nag_faithful"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Soft Engage</span><label class="sw"><input type="checkbox" data-state="soft_engage" data-cmd="soft_engage"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">NAG Burst</span><label class="sw"><input type="checkbox" data-state="nag_burst" data-cmd="nag_burst"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Abort Guard</span><label class="sw"><input type="checkbox" data-state="abort_guard" data-cmd="abort_guard"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">BMS Display</span><label class="sw"><input type="checkbox" data-state="bms_output" data-cmd="bms"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Force FSD</span><label class="sw"><input type="checkbox" data-state="force_fsd" data-cmd="force_fsd"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">China Mode</span><label class="sw"><input type="checkbox" data-state="china_mode" data-cmd="china_mode"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Suppress Chime</span><label class="sw"><input type="checkbox" data-state="suppress_speed_chime" data-cmd="suppress_speed_chime"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">TLSSC Restore</span><label class="sw"><input type="checkbox" data-state="tlssc_restore" data-cmd="tlssc_restore"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Summon EU Unlock</span><label class="sw"><input type="checkbox" data-state="summon_unlock" data-cmd="summon_unlock"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Continue on Green</span><label class="sw"><input type="checkbox" data-state="continue_on_green" data-cmd="continue_on_green"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">TLSSC bit38</span><label class="sw"><input type="checkbox" data-state="assist_tlssc_bit38" data-cmd="assist_tlssc_bit38"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">RHD Override</span><label class="sw"><input type="checkbox" data-state="assist_rhd_override" data-cmd="assist_rhd_override"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Telemetry Off</span><label class="sw"><input type="checkbox" data-state="assist_telemetry_off" data-cmd="assist_telemetry_off"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">AP Branch / Tier</span><select data-state="apmv3_branch" data-cmd="apmv3_branch">
+        <option value="255">Off</option><option value="0">Live</option><option value="1">Stage</option><option value="2">Dev</option><option value="3">Stage2</option><option value="4">EAP</option><option value="5">Demo</option>
+      </select></div>
+      <div class="switch-row"><span class="switch-label">Track Mode</span><label class="sw"><input type="checkbox" data-state="track_mode_inject" data-cmd="track_mode_inject"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Handling Balance</span><input type="range" min="0" max="100" data-state="track_rotation_pct" data-cmd="track_rotation_pct"></div>
+      <div class="switch-row"><span class="switch-label">Stability Assist</span><input type="range" min="0" max="100" data-state="track_stability_pct" data-cmd="track_stability_pct"></div>
+      <div class="switch-row"><span class="switch-label">Post-drive Cooling</span><label class="sw"><input type="checkbox" data-state="track_post_cooling" data-cmd="track_post_cooling"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Compressor Overclock</span><label class="sw"><input type="checkbox" data-state="track_cmp_overclock" data-cmd="track_cmp_overclock"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Black-box Capture</span><label class="sw"><input type="checkbox" data-state="blackbox_enabled" data-cmd="blackbox_enable"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">HTTP CAN Dump</span><label class="sw"><input type="checkbox" data-state="can_dump" data-cmd="dump"><span class="sl2"></span></label></div>
+    </div>
+
+    <div class="card">
+      <h2>Gear Lever Control (0x229)</h2>
+      <div class="grid">
+        <button data-cmd="gear" data-value="down">Stalk DOWN (Drive request)</button>
+        <button data-cmd="gear" data-value="up">Stalk UP (R/N/P request)</button>
+      </div>
+      <div class="hint" style="margin-top: 8px;">
+        Gear command sends a detent pulse then center pulse using live 0x229 counter. Active mode + fresh counter required.
+      </div>
+    </div>
+    </div>
+
+    <div class="status-column">
+    <div class="status-card">
+      <h2>FSD Status</h2>
+      <div class="status-row"><span class="status-label">AP Status</span><span class="pill off" id="stAp"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Mode</span><span class="pill off" id="stMode"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Hardware</span><span class="pill off" id="stHardware"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Gear Lever</span><span class="pill off" id="stGear"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Pedal</span><span class="pill off" id="stPedal"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">NAG Killer</span><span class="pill off" id="stNag"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Summon</span><span class="pill off" id="stSummon" title="Click to toggle"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Summon Auto Control</span><span class="pill off" id="stSummonControl"><span class="pill-dot"></span>--</span></div>
+      <div class="hint" id="stUpdated" style="margin-top: 8px;">No status yet.</div>
+    </div>
+
+    <div class="status-card">
+      <h2>Vehicle Status</h2>
+      <div class="status-row"><span class="status-label">Vehicle Speed</span><span class="pill off" id="stSpeed"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">UI Speed</span><span class="pill off" id="stUiSpeed"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Vehicle Gear</span><span class="pill off" id="stVehicleGear"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Brake</span><span class="pill off" id="stBrake"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Turn Signal</span><span class="pill off" id="stTurn"><span class="pill-dot"></span>--</span></div>
+    </div>
+
+    <div class="status-card">
+      <h2>Battery</h2>
+      <div class="status-row"><span class="status-label">BMS Status</span><span class="pill off" id="stBms"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">BMS Frames</span><span class="pill off" id="stBmsFrames"><span class="pill-dot"></span>--</span></div>
+    </div>
+
+    <div class="status-card">
+      <h2>CAN Bus</h2>
+      <div class="status-row"><span class="status-label">CAN Vehicle</span><span class="pill off" id="stCan"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">RX Frames</span><span class="pill off" id="stRx"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">TX Frames</span><span class="pill off" id="stTx"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">TX Errors</span><span class="pill off" id="stCrc"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Frames/s</span><span class="pill off" id="stFps"><span class="pill-dot"></span>--</span></div>
+    </div>
+    </div>
+    </div>
+
+    <div class="card">
+      <h2>Send Raw JSON Line</h2>
+      <textarea id="rawInput">{ "cmd": "mode", "value": true }</textarea>
+      <div class="row" style="margin-top: 8px;">
+        <button id="sendRawBtn" disabled>Send JSON</button>
+        <button id="clearLogBtn">Clear Log</button>
+      </div>
+      <div class="hint">Each send is one JSON line with newline ending. Device replies with JSON ack.</div>
+    </div>
+
+    <div class="card">
+      <h2>Serial Log</h2>
+      <pre id="log"></pre>
+    </div>
+  </div>
+
+  <script>
+    const connectBtn = document.getElementById("connectBtn");
+    const disconnectBtn = document.getElementById("disconnectBtn");
+    const ipBtn = document.getElementById("ipBtn");
+    const sendRawBtn = document.getElementById("sendRawBtn");
+    const clearLogBtn = document.getElementById("clearLogBtn");
+    const connStatus = document.getElementById("connStatus");
+    const baudSel = document.getElementById("baud");
+    const rawInput = document.getElementById("rawInput");
+    const logEl = document.getElementById("log");
+    const stMode = document.getElementById("stMode");
+    const stAp = document.getElementById("stAp");
+    const stHardware = document.getElementById("stHardware");
+    const stNag = document.getElementById("stNag");
+    const stSpeed = document.getElementById("stSpeed");
+    const stUiSpeed = document.getElementById("stUiSpeed");
+    const stVehicleGear = document.getElementById("stVehicleGear");
+    const stGear = document.getElementById("stGear");
+    const stBrake = document.getElementById("stBrake");
+    const stPedal = document.getElementById("stPedal");
+    const stSummon = document.getElementById("stSummon");
+    const stSummonControl = document.getElementById("stSummonControl");
+    const stTurn = document.getElementById("stTurn");
+    const stUpdated = document.getElementById("stUpdated");
+    const stBms = document.getElementById("stBms");
+    const stBmsFrames = document.getElementById("stBmsFrames");
+    const stCan = document.getElementById("stCan");
+    const stRx = document.getElementById("stRx");
+    const stTx = document.getElementById("stTx");
+    const stCrc = document.getElementById("stCrc");
+    const stFps = document.getElementById("stFps");
+
+    let port = null;
+    let writer = null;
+    let reader = null;
+    let readLoopRunning = false;
+    let statusTimer = null;
+    let statusRequestInFlight = false;
+
+    function setStatus(text, cls) {
+      connStatus.className = "status " + (cls || "");
+      connStatus.textContent = text;
+    }
+
+    function appendLog(line) {
+      const now = new Date().toLocaleTimeString();
+      logEl.textContent += `[${now}] ${line}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function setValue(el, text, cls) {
+      el.className = "pill " + (cls || "off");
+      el.replaceChildren(
+        Object.assign(document.createElement("span"), { className: "pill-dot" }),
+        document.createTextNode(text)
+      );
+    }
+
+    function gearLabel(pos, fallback) {
+      if (typeof fallback === "string" && fallback) return fallback;
+      const map = { 0: "center", 1: "half_up", 2: "full_up", 3: "half_down", 4: "full_down" };
+      return map[pos] || "unknown";
+    }
+
+    function applyStatus(s) {
+      document.querySelectorAll("[data-state]").forEach((control) => {
+        const key = control.getAttribute("data-state");
+        if (control.type === "checkbox" && typeof s[key] === "boolean") {
+          control.checked = s[key];
+        } else if ((control.tagName === "SELECT" || control.type === "range") && s[key] !== undefined) {
+          control.value = String(s[key]);
+        }
+      });
+      const active = Number(s.op_mode) === 1;
+      const modeControl = document.querySelector('[data-cmd="mode"]');
+      if (modeControl) modeControl.checked = active;
+      setValue(stAp, s.ap_active ? "Active" : "Inactive", s.ap_active ? "ok" : "off");
+      setValue(stMode, active ? "Active" : "Listen-Only", active ? "ok" : "warn");
+      setValue(stHardware, s.hw_version ? "HW" + s.hw_version : "Auto", s.hw_version ? "ok" : "off");
+      setValue(stNag, s.nag_killer ? "Enabled" : "Disabled", s.nag_killer ? "ok" : "off");
+      const speedSeen = s.speed_fresh !== undefined ? s.speed_fresh : s.speed_seen;
+      setValue(stSpeed, speedSeen ? (Number(s.vehicle_speed_kph).toFixed(1) + " km/h") : "not seen",
+        speedSeen ? "" : "warn");
+      setValue(stUiSpeed, s.speed_seen ? (Number(s.ui_speed || 0) + " km/h") : "not seen",
+        s.speed_seen ? "" : "warn");
+      const vehicleGearNames = { 1: "P", 2: "R", 3: "N", 4: "D" };
+      const vehicleGear = s.vehicle_gear_seen
+        ? (vehicleGearNames[s.vehicle_gear] || "unknown") : "not seen";
+      setValue(stVehicleGear, vehicleGear, s.vehicle_gear_seen ? "" : "warn");
+      const gear = s.gear_lever_seen ? gearLabel(s.gear_lever_pos, s.gear_lever_label) : "not seen";
+      setValue(stGear, gear, s.gear_lever_seen ? "" : "warn");
+      const brake = s.brake_status_seen ? (s.driver_brake_applied ? "Pressed" : "Released") : "not seen";
+      setValue(stBrake, brake, s.driver_brake_applied ? "err" : "");
+      const turnSeen = s.turn_status_seen === true;
+      const turn = turnSeen ? ((s.left_turn_active ? "L" : "") + (s.right_turn_active ? "R" : "") || "Off") : "not seen";
+      setValue(stTurn, turn, turnSeen && (s.left_turn_active || s.right_turn_active) ? "ok" : "");
+      const torque = s.di_torque_seen ? Number(s.di_torque_nm).toFixed(1) + " Nm" : "not seen";
+      const pedal = s.di_torque_seen ? ((s.pedal_pressed ? "Pressed" : "Released") + " (" + torque + ")") : "not seen";
+      setValue(stPedal, pedal, s.pedal_pressed ? "ok" : "");
+      const summonStatus = s.summon_temp_disabled ? "Temp disabled"
+        : (s.summon_unlock ? "Enabled" : "Disabled");
+      setValue(stSummon, summonStatus, s.summon_temp_disabled ? "warn" : (s.summon_unlock ? "ok" : ""));
+      stSummon.dataset.tempDisabled = s.summon_temp_disabled ? "true" : "false";
+      stSummon.dataset.summonEnabled = s.summon_unlock ? "true" : "false";
+      stSummon.classList.toggle("actionable", !!s.summon_unlock);
+      setValue(stSummonControl, s.summon_auto_control === 0 ? "Brake" : "unknown", "");
+      const bmsFrames = (s.bms_hv_seen ? 1 : 0) + (s.bms_soc_seen ? 1 : 0) + (s.bms_thermal_seen ? 1 : 0);
+      setValue(stBms, s.bms_output ? "Enabled" : "Disabled", s.bms_output ? "ok" : "off");
+      setValue(stBmsFrames, bmsFrames + " seen", bmsFrames ? "ok" : "off");
+      setValue(stCan, s.can_vehicle_detected ? "Detected" : "Not detected", s.can_vehicle_detected ? "ok" : "warn");
+      setValue(stRx, String(s.rx_count || 0), "off");
+      setValue(stTx, String(s.tx_count || 0), "off");
+      setValue(stCrc, String(s.crc_errors || 0), s.crc_errors ? "warn" : "off");
+      setValue(stFps, Number(s.fps || 0).toFixed(1), "off");
+      stUpdated.textContent = "Updated: " + new Date().toLocaleTimeString();
+    }
+
+    function setConnectedUi(connected) {
+      connectBtn.disabled = connected;
+      disconnectBtn.disabled = !connected;
+      ipBtn.disabled = !connected;
+      sendRawBtn.disabled = !connected;
+      document.querySelectorAll("[data-cmd]").forEach((btn) => { btn.disabled = !connected; });
+    }
+
+    function parseValue(raw) {
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      const n = Number(raw);
+      if (!Number.isNaN(n)) return n;
+      return raw;
+    }
+
+    async function sendJson(obj) {
+      if (!writer) throw new Error("Serial not connected");
+      const line = JSON.stringify(obj) + "\n";
+      await writer.write(new TextEncoder().encode(line));
+      appendLog(`TX ${line.trim()}`);
+    }
+
+    async function requestStatus() {
+      if (statusRequestInFlight || !writer) return;
+      statusRequestInFlight = true;
+      try {
+        await sendJson({ cmd: "status", value: true });
+      } finally {
+        statusRequestInFlight = false;
+      }
+    }
+
+    async function sendTextLine(text) {
+      if (!writer) throw new Error("Serial not connected");
+      const line = text.trim() + "\n";
+      await writer.write(new TextEncoder().encode(line));
+      appendLog(`TX ${line.trim()}`);
+    }
+
+    async function readLoop() {
+      readLoopRunning = true;
+      let text = "";
+      while (readLoopRunning && port && port.readable) {
+        try {
+          const localReader = port.readable.getReader();
+          reader = localReader;
+          while (readLoopRunning) {
+            const { value, done } = await localReader.read();
+            if (done) break;
+            if (!value) continue;
+            text += new TextDecoder().decode(value, { stream: true });
+            let idx;
+            while ((idx = text.indexOf("\n")) >= 0) {
+              const line = text.slice(0, idx).trim();
+              text = text.slice(idx + 1);
+              if (line) {
+                appendLog(`RX ${line}`);
+                try {
+                  const obj = JSON.parse(line);
+                  if (obj && Object.prototype.hasOwnProperty.call(obj, "op_mode")) {
+                    applyStatus(obj);
+                  }
+                } catch (_) {}
+              }
+            }
+          }
+          localReader.releaseLock();
+        } catch (err) {
+          appendLog(`RX error: ${err.message || err}`);
+          break;
+        }
+      }
+      readLoopRunning = false;
+    }
+
+    async function connect() {
+      if (!("serial" in navigator)) {
+        setStatus("Web Serial API is not supported in this browser.", "err");
+        return;
+      }
+      try {
+        port = await navigator.serial.requestPort();
+        await port.open({
+          baudRate: Number(baudSel.value),
+          dataBits: 8,
+          stopBits: 1,
+          parity: "none",
+          flowControl: "none"
+        });
+        writer = port.writable.getWriter();
+        setConnectedUi(true);
+        setStatus("Connected", "ok");
+        appendLog("Connected to serial port");
+        readLoop();
+        // Opening a USB serial port commonly resets the ESP32. Give its
+        // boot log time to finish, then poll repeatedly until a status line
+        // is received instead of losing the first request during reset.
+        window.setTimeout(() => {
+          requestStatus().catch((err) => appendLog(`Status request error: ${err.message || err}`));
+        }, 1200);
+        statusTimer = window.setInterval(() => {
+          requestStatus().catch((err) => appendLog(`Status poll error: ${err.message || err}`));
+        }, 1000);
+      } catch (err) {
+        setStatus("Connect failed", "err");
+        appendLog(`Connect failed: ${err.message || err}`);
+      }
+    }
+
+    async function disconnect() {
+      readLoopRunning = false;
+      if (statusTimer !== null) {
+        window.clearInterval(statusTimer);
+        statusTimer = null;
+      }
+      try {
+        if (reader) {
+          await reader.cancel();
+          reader = null;
+        }
+      } catch (_) {}
+      try {
+        if (writer) {
+          writer.releaseLock();
+          writer = null;
+        }
+      } catch (_) {}
+      try {
+        if (port) {
+          await port.close();
+          port = null;
+        }
+      } catch (err) {
+        appendLog(`Disconnect warning: ${err.message || err}`);
+      }
+      statusRequestInFlight = false;
+      setConnectedUi(false);
+      setStatus("Disconnected", "warn");
+      appendLog("Disconnected");
+    }
+
+    connectBtn.addEventListener("click", connect);
+    disconnectBtn.addEventListener("click", disconnect);
+
+    stSummon.addEventListener("click", async () => {
+      if (stSummon.dataset.summonEnabled !== "true") return;
+      try {
+        const temporaryDisabled = stSummon.dataset.tempDisabled === "true";
+        await sendJson({
+          cmd: temporaryDisabled ? "summon_force_recover" : "summon_temp_disable",
+          value: true
+        });
+        setValue(stSummon, temporaryDisabled ? "Enabled" : "Temp disabled",
+          temporaryDisabled ? "ok" : "warn");
+        stSummon.dataset.tempDisabled = temporaryDisabled ? "false" : "true";
+        window.setTimeout(() => {
+          requestStatus().catch(() => {});
+        }, 120);
+      } catch (err) {
+        appendLog(`TX error: ${err.message || err}`);
+      }
+    });
+
+    ipBtn.addEventListener("click", async () => {
+      try {
+        await sendTextLine("ip");
+      } catch (err) {
+        appendLog(`TX error: ${err.message || err}`);
+      }
+    });
+
+    document.querySelectorAll("[data-cmd]").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        try {
+          const value = btn.type === "checkbox" ? btn.checked
+            : (btn.tagName === "SELECT" || btn.type === "range") ? parseValue(btn.value)
+            : parseValue(btn.getAttribute("data-value"));
+          await sendJson({
+            cmd: btn.getAttribute("data-cmd"),
+            value
+          });
+          window.setTimeout(() => {
+            requestStatus().catch(() => {});
+          }, 120);
+        } catch (err) {
+          appendLog(`TX error: ${err.message || err}`);
+        }
+      });
+    });
+
+    sendRawBtn.addEventListener("click", async () => {
+      try {
+        const parsed = JSON.parse(rawInput.value);
+        await sendJson(parsed);
+      } catch (err) {
+        appendLog(`JSON/TX error: ${err.message || err}`);
+      }
+    });
+
+    clearLogBtn.addEventListener("click", () => {
+      logEl.textContent = "";
+    });
+
+    setConnectedUi(false);
+  </script>
+</body>
+</html>

--- a/esp32/webserial-control.html
+++ b/esp32/webserial-control.html
@@ -293,7 +293,6 @@
       <div class="status-row"><span class="status-label">Mode</span><span class="pill off" id="stMode"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Hardware</span><span class="pill off" id="stHardware"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Gear Lever</span><span class="pill off" id="stGear"><span class="pill-dot"></span>--</span></div>
-      <div class="status-row"><span class="status-label">Pedal</span><span class="pill off" id="stPedal"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">NAG Killer</span><span class="pill off" id="stNag"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Summon</span><span class="pill off" id="stSummon" title="Click to toggle"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Summon Auto Control</span><span class="pill off" id="stSummonControl"><span class="pill-dot"></span>--</span></div>
@@ -305,6 +304,7 @@
       <div class="status-row"><span class="status-label">Vehicle Speed</span><span class="pill off" id="stSpeed"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">UI Speed</span><span class="pill off" id="stUiSpeed"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Vehicle Gear</span><span class="pill off" id="stVehicleGear"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Accelerator</span><span class="pill off" id="stPedal"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Brake</span><span class="pill off" id="stBrake"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Turn Signal</span><span class="pill off" id="stTurn"><span class="pill-dot"></span>--</span></div>
     </div>
@@ -447,7 +447,7 @@
       stSummon.dataset.tempDisabled = s.summon_temp_disabled ? "true" : "false";
       stSummon.dataset.summonEnabled = s.summon_unlock ? "true" : "false";
       stSummon.classList.toggle("actionable", !!s.summon_unlock);
-      setValue(stSummonControl, s.summon_auto_control === 0 ? "Brake" : "unknown", "");
+      setValue(stSummonControl, s.summon_auto_control === 0 ? "Accelerator + P gear" : "unknown", "");
       const bmsFrames = (s.bms_hv_seen ? 1 : 0) + (s.bms_soc_seen ? 1 : 0) + (s.bms_thermal_seen ? 1 : 0);
       setValue(stBms, s.bms_output ? "Enabled" : "Disabled", s.bms_output ? "ok" : "off");
       setValue(stBmsFrames, bmsFrames + " seen", bmsFrames ? "ok" : "off");

--- a/esp32/webserial-control.html
+++ b/esp32/webserial-control.html
@@ -245,44 +245,33 @@
       <div class="switch-row"><span class="switch-label">FSD Unlock</span><label class="sw"><input type="checkbox" data-state="fsd_unlock" data-cmd="fsd_unlock"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">NAG Killer</span><label class="sw"><input type="checkbox" data-state="nag_killer" data-cmd="nag"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Continuous AP</span><label class="sw"><input type="checkbox" data-state="continuous_ap" data-cmd="continuous_ap"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">AP-First</span><label class="sw"><input type="checkbox" data-state="ap_first" data-cmd="ap_first"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">Instant Engage</span><label class="sw"><input type="checkbox" data-state="ap_first_edge" data-cmd="ap_first_edge"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">Minimal Inject</span><label class="sw"><input type="checkbox" data-state="ap_first_minimal" data-cmd="ap_first_minimal"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">NAG EPAS-faithful</span><label class="sw"><input type="checkbox" data-state="nag_faithful" data-cmd="nag_faithful"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">Soft Engage</span><label class="sw"><input type="checkbox" data-state="soft_engage" data-cmd="soft_engage"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">NAG Burst</span><label class="sw"><input type="checkbox" data-state="nag_burst" data-cmd="nag_burst"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">Abort Guard</span><label class="sw"><input type="checkbox" data-state="abort_guard" data-cmd="abort_guard"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">AP-First (14.x)</span><label class="sw"><input type="checkbox" data-state="ap_first" data-cmd="ap_first"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Instant Engage (exp.)</span><label class="sw"><input type="checkbox" data-state="ap_first_edge" data-cmd="ap_first_edge"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Minimal Inject (exp.)</span><label class="sw"><input type="checkbox" data-state="ap_first_minimal" data-cmd="ap_first_minimal"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Nag EPAS-faithful (14.x, exp.)</span><label class="sw"><input type="checkbox" data-state="nag_faithful" data-cmd="nag_faithful"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Soft Engage (14.x, exp.)</span><label class="sw"><input type="checkbox" data-state="soft_engage" data-cmd="soft_engage"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Nag Burst (14.x, exp.)</span><label class="sw"><input type="checkbox" data-state="nag_burst" data-cmd="nag_burst"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Abort Guard (14.x, exp.)</span><label class="sw"><input type="checkbox" data-state="abort_guard" data-cmd="abort_guard"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">BMS Display</span><label class="sw"><input type="checkbox" data-state="bms_output" data-cmd="bms"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Force FSD</span><label class="sw"><input type="checkbox" data-state="force_fsd" data-cmd="force_fsd"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">China Mode</span><label class="sw"><input type="checkbox" data-state="china_mode" data-cmd="china_mode"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">Suppress Chime</span><label class="sw"><input type="checkbox" data-state="suppress_speed_chime" data-cmd="suppress_speed_chime"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Suppress Chime</span><label class="sw"><input type="checkbox" data-state="suppress_speed_chime_configured" data-cmd="suppress_speed_chime"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">TLSSC Restore</span><label class="sw"><input type="checkbox" data-state="tlssc_restore" data-cmd="tlssc_restore"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Summon EU Unlock</span><label class="sw"><input type="checkbox" data-state="summon_unlock" data-cmd="summon_unlock"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Continue on Green</span><label class="sw"><input type="checkbox" data-state="continue_on_green" data-cmd="continue_on_green"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">TLSSC bit38</span><label class="sw"><input type="checkbox" data-state="assist_tlssc_bit38" data-cmd="assist_tlssc_bit38"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">RHD Override</span><label class="sw"><input type="checkbox" data-state="assist_rhd_override" data-cmd="assist_rhd_override"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">Telemetry Off</span><label class="sw"><input type="checkbox" data-state="assist_telemetry_off" data-cmd="assist_telemetry_off"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">AP Branch / Tier</span><select data-state="apmv3_branch" data-cmd="apmv3_branch">
+      <div class="switch-row"><span class="switch-label">Right-Hand Drive (RHD)</span><label class="sw"><input type="checkbox" data-state="assist_rhd_override" data-cmd="assist_rhd_override"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Telemetry Off (experimental)</span><label class="sw"><input type="checkbox" data-state="assist_telemetry_off" data-cmd="assist_telemetry_off"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">AP Branch/Tier (experimental)</span><select data-state="apmv3_branch" data-cmd="apmv3_branch">
         <option value="255">Off</option><option value="0">Live</option><option value="1">Stage</option><option value="2">Dev</option><option value="3">Stage2</option><option value="4">EAP</option><option value="5">Demo</option>
       </select></div>
-      <div class="switch-row"><span class="switch-label">Track Mode</span><label class="sw"><input type="checkbox" data-state="track_mode_inject" data-cmd="track_mode_inject"><span class="sl2"></span></label></div>
+      <div class="switch-row"><span class="switch-label">Track Mode (experimental)</span><label class="sw"><input type="checkbox" data-state="track_mode_inject" data-cmd="track_mode_inject"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Handling Balance</span><input type="range" min="0" max="100" data-state="track_rotation_pct" data-cmd="track_rotation_pct"></div>
       <div class="switch-row"><span class="switch-label">Stability Assist</span><input type="range" min="0" max="100" data-state="track_stability_pct" data-cmd="track_stability_pct"></div>
       <div class="switch-row"><span class="switch-label">Post-drive Cooling</span><label class="sw"><input type="checkbox" data-state="track_post_cooling" data-cmd="track_post_cooling"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Compressor Overclock</span><label class="sw"><input type="checkbox" data-state="track_cmp_overclock" data-cmd="track_cmp_overclock"><span class="sl2"></span></label></div>
       <div class="switch-row"><span class="switch-label">Black-box Capture</span><label class="sw"><input type="checkbox" data-state="blackbox_enabled" data-cmd="blackbox_enable"><span class="sl2"></span></label></div>
-      <div class="switch-row"><span class="switch-label">HTTP CAN Dump</span><label class="sw"><input type="checkbox" data-state="can_dump" data-cmd="dump"><span class="sl2"></span></label></div>
-    </div>
-
-    <div class="card">
-      <h2>Gear Lever Control (0x229)</h2>
-      <div class="grid">
-        <button data-cmd="gear" data-value="down">Stalk DOWN (Drive request)</button>
-        <button data-cmd="gear" data-value="up">Stalk UP (R/N/P request)</button>
-      </div>
-      <div class="hint" style="margin-top: 8px;">
-        Gear command sends a detent pulse then center pulse using live 0x229 counter. Active mode + fresh counter required.
-      </div>
+      <div class="switch-row"><span class="switch-label">CAN Dump</span><label class="sw"><input type="checkbox" data-state="can_dump" data-cmd="dump"><span class="sl2"></span></label></div>
     </div>
     </div>
 
@@ -292,17 +281,15 @@
       <div class="status-row"><span class="status-label">AP Status</span><span class="pill off" id="stAp"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Mode</span><span class="pill off" id="stMode"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Hardware</span><span class="pill off" id="stHardware"><span class="pill-dot"></span>--</span></div>
-      <div class="status-row"><span class="status-label">Gear Lever</span><span class="pill off" id="stGear"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">NAG Killer</span><span class="pill off" id="stNag"><span class="pill-dot"></span>--</span></div>
-      <div class="status-row"><span class="status-label">Summon</span><span class="pill off" id="stSummon" title="Click to toggle"><span class="pill-dot"></span>--</span></div>
-      <div class="status-row"><span class="status-label">Summon Auto Control</span><span class="pill off" id="stSummonControl"><span class="pill-dot"></span>--</span></div>
-      <div class="hint" id="stUpdated" style="margin-top: 8px;">No status yet.</div>
+      <div class="status-row"><span class="status-label">CAN Vehicle</span><span class="pill off" id="stCan"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Summon Status</span><span class="pill off" id="stSummon" title="Click to toggle"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row"><span class="status-label">Suppress Chime</span><span class="pill off" id="stChime"><span class="pill-dot"></span>--</span></div>
     </div>
 
     <div class="status-card">
       <h2>Vehicle Status</h2>
       <div class="status-row"><span class="status-label">Vehicle Speed</span><span class="pill off" id="stSpeed"><span class="pill-dot"></span>--</span></div>
-      <div class="status-row"><span class="status-label">UI Speed</span><span class="pill off" id="stUiSpeed"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Vehicle Gear</span><span class="pill off" id="stVehicleGear"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Accelerator</span><span class="pill off" id="stPedal"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Brake</span><span class="pill off" id="stBrake"><span class="pill-dot"></span>--</span></div>
@@ -317,7 +304,6 @@
 
     <div class="status-card">
       <h2>CAN Bus</h2>
-      <div class="status-row"><span class="status-label">CAN Vehicle</span><span class="pill off" id="stCan"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">RX Frames</span><span class="pill off" id="stRx"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">TX Frames</span><span class="pill off" id="stTx"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">TX Errors</span><span class="pill off" id="stCrc"><span class="pill-dot"></span>--</span></div>
@@ -357,15 +343,12 @@
     const stHardware = document.getElementById("stHardware");
     const stNag = document.getElementById("stNag");
     const stSpeed = document.getElementById("stSpeed");
-    const stUiSpeed = document.getElementById("stUiSpeed");
     const stVehicleGear = document.getElementById("stVehicleGear");
-    const stGear = document.getElementById("stGear");
     const stBrake = document.getElementById("stBrake");
     const stPedal = document.getElementById("stPedal");
     const stSummon = document.getElementById("stSummon");
-    const stSummonControl = document.getElementById("stSummonControl");
+    const stChime = document.getElementById("stChime");
     const stTurn = document.getElementById("stTurn");
-    const stUpdated = document.getElementById("stUpdated");
     const stBms = document.getElementById("stBms");
     const stBmsFrames = document.getElementById("stBmsFrames");
     const stCan = document.getElementById("stCan");
@@ -400,12 +383,6 @@
       );
     }
 
-    function gearLabel(pos, fallback) {
-      if (typeof fallback === "string" && fallback) return fallback;
-      const map = { 0: "center", 1: "half_up", 2: "full_up", 3: "half_down", 4: "full_down" };
-      return map[pos] || "unknown";
-    }
-
     function applyStatus(s) {
       document.querySelectorAll("[data-state]").forEach((control) => {
         const key = control.getAttribute("data-state");
@@ -418,45 +395,45 @@
       const active = Number(s.op_mode) === 1;
       const modeControl = document.querySelector('[data-cmd="mode"]');
       if (modeControl) modeControl.checked = active;
-      setValue(stAp, s.ap_active ? "Active" : "Inactive", s.ap_active ? "ok" : "off");
-      setValue(stMode, active ? "Active" : "Listen-Only", active ? "ok" : "warn");
-      setValue(stHardware, s.hw_version ? "HW" + s.hw_version : "Auto", s.hw_version ? "ok" : "off");
-      setValue(stNag, s.nag_killer ? "Enabled" : "Disabled", s.nag_killer ? "ok" : "off");
+      setValue(stAp, s.ap_active ? "Active" : "Waiting", s.ap_active ? "ok" : "off");
+      setValue(stMode, active ? "Active" : "Listen-Only", active ? "ok" : "off");
+      const hardwareNames = { 1: "HW1 Legacy", 2: "HW3", 3: "HW4" };
+      setValue(stHardware, hardwareNames[s.hw_version] || "?", s.hw_version ? "ok" : "off");
+      setValue(stNag, s.nag_killer ? "ON" : "OFF", s.nag_killer ? "ok" : "off");
+      setValue(stCan, s.can_vehicle_detected ? "Detected" : "No CAN Traffic", s.can_vehicle_detected ? "ok" : "off");
       const speedSeen = s.speed_fresh !== undefined ? s.speed_fresh : s.speed_seen;
-      setValue(stSpeed, speedSeen ? (Number(s.vehicle_speed_kph).toFixed(1) + " km/h") : "not seen",
-        speedSeen ? "" : "warn");
-      setValue(stUiSpeed, s.speed_seen ? (Number(s.ui_speed || 0) + " km/h") : "not seen",
-        s.speed_seen ? "" : "warn");
+      setValue(stSpeed, speedSeen ? (Number(s.vehicle_speed_kph).toFixed(1) + " km/h") : "Waiting",
+        speedSeen ? "ok" : "off");
       const vehicleGearNames = { 1: "P", 2: "R", 3: "N", 4: "D" };
       const vehicleGear = s.vehicle_gear_seen
-        ? (vehicleGearNames[s.vehicle_gear] || "unknown") : "not seen";
-      setValue(stVehicleGear, vehicleGear, s.vehicle_gear_seen ? "" : "warn");
-      const gear = s.gear_lever_seen ? gearLabel(s.gear_lever_pos, s.gear_lever_label) : "not seen";
-      setValue(stGear, gear, s.gear_lever_seen ? "" : "warn");
-      const brake = s.brake_status_seen ? (s.driver_brake_applied ? "Pressed" : "Released") : "not seen";
-      setValue(stBrake, brake, s.driver_brake_applied ? "err" : "");
+        ? (vehicleGearNames[s.vehicle_gear] || "Unknown") : "Waiting";
+      setValue(stVehicleGear, vehicleGear, s.vehicle_gear_seen ? "ok" : "off");
+      const brake = s.brake_status_seen ? (s.driver_brake_applied ? "Pressed" : "Released") : "Waiting";
+      setValue(stBrake, brake, s.driver_brake_applied ? "ok" : "");
       const turnSeen = s.turn_status_seen === true;
-      const turn = turnSeen ? ((s.left_turn_active ? "L" : "") + (s.right_turn_active ? "R" : "") || "Off") : "not seen";
+      const turn = turnSeen ? ((s.left_turn_active ? "L" : "") + (s.right_turn_active ? "R" : "") || "Off") : "Waiting";
       setValue(stTurn, turn, turnSeen && (s.left_turn_active || s.right_turn_active) ? "ok" : "");
-      const torque = s.di_torque_seen ? Number(s.di_torque_nm).toFixed(1) + " Nm" : "not seen";
-      const pedal = s.di_torque_seen ? ((s.pedal_pressed ? "Pressed" : "Released") + " (" + torque + ")") : "not seen";
+      const pedal = s.di_torque_seen ? (s.pedal_pressed ? "Pressed" : "Released") : "Waiting";
       setValue(stPedal, pedal, s.pedal_pressed ? "ok" : "");
       const summonStatus = s.summon_temp_disabled ? "Temp disabled"
         : (s.summon_unlock ? "Enabled" : "Disabled");
-      setValue(stSummon, summonStatus, s.summon_temp_disabled ? "warn" : (s.summon_unlock ? "ok" : ""));
+      setValue(stSummon, summonStatus, s.summon_unlock && !s.summon_temp_disabled ? "ok" : "off");
       stSummon.dataset.tempDisabled = s.summon_temp_disabled ? "true" : "false";
       stSummon.dataset.summonEnabled = s.summon_unlock ? "true" : "false";
       stSummon.classList.toggle("actionable", !!s.summon_unlock);
-      setValue(stSummonControl, s.summon_auto_control === 0 ? "Accelerator + P gear" : "unknown", "");
-      const bmsFrames = (s.bms_hv_seen ? 1 : 0) + (s.bms_soc_seen ? 1 : 0) + (s.bms_thermal_seen ? 1 : 0);
-      setValue(stBms, s.bms_output ? "Enabled" : "Disabled", s.bms_output ? "ok" : "off");
-      setValue(stBmsFrames, bmsFrames + " seen", bmsFrames ? "ok" : "off");
-      setValue(stCan, s.can_vehicle_detected ? "Detected" : "Not detected", s.can_vehicle_detected ? "ok" : "warn");
+      const chimeConfigured = s.suppress_speed_chime_configured !== undefined
+        ? !!s.suppress_speed_chime_configured : !!s.suppress_speed_chime;
+      setValue(stChime, chimeConfigured
+        ? (s.suppress_speed_chime ? "Suppressed" : "Not suppressed") : "Disabled",
+        s.suppress_speed_chime ? "ok" : "off");
+      const bmsSeen = !!(s.bms && s.bms.seen);
+      setValue(stBms, bmsSeen ? "Live" : "Waiting Frames", bmsSeen ? "ok" : "off");
+      setValue(stBmsFrames, "HV:" + (s.bms_hv_seen || 0) + " SOC:" + (s.bms_soc_seen || 0) +
+        " TH:" + (s.bms_thermal_seen || 0), "off");
       setValue(stRx, String(s.rx_count || 0), "off");
       setValue(stTx, String(s.tx_count || 0), "off");
       setValue(stCrc, String(s.crc_errors || 0), s.crc_errors ? "warn" : "off");
       setValue(stFps, Number(s.fps || 0).toFixed(1), "off");
-      stUpdated.textContent = "Updated: " + new Date().toLocaleTimeString();
     }
 
     function setConnectedUi(connected) {

--- a/esp32/webserial-control.html
+++ b/esp32/webserial-control.html
@@ -284,7 +284,7 @@
       <div class="status-row"><span class="status-label">NAG Killer</span><span class="pill off" id="stNag"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">CAN Vehicle</span><span class="pill off" id="stCan"><span class="pill-dot"></span>--</span></div>
       <div class="status-row"><span class="status-label">Summon Status</span><span class="pill off" id="stSummon" title="Click to toggle"><span class="pill-dot"></span>--</span></div>
-      <div class="status-row"><span class="status-label">Suppress Chime</span><span class="pill off" id="stChime"><span class="pill-dot"></span>--</span></div>
+      <div class="status-row" id="stChimeRow"><span class="status-label">Suppress Chime</span><span class="pill off" id="stChime"><span class="pill-dot"></span>--</span></div>
     </div>
 
     <div class="status-card">
@@ -348,6 +348,7 @@
     const stPedal = document.getElementById("stPedal");
     const stSummon = document.getElementById("stSummon");
     const stChime = document.getElementById("stChime");
+    const stChimeRow = document.getElementById("stChimeRow");
     const stTurn = document.getElementById("stTurn");
     const stBms = document.getElementById("stBms");
     const stBmsFrames = document.getElementById("stBmsFrames");
@@ -413,7 +414,8 @@
       const turnSeen = s.turn_status_seen === true;
       const turn = turnSeen ? ((s.left_turn_active ? "L" : "") + (s.right_turn_active ? "R" : "") || "Off") : "Waiting";
       setValue(stTurn, turn, turnSeen && (s.left_turn_active || s.right_turn_active) ? "ok" : "");
-      const pedal = s.di_torque_seen ? (s.pedal_pressed ? "Pressed" : "Released") : "Waiting";
+      const pedalSeen = s.accelerator_pedal_seen === true;
+      const pedal = pedalSeen ? (s.pedal_pressed ? "Pressed" : "Released") : "Waiting";
       setValue(stPedal, pedal, s.pedal_pressed ? "ok" : "");
       const summonStatus = s.summon_temp_disabled ? "Temp disabled"
         : (s.summon_unlock ? "Enabled" : "Disabled");
@@ -423,6 +425,7 @@
       stSummon.classList.toggle("actionable", !!s.summon_unlock);
       const chimeConfigured = s.suppress_speed_chime_configured !== undefined
         ? !!s.suppress_speed_chime_configured : !!s.suppress_speed_chime;
+      stChimeRow.hidden = !chimeConfigured;
       setValue(stChime, chimeConfigured
         ? (s.suppress_speed_chime ? "Suppressed" : "Not suppressed") : "Disabled",
         s.suppress_speed_chime ? "ok" : "off");

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -18,6 +18,10 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->das_prev_hands_on_state = 0xFF; // escalation-edge baseline (#100)
     state->enhanced_autopilot = false;
     state->summon_unlock = false;   // opt-in Summon EU Unlock, default OFF
+    state->summon_auto_control = SummonAutoControl_BrakeTemporary;
+    state->summon_temp_disabled = false;
+    state->summon_temp_recovery_armed = false;
+    state->summon_temp_disabled_ms = 0;
     state->apmv3_branch = 0xFF;     // opt-in AP branch/tier selector, default OFF (0xFF sentinel)
     state->continue_on_green = false; // opt-in Continue on Green, default OFF
     state->assist_rhd_override = false; // opt-in RHD driving-side override, default OFF

--- a/fsd_logic/fsd_handler.c
+++ b/fsd_logic/fsd_handler.c
@@ -18,7 +18,7 @@ void fsd_state_init(FSDState* state, TeslaHWVersion hw) {
     state->das_prev_hands_on_state = 0xFF; // escalation-edge baseline (#100)
     state->enhanced_autopilot = false;
     state->summon_unlock = false;   // opt-in Summon EU Unlock, default OFF
-    state->summon_auto_control = SummonAutoControl_BrakeTemporary;
+    state->summon_auto_control = SummonAutoControl_AcceleratorTemporary;
     state->summon_temp_disabled = false;
     state->summon_temp_recovery_armed = false;
     state->summon_temp_disabled_ms = 0;

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -20,6 +20,10 @@ typedef enum {
     SpeedLimitSource_Acc,
 } SpeedLimitSource;
 
+typedef enum {
+    SummonAutoControl_BrakeTemporary = 0,
+} SummonAutoControlMode;
+
 typedef struct FSDState {
     TeslaHWVersion hw_version;
     // Manual HW selection (#110). TeslaHW_Unknown = auto-detect (default); any
@@ -85,6 +89,8 @@ typedef struct FSDState {
     uint8_t rear_defrost_state;  // 0=sna 1=on 2=off (from 0x343)
     float vehicle_speed_kph;     // from 0x257 DI_vehicleSpeed (12-bit, 0.08 factor, -40 offset)
     uint8_t ui_speed;            // from 0x257 DI_uiSpeed (8-bit, display value)
+    uint8_t vehicle_gear;        // from 0x118 DI_gear: 1=P, 2=R, 3=N, 4=D
+    bool vehicle_gear_seen;
     uint8_t steering_tune_mode;  // from 0x370 EPAS3S_currentTuneMode (0-6)
     float torsion_bar_torque_nm; // from 0x370 EPAS3S_torsionBarTorque
     bool torsion_bar_torque_seen;
@@ -204,6 +210,10 @@ typedef struct FSDState {
     // bit19 (EU summon restriction) and sets bit47 (summon enable), on HW3 + HW4.
     // Opt-in, default OFF. // TODO: add Summon EU Unlock to Flipper menu
     bool summon_unlock;
+    SummonAutoControlMode summon_auto_control;
+    bool summon_temp_disabled;
+    bool summon_temp_recovery_armed;
+    uint32_t summon_temp_disabled_ms;
     // AP branch/tier selector (0x3FD DAS_autopilotControl mux1, UI_apmv3Branch,
     // bits 40-42 = byte5 bits 0-2). Enum: 0=LIVE 1=STAGE 2=DEV 3=STAGE2 4=EAP
     // 5=DEMO. Opt-in, default OFF (0xFF sentinel = don't touch). Experimental and
@@ -223,6 +233,11 @@ typedef struct FSDState {
     uint8_t di_park_brake_state; // 0-15
     uint8_t di_autopark_state;   // 0-15
     uint8_t di_digital_speed;    // 0.5 kph resolution (9-bit)
+    uint8_t gear_lever_last_pos; // latest 0x229 right-stalk detent (0=center, 2=full-up, 4=full-down)
+    uint8_t gear_lever_last_counter; // latest 0x229 rolling counter
+    bool gear_lever_seen;        // true once any valid 0x229 detent is seen
+    bool gear_lever_counter_seen; // true once 0x229 counter has been observed
+    uint32_t gear_lever_last_ms; // last ms timestamp when 0x229 detent/counter was captured
 
     // --- DI_torque (0x108) — motor power ---
     float di_torque_nm;          // drive motor torque

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -21,7 +21,7 @@ typedef enum {
 } SpeedLimitSource;
 
 typedef enum {
-    SummonAutoControl_BrakeTemporary = 0,
+    SummonAutoControl_AcceleratorTemporary = 0,
 } SummonAutoControlMode;
 
 typedef struct FSDState {

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -242,6 +242,9 @@ typedef struct FSDState {
     // --- DI_torque (0x108) — motor power ---
     float di_torque_nm;          // drive motor torque
     bool di_torque_seen;
+    bool accelerator_pressed;    // debounced accelerator demand inferred from torque
+    uint8_t accelerator_press_count;
+    uint8_t accelerator_release_count;
 
     // --- UI_warning (0x311) — dashboard indicators ---
     bool ui_left_blinker;

--- a/fsd_logic/fsd_state.h
+++ b/fsd_logic/fsd_state.h
@@ -239,10 +239,12 @@ typedef struct FSDState {
     bool gear_lever_counter_seen; // true once 0x229 counter has been observed
     uint32_t gear_lever_last_ms; // last ms timestamp when 0x229 detent/counter was captured
 
-    // --- DI_torque (0x108) — motor power ---
-    float di_torque_nm;          // drive motor torque
+    // --- Accelerator / motor telemetry ---
+    float di_torque_nm;          // DI_torqueActual from 0x108
     bool di_torque_seen;
-    bool accelerator_pressed;    // debounced accelerator demand inferred from torque
+    float accelerator_pedal_percent; // DI_accelPedalPos from 0x118
+    bool accelerator_pedal_seen;
+    bool accelerator_pressed;    // debounced accelerator pedal state
     uint8_t accelerator_press_count;
     uint8_t accelerator_release_count;
 


### PR DESCRIPTION
Add brake-triggered temporary Summon disable and guarded recovery, vehicle and BMS status telemetry, and matching WiFi/USB web controls. Remove permanent D-gear disable behavior and keep only the brake safety mode.

- #173